### PR TITLE
Makes album-heuristics consider date-tag

### DIFF
--- a/quodlibet/quodlibet/formats/_audio.py
+++ b/quodlibet/quodlibet/formats/_audio.py
@@ -91,7 +91,8 @@ class AudioFile(dict, ImageContainer):
         return (human(self("albumsort", "")),
                 human(self("albumartistsort", "")),
                 self.get("album_grouping_key") or self.get("labelid") or
-                self.get("musicbrainz_albumid") or "")
+                self.get("musicbrainz_albumid") or
+                str(self("date")) * bool(self("albumsort")) or "")
 
     @util.cached_property
     def sort_key(self):


### PR DESCRIPTION
This is a simple heuristic that ensures that albums with the same name are considered distinct if they have different date-tags.

As by their nature albums have an unambigious release date, there should be nothing messed by this.

This solves e.g., different Albums named "In Dub" to be merged into one.
This should also solve the initial behaviour described in #559. Though this patch also allows for same-named albums to be in the same directory.