### PR TITLE
allow users to optionally bypass the trash even if it is available on their OS

### DIFF
--- a/quodlibet/quodlibet/config.py
+++ b/quodlibet/quodlibet/config.py
@@ -114,6 +114,10 @@ INITIAL = {
         # tags which get searched in addition to the ones present in the
         # song list, separate with ","
         "search_tags": "",
+
+        # If set to "true" allow directly deleting files, even on systems that
+        # support sending them to the trash.
+        "bypass_trash": "false",
     },
     "rename": {
         "spaces": "false",

--- a/quodlibet/quodlibet/qltk/delete.py
+++ b/quodlibet/quodlibet/qltk/delete.py
@@ -141,7 +141,7 @@ class TrashDialog(WarningMessage):
 
 
 def TrashMenuItem():
-    return (MenuItem(_("_Move to Trash"), "user-trash") if trash.can_trash()
+    return (MenuItem(_("_Move to Trash"), "user-trash") if trash.use_trash()
             else Gtk.ImageMenuItem(Gtk.STOCK_DELETE, use_stock=True))
 
 
@@ -283,7 +283,7 @@ def trash_files(parent, paths):
         return
 
     # depends on the platform if we can
-    if trash.can_trash():
+    if trash.use_trash():
         _do_trash_files(parent, paths)
     else:
         _do_delete_files(parent, paths)
@@ -302,7 +302,7 @@ def trash_songs(parent, songs, librarian):
         return
 
     # depends on the platform if we can
-    if trash.can_trash():
+    if trash.use_trash():
         _do_trash_songs(parent, songs, librarian)
     else:
         _do_delete_songs(parent, songs, librarian)

--- a/quodlibet/quodlibet/util/trash.py
+++ b/quodlibet/quodlibet/util/trash.py
@@ -15,6 +15,7 @@ import time
 from os.path import join, islink, abspath, dirname
 from os.path import isdir, basename, exists, splitext
 
+from quodlibet import config
 from quodlibet.util.path import find_mount_point, xdg_get_data_home
 
 
@@ -121,9 +122,11 @@ def trash_free_desktop(path):
         raise
 
 
-def can_trash():
+def use_trash():
     """If the current platform supports moving files into a trash can."""
-    return (os.name == "posix" and sys.platform != "darwin")
+    return (
+        os.name == "posix" and sys.platform != "darwin" and
+        not config.getboolean("settings", "bypass_trash"))
 
 
 def trash(path):

--- a/quodlibet/tests/test_qltk_delete.py
+++ b/quodlibet/tests/test_qltk_delete.py
@@ -3,6 +3,7 @@ from gi.repository import Gtk
 
 from tests import TestCase
 
+from quodlibet import config
 from quodlibet.formats._audio import AudioFile
 from quodlibet.util.path import fsnative
 from quodlibet.qltk.delete import DeleteDialog, TrashDialog, TrashMenuItem
@@ -12,6 +13,13 @@ SONG.sanitize()
 
 
 class TDeleteDialog(TestCase):
+
+    def setUp(self):
+        config.init()
+
+    def tearDown(self):
+        config.quit()
+
     def test_delete_songs(self):
         dialog = DeleteDialog.for_songs(None, [])
         dialog.destroy()

--- a/quodlibet/tests/test_util_trash.py
+++ b/quodlibet/tests/test_util_trash.py
@@ -1,0 +1,60 @@
+"""Tests for quodlibet.util.trash."""
+
+import os
+import sys
+
+from tests import TestCase
+
+from quodlibet import config
+from quodlibet.util.trash import use_trash
+
+
+class Ttrash(TestCase):
+
+    def setUp(self):
+        config.init()
+
+    def tearDown(self):
+        config.quit()
+
+    def test_use_trash_is_false_on_non_posix(self):
+        old_os_name = os.name
+        try:
+            os.name = 'not posix'
+            self.assertFalse(use_trash())
+        finally:
+            os.name = old_os_name
+
+    def test_use_trash_is_false_on_darwin(self):
+        old_os_name = os.name
+        old_sys_platform = sys.platform
+        try:
+            os.name = 'posix'
+            sys.platform = 'darwin'
+            self.assertFalse(use_trash())
+        finally:
+            os.name = old_os_name
+            sys.platform = old_sys_platform
+
+    def test_use_trash_is_true_by_default_on_posix(self):
+        old_os_name = os.name
+        old_sys_platform = sys.platform
+        try:
+            os.name = 'posix'
+            sys.platform = 'linux'
+            self.assertTrue(use_trash())
+        finally:
+            os.name = old_os_name
+            sys.platform = old_sys_platform
+
+    def test_use_trash_is_false_when_bypassed(self):
+        old_os_name = os.name
+        old_sys_platform = sys.platform
+        try:
+            config.set('settings', 'bypass_trash', "true")
+            os.name = 'posix'
+            sys.platform = 'linux'
+            self.assertFalse(use_trash())
+        finally:
+            os.name = old_os_name
+            sys.platform = old_sys_platform


### PR DESCRIPTION
I have:

  - added a setting to bypass the trash, with a default of "false", which, when set to "true" will allow users to delete files, even if their OS supports using a trash bin.
  - renamed can_trash to use_trash

Since no tests existed around deleting/trashing files, as far as I could tell, I did not add any, but am happy to add them if you think it makes sense, and if you can tell me which mocking library you prefer.

I *did* test this setting manually, and confirmed that:

  1. With no action taken by the user, on non-darwin POSIX, QL still uses the trash by default.
  2. After changing `bypass_trash` in `.quodlibet/config` to `"true"`, QL shows the delete icon in the track right-click menu, and actually deletes the file when choosing that menu item.
  3. When removing the `bypass_trash` setting from `.quodlibet/config`, the behavior reverts to what it was before this setting existed.

Motiviation: I download and listen to a lot of new tracks almost daily. Consequently I delete a lot of files every day also to clear up disk space, and I don't want to have to take two actions (move to trash, empty trash) to do so.
