### PR TITLE
Playlists Browser: enable searching of contents

### DIFF
--- a/quodlibet/quodlibet/browsers/playlists/main.py
+++ b/quodlibet/quodlibet/browsers/playlists/main.py
@@ -45,6 +45,7 @@ class PlaylistsBrowser(Browser):
         rhbox.pack_start(songpane, True, True, 0)
         self._main_box.pack2(rhbox, True, False)
         rhbox.show()
+        align.show_all()
         return self._main_box
 
     def unpack(self, container, songpane):

--- a/quodlibet/tests/test_browsers_playlists.py
+++ b/quodlibet/tests/test_browsers_playlists.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from quodlibet.browsers.playlists.util import parse_m3u, parse_pls
+from quodlibet.browsers.playlists.util import parse_m3u, parse_pls, PLAYLISTS
 from quodlibet.util.collection import Playlist
 from tests import TestCase, AbstractTestCase, DATA_DIR, mkstemp, mkdtemp
 
@@ -13,6 +13,7 @@ from quodlibet.formats._audio import AudioFile
 from quodlibet.util.path import fsnative, fsnative2glib
 from quodlibet.library.librarians import SongLibrarian
 from quodlibet.library.libraries import FileLibrary
+from tests.test_browsers_search import SONGS, TSearchBar
 
 
 class TParsePlaylist(AbstractTestCase):
@@ -147,17 +148,55 @@ class TPlaylistIntegration(TestCase):
         self.assertFalse(len(pl))
 
 
-class TPlaylists(TestCase):
-    def setUp(self):
-        quodlibet.config.init()
-        self.library = SongLibrary()
-        self.bar = PlaylistsBrowser(SongLibrary())
+class TPlaylists(TSearchBar):
+    Bar = PlaylistsBrowser
 
-    def test_can_filter(self):
-        for key in ["foo", "title", "fake~key", "~woobar", "~#huh"]:
-            self.failIf(self.bar.can_filter(key))
+    @classmethod
+    def setUpClass(cls):
+        # Only want to do this playlists setup once per test class...
+        quodlibet.config.init()
+        cls.lib = quodlibet.browsers.playlists.library = SongLibrary()
+        cls.lib.librarian = SongLibrarian()
+        for af in SONGS:
+            af.sanitize()
+        cls.lib.add(SONGS)
+        cls._create_temp_playlist_with(SONGS)
+        PlaylistsBrowser.init(cls.lib)
+
+    @classmethod
+    def _create_temp_playlist_with(cls, songs):
+        pl = Playlist.new(PLAYLISTS, "Foobar", cls.lib)
+        pl.extend(songs)
+        pl.write()
+
+    def setUp(self):
+        self.bar = PlaylistsBrowser(self.lib)
+        self.bar.connect('songs-selected', self._expected)
+        self.bar._select_playlist(self.bar.playlists()[0])
+        self.expected = None
+
+    def test_saverestore(self):
+        # Flush previous signals, etc. Hmm.
+        self.expected = None
+        self._do()
+        self.expected = [SONGS[0]]
+        self.bar.filter_text("title = %s" % SONGS[0]["title"])
+        self.bar._select_playlist(self.bar.playlists()[0])
+        self.expected = [SONGS[0]]
+        self._do()
+        self.bar.save()
+        self.bar.filter_text("")
+        self.expected = list(sorted(SONGS))
+        self._do()
+        self.bar.restore()
+        self.bar.activate()
+        self.expected = [SONGS[0]]
+        self._do()
 
     def tearDown(self):
         self.bar.destroy()
-        self.library.destroy()
+        self.lib.destroy()
+
+    @classmethod
+    def tearDownClass(cls):
         quodlibet.config.quit()

--- a/quodlibet/tests/test_browsers_search.py
+++ b/quodlibet/tests/test_browsers_search.py
@@ -54,8 +54,9 @@ class TEmptyBar(TestCase):
 
     def _expected(self, bar, songs, sort):
         songs.sort()
-        self.failUnlessEqual(self.expected, songs)
-        self.expected = None
+        if self.expected:
+            self.failUnlessEqual(self.expected, songs)
+            self.expected = None
 
     def _do(self):
         while Gtk.events_pending():


### PR DESCRIPTION
@lazka - as discussed really. Please have a look, we can either then merge or update first.

 * Add searchbar as per other browsers, mostly.
 * Query is normal QL syntax
 * Searches persist across playlists selection
 * Text-compatible filtering supported too (TODO: ~playlists tag should select playlist)

Closes #1588.