### PR TITLE
Add a song "energy" value that operates much like song rating.

### DIFF
--- a/quodlibet/po/POTFILES.in
+++ b/quodlibet/po/POTFILES.in
@@ -138,6 +138,7 @@ quodlibet/qltk/delete.py
 quodlibet/qltk/downloader.py
 quodlibet/qltk/edittags.py
 quodlibet/qltk/_editutils.py
+quodlibet/qltk/energymenu.py
 quodlibet/qltk/exfalsowindow.py
 quodlibet/qltk/filesel.py
 quodlibet/qltk/info.py

--- a/quodlibet/quodlibet/browsers/albums/main.py
+++ b/quodlibet/quodlibet/browsers/albums/main.py
@@ -62,7 +62,7 @@ class AlbumTagCompletion(EntryWordCompletion):
             self.__model.append(row=[tag])
         for tag in ["tracks", "discs", "length", "date"]:
             self.__model.append(row=["#(" + tag])
-        for tag in ["rating", "playcount", "skipcount"]:
+        for tag in ["rating", "energy", "playcount", "skipcount"]:
             for suffix in ["avg", "max", "min", "sum"]:
                 self.__model.append(row=["#(%s:%s" % (tag, suffix)])
 
@@ -141,6 +141,19 @@ def compare_rating(a1, a2):
             cmp(a1.key, a2.key))
 
 
+def compare_energy(a1, a2):
+    if (a1 and a2) is None:
+        return cmp(a1, a2)
+    if not a1.title:
+        return 1
+    if not a2.title:
+        return -1
+    return (-cmp(a1("~#energy"), a2("~#energy")) or
+            cmpa(a1.date, a2.date) or
+            cmpa(a1.sort, a2.sort) or
+            cmp(a1.key, a2.key))
+
+
 class PreferencesButton(Gtk.HBox):
     def __init__(self, browser, model):
         super(PreferencesButton, self).__init__()
@@ -151,6 +164,7 @@ class PreferencesButton(Gtk.HBox):
             (_("_Date"), self.__compare_date),
             (_("_Genre"), self.__compare_genre),
             (_("_Rating"), self.__compare_rating),
+            (_("_Energy"), self.__compare_energy),
         ]
 
         menu = Gtk.Menu()
@@ -213,6 +227,10 @@ class PreferencesButton(Gtk.HBox):
     def __compare_rating(self, model, i1, i2, data):
         a1, a2 = model.get_value(i1), model.get_value(i2)
         return compare_rating(a1, a2)
+
+    def __compare_energy(self, model, i1, i2, data):
+        a1, a2 = model.get_value(i1), model.get_value(i2)
+        return compare_energy(a1, a2)
 
 
 class VisibleUpdate(object):

--- a/quodlibet/quodlibet/browsers/albums/prefs.py
+++ b/quodlibet/quodlibet/browsers/albums/prefs.py
@@ -15,7 +15,7 @@ from quodlibet import qltk
 from quodlibet import util
 from quodlibet.formats import PEOPLE
 
-from quodlibet.util import format_rating, connect_obj
+from quodlibet.util import format_rating, format_energy, connect_obj
 from quodlibet.qltk.ccb import ConfigCheckButton
 from quodlibet.qltk.textedit import PatternEditBox
 from quodlibet.pattern import XMLFromMarkupPattern
@@ -62,6 +62,7 @@ class Preferences(qltk.UniqueWindow):
         "~tracks": ngettext("%d track", "%d tracks", 5) % 5,
         "~discs": ngettext("%d disc", "%d discs", 2) % 2,
         "~#rating": 0.75,
+        "~#energy": 0.5,
         "album": _("An Example Album"),
         "~people": _SOME_PEOPLE + "..."})
 
@@ -75,6 +76,7 @@ class Preferences(qltk.UniqueWindow):
         self.set_transient_for(qltk.get_top_parent(browser))
         # Do this config-driven setup at instance-time
         self._EXAMPLE_ALBUM["~rating"] = format_rating(0.75)
+        self._EXAMPLE_ALBUM["~energy"] = format_energy(0.5)
 
         box = Gtk.VBox(spacing=6)
         vbox = Gtk.VBox(spacing=6)

--- a/quodlibet/quodlibet/browsers/playlists/main.py
+++ b/quodlibet/quodlibet/browsers/playlists/main.py
@@ -376,7 +376,7 @@ class PlaylistsBrowser(Browser):
         songs = filter(lambda s: isinstance(s, AudioFile), songs)
         menu = SongsMenu(library, songs,
                          playlists=False, remove=False,
-                         ratings=False)
+                         ratings=False, energy=False)
         menu.preseparate()
 
         def _remove(model, itr):

--- a/quodlibet/quodlibet/cli.py
+++ b/quodlibet/quodlibet/cli.py
@@ -72,8 +72,8 @@ def process_arguments(argv):
                 "hide-window", "show-window", "toggle-window",
                 "focus", "quit", "unfilter", "refresh", "force-previous"]
     controls_opt = ["seek", "order", "repeat", "query", "volume", "filter",
-                    "set-rating", "set-browser", "open-browser", "random",
-                    "song-list", "queue"]
+                    "set-rating", "set-energy", "set-browser", "open-browser",
+                    "random", "song-list", "queue"]
 
     options = util.OptionParser(
         "Quod Libet", const.VERSION,
@@ -119,6 +119,7 @@ def process_arguments(argv):
         ("query", _("Search your audio library"), _("query")),
         ("play-file", _("Play a file"), C_("command", "filename")),
         ("set-rating", _("Rate the playing song"), "0.0..1.0"),
+        ("set-energy", _("Set the energy of the playing song"), "0.0..1.0"),
         ("set-browser", _("Set the current browser"), "BrowserName"),
         ("open-browser", _("Open a new browser"), "BrowserName"),
         ("queue", _("Show or hide the queue"), "on|off|t"),
@@ -173,6 +174,7 @@ def process_arguments(argv):
         "volume": is_vol,
         "seek": is_time,
         "set-rating": is_float,
+        "set-energy": is_float,
         }
 
     cmds_todo = []

--- a/quodlibet/quodlibet/commands.py
+++ b/quodlibet/quodlibet/commands.py
@@ -241,6 +241,20 @@ def _set_rating(app, value):
         app.library.changed([song])
 
 
+@registry.register("set-energy", args=1)
+def _set_energy(app, value):
+    song = app.player.song
+    if not song:
+        return
+
+    try:
+        song["~#energy"] = max(0.0, min(1.0, float(value)))
+    except (ValueError, TypeError):
+        pass
+    else:
+        app.library.changed([song])
+
+
 @registry.register("dump-browsers")
 def _dump_browsers(app):
     f = StringIO()

--- a/quodlibet/quodlibet/formats/_audio.py
+++ b/quodlibet/quodlibet/formats/_audio.py
@@ -29,7 +29,7 @@ from quodlibet.util.tags import TAG_ROLES, TAG_TO_SORT
 
 
 MIGRATE = {"~#playcount", "~#laststarted", "~#lastplayed", "~#added",
-           "~#skipcount", "~#rating", "~bookmark"}
+           "~#skipcount", "~#rating", "~#rating", "~bookmark"}
 """These get migrated if a song gets reloaded"""
 
 PEOPLE = ["artist", "albumartist", "author", "composer", "~performers",
@@ -271,6 +271,10 @@ class AudioFile(dict, ImageContainer):
                 return dict.get(self, "~" + key, config.RATINGS.default)
             elif key == "rating":
                 return util.format_rating(self("~#rating"))
+            elif key == "#energy":
+                return dict.get(self, "~" + key, config.ENERGY.default)
+            elif key == "energy":
+                return util.format_energy(self("~#energy"))
             elif key == "people":
                 return "\n".join(self.list_unique(PEOPLE)) or default
             elif key == "people:real":
@@ -722,6 +726,8 @@ class AudioFile(dict, ImageContainer):
             s.append("%s=%d" % (enc_key, self.get(k, 0)))
         if "~#rating" not in self:
             s.append("~#rating=%f" % self("~#rating"))
+        if "~#energy" not in self:
+            s.append("~#energy=%f" % self("~#energy"))
         s.append("~format=%s" % self.format)
         s.append("")
         return "\n".join(s)

--- a/quodlibet/quodlibet/qltk/completion.py
+++ b/quodlibet/quodlibet/qltk/completion.py
@@ -126,7 +126,7 @@ class LibraryTagCompletion(EntryWordCompletion):
 
         tags.update(["~dirname", "~basename", "~people", "~format"])
         for tag in ["track", "disc", "playcount", "skipcount", "lastplayed",
-                    "mtime", "added", "rating", "length"]:
+                    "mtime", "added", "rating", "energy", "length"]:
             tags.add("#(" + tag)
         for tag in ["date", "bpm"]:
             if tag in all_tags:

--- a/quodlibet/quodlibet/qltk/energymenu.py
+++ b/quodlibet/quodlibet/qltk/energymenu.py
@@ -1,0 +1,80 @@
+# -*- coding: utf-8 -*-
+# Copyright 2011-2013 Nick Boultbee
+#           2005 Joe Wreschnig
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 as
+# published by the Free Software Foundation
+
+from gi.repository import Gtk
+
+from quodlibet import util
+from quodlibet import config
+from quodlibet import qltk
+from quodlibet.config import ENERGY
+from quodlibet.qltk import SeparatorMenuItem
+from quodlibet.util import connect_obj
+
+
+class ConfirmEnergyMultipleDialog(qltk.Message):
+    def __init__(self, parent, action_title, count, value):
+        assert count > 1
+
+        title = (_("Are you sure you want to change the "
+                   "energy of all %d songs?") % count)
+        desc = (_("The saved energy will be removed") if value is None
+                else _("The energy of all selected songs will be changed to "
+                       "'%s'") % util.format_energy(value))
+
+        super(ConfirmEnergyMultipleDialog, self).__init__(
+            Gtk.MessageType.WARNING, parent, title, desc, Gtk.ButtonsType.NONE)
+
+        self.add_button(Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL)
+        self.add_button(action_title, Gtk.ResponseType.YES)
+
+
+class EnergyMenuItem(Gtk.MenuItem):
+    __accels = Gtk.AccelGroup()
+
+    def set_energy(self, value, songs, librarian):
+        count = len(songs)
+        if (count > 1 and
+                config.getboolean("browsers", "energy_confirm_multiple")):
+            parent = qltk.get_menu_item_top_parent(self)
+            dialog = ConfirmEnergyMultipleDialog(
+                parent, _("Change _Energy"), count, value)
+            if dialog.run() != Gtk.ResponseType.YES:
+                return
+        for song in songs:
+            song["~#energy"] = value
+        librarian.changed(songs)
+
+    def remove_energy(self, songs, librarian):
+        count = len(songs)
+        if (count > 1 and
+                config.getboolean("browsers", "energy_confirm_multiple")):
+            parent = qltk.get_menu_item_top_parent(self)
+            dialog = ConfirmEnergyMultipleDialog(
+                parent, _("_Remove Energy"), count, None)
+            if dialog.run() != Gtk.ResponseType.YES:
+                return
+        reset = []
+        for song in songs:
+            if "~#energy" in song:
+                del song["~#energy"]
+                reset.append(song)
+        librarian.changed(reset)
+
+    def __init__(self, songs, library, label=_("_Energy")):
+        super(EnergyMenuItem, self).__init__(label=label, use_underline=True)
+        submenu = Gtk.Menu()
+        self.set_submenu(submenu)
+        for i in ENERGY.all:
+            itm = Gtk.MenuItem(label="%0.2f\t%s" % (i, util.format_energy(i)))
+            submenu.append(itm)
+            connect_obj(itm, 'activate', self.set_energy, i, songs, library)
+        reset = Gtk.MenuItem(label=_("_Remove energy"), use_underline=True)
+        connect_obj(reset, 'activate', self.remove_energy, songs, library)
+        submenu.append(SeparatorMenuItem())
+        submenu.append(reset)
+        submenu.show_all()

--- a/quodlibet/quodlibet/qltk/information.py
+++ b/quodlibet/quodlibet/qltk/information.py
@@ -228,6 +228,8 @@ class OneSong(qltk.Notebook):
         added = ftime(song.get("~#added", 0))
         rating = song("~rating")
         has_rating = "~#rating" in song
+        energy = song("~energy")
+        has_energy = "~#energy" in song
 
         t = Gtk.Table(n_rows=5, n_columns=2)
         t.set_col_spacings(6)
@@ -236,7 +238,8 @@ class OneSong(qltk.Notebook):
                  (_("last played"), lastplayed, True),
                  (_("plays"), playcount, True),
                  (_("skips"), skipcount, True),
-                 (_("rating"), rating, has_rating)]
+                 (_("rating"), rating, has_rating),
+                 (_("energy"), energy, has_energy)]
 
         for i, (l, r, s) in enumerate(table):
             l = "<b>%s</b>" % util.capitalize(util.escape(l) + ":")

--- a/quodlibet/quodlibet/qltk/queue.py
+++ b/quodlibet/quodlibet/qltk/queue.py
@@ -280,7 +280,7 @@ class PlayQueue(SongList):
 
         menu = SongsMenu(
             library, songs, queue=False, remove=False, delete=False,
-            ratings=False)
+            ratings=False, energy=False)
         menu.preseparate()
         remove = Gtk.ImageMenuItem(Gtk.STOCK_REMOVE, use_stock=True)
         qltk.add_fake_accel(remove, "Delete")

--- a/quodlibet/quodlibet/qltk/songlist.py
+++ b/quodlibet/quodlibet/qltk/songlist.py
@@ -1047,7 +1047,7 @@ class SongList(AllTreeView, SongListDnDMixin, DragScroll,
         menu.append(sep)
 
         trackinfo = """title genre ~title~version ~#track
-            ~#playcount ~#skipcount ~rating ~#length""".split()
+            ~#playcount ~#skipcount ~rating ~energy ~#length""".split()
         peopleinfo = """artist ~people performer arranger author composer
             conductor lyricist originalartist""".split()
         albuminfo = """album ~album~discsubtitle labelid ~#disc ~#discs

--- a/quodlibet/quodlibet/qltk/songlistcolumns.py
+++ b/quodlibet/quodlibet/qltk/songlistcolumns.py
@@ -32,6 +32,8 @@ def create_songlist_column(t):
         return FilesizeColumn()
     elif t in ["~rating"]:
         return RatingColumn()
+    elif t in ["~energy"]:
+        return EnergyColumn()
     elif t.startswith("~#"):
         return NumericColumn(t)
     elif t in FILESYSTEM_TAGS:
@@ -133,6 +135,33 @@ class RatingColumn(TextColumn):
         cell.set_sensitive(rating is not None)
         value = rating if rating is not None else default
         cell.set_property('text', util.format_rating(value))
+
+
+class EnergyColumn(TextColumn):
+    """Render ~energy directly
+
+    (simplifies filtering, saves a function call).
+    """
+
+    def __init__(self, *args, **kwargs):
+        super(EnergyColumn, self).__init__("~energy", *args, **kwargs)
+        self.set_expand(False)
+        self.set_resizable(False)
+        width = self._cell_width(util.format_energy(1.0))
+        self.set_fixed_width(width)
+        self.set_min_width(width)
+
+    def _cdf(self, column, cell, model, iter_, user_data):
+        song = model.get_value(iter_)
+        energy = song.get("~#energy")
+        default = config.ENERGY.default
+
+        if not self._needs_update((energy, default)):
+            return
+
+        cell.set_sensitive(energy is not None)
+        value = energy if energy is not None else default
+        cell.set_property('text', util.format_energy(value))
 
 
 class WideTextColumn(TextColumn):

--- a/quodlibet/quodlibet/qltk/songsmenu.py
+++ b/quodlibet/quodlibet/qltk/songsmenu.py
@@ -17,6 +17,7 @@ from quodlibet.qltk.information import Information
 from quodlibet.qltk.properties import SongProperties
 from quodlibet.qltk.x import SeparatorMenuItem, Button
 from quodlibet.qltk.ratingsmenu import RatingsMenuItem
+from quodlibet.qltk.energymenu import EnergyMenuItem
 from quodlibet.qltk import get_top_parent, get_menu_item_top_parent
 from quodlibet.plugins import PluginManager, PluginHandler
 from quodlibet.plugins.songsmenu import SongsMenuPlugin
@@ -272,7 +273,8 @@ class SongsMenu(Gtk.Menu):
 
     def __init__(self, library, songs, plugins=True, playlists=True,
                  queue=True, devices=True, remove=True, delete=False,
-                 edit=True, ratings=True, items=None, accels=True):
+                 edit=True, ratings=True, energy=True, items=None,
+                 accels=True):
         super(SongsMenu, self).__init__()
 
         # The library may actually be a librarian; if it is, use it,
@@ -283,6 +285,13 @@ class SongsMenu(Gtk.Menu):
             ratings_item = RatingsMenuItem(songs, librarian)
             ratings_item.set_sensitive(bool(songs))
             self.append(ratings_item)
+
+        if energy:
+            energy_item = EnergyMenuItem(songs, librarian)
+            energy_item.set_sensitive(bool(songs))
+            self.append(energy_item)
+
+        if ratings or energy:
             self.separate()
 
         # external item groups

--- a/quodlibet/quodlibet/util/__init__.py
+++ b/quodlibet/quodlibet/util/__init__.py
@@ -319,6 +319,19 @@ def format_rating(value, blank=True):
     return prefs.full_symbol * ons + prefs.blank_symbol * offs
 
 
+def format_energy(value, blank=True):
+    """Turn a number into a sequence of energy symbols."""
+
+    from quodlibet import config
+
+    prefs = config.ENERGY
+    steps = prefs.number
+    value = max(min(value, 1.0), 0)
+    ons = int(round(steps * value))
+    offs = (steps - ons) if blank else 0
+    return prefs.full_symbol * ons + prefs.blank_symbol * offs
+
+
 def format_size(size):
     """Turn an integer size value into something human-readable."""
     # TODO: Better i18n of this (eg use O/KO/MO/GO in French)

--- a/quodlibet/quodlibet/util/collection.py
+++ b/quodlibet/quodlibet/util/collection.py
@@ -52,6 +52,7 @@ NUM_DEFAULT_FUNCS = {
     "laststarted": "max",
     "mtime": "max",
     "rating": "bav",
+    "energy": "avg",
     "skipcount": "sum",
     "year": "min",
     "originalyear": "min",
@@ -248,6 +249,11 @@ class Collection(object):
                 if rating is None:
                     return None
                 return util.format_rating(rating)
+            elif numkey == "energy":
+                energy = self.__get_value("~#" + key)
+                if energy is None:
+                    return None
+                return util.format_energy(energy)
             elif key == "cover":
                 return ((self.cover != type(self).cover) and "y") or None
             elif numkey == "filesize":

--- a/quodlibet/tests/test_browsers_albums.py
+++ b/quodlibet/tests/test_browsers_albums.py
@@ -15,7 +15,7 @@ from quodlibet import config
 from quodlibet.browsers.albums import AlbumList
 from quodlibet.browsers.albums.prefs import Preferences, FakeAlbum
 from quodlibet.browsers.albums.main import (compare_title, compare_artist,
-    compare_genre, compare_rating, compare_date)
+    compare_genre, compare_rating, compare_energy, compare_date)
 from quodlibet.formats._audio import AudioFile
 from quodlibet.library import SongLibrary, SongLibrarian
 from quodlibet.util.path import fsnative
@@ -117,6 +117,14 @@ class TAlbumSort(TestCase):
 
         self.assertOrder(compare_rating, [None, a, b, c, n])
 
+    def test_sort_energy(self):
+        a = self._get_album({"album": "b", "~#energy": 0.5})
+        b = self._get_album({"album": "a", "~#energy": 0.25})
+        c = self._get_album({"album": "x", "~#energy": 0.0})
+        n = self._get_album({"album": "", "~#energy": 0.25})
+
+        self.assertOrder(compare_energy, [None, a, b, c, n])
+
 
 class TFakeAlbum(TestCase):
 
@@ -128,6 +136,9 @@ class TFakeAlbum(TestCase):
         self.assertEqual(FakeAlbum()("~#rating"), "Rating")
         self.assertEqual(FakeAlbum({"~#rating": 0.5})("~#rating"), 0.5)
         self.assertEqual(FakeAlbum()("~#rating:max"), "Rating<max>")
+        self.assertEqual(FakeAlbum()("~#energy"), "Energy")
+        self.assertEqual(FakeAlbum({"~#energy": 0.5})("~#energy"), 0.5)
+        self.assertEqual(FakeAlbum()("~#energy:max"), "Energy<max>")
 
     def test_get(self):
         self.assertEqual(FakeAlbum().get("title"), "Title")
@@ -135,6 +146,7 @@ class TFakeAlbum(TestCase):
     def test_comma(self):
         self.assertEqual(FakeAlbum().comma("title"), "Title")
         self.assertEqual(FakeAlbum({"~#rating": 0.5}).comma("~#rating"), 0.5)
+        self.assertEqual(FakeAlbum({"~#energy": 0.5}).comma("~#energy"), 0.5)
         self.assertEqual(FakeAlbum(title="a\nb").comma("title"), "a, b")
 
 

--- a/quodlibet/tests/test_browsers_iradio.py
+++ b/quodlibet/tests/test_browsers_iradio.py
@@ -7,6 +7,7 @@ from quodlibet.browsers.iradio import InternetRadio, IRFile, QuestionBar
 import quodlibet.config
 
 quodlibet.config.RATINGS = quodlibet.config.HardCodedRatingsPrefs()
+quodlibet.config.ENERGY = quodlibet.config.HardCodedEnergyPrefs()
 
 
 class TQuestionBar(TestCase):

--- a/quodlibet/tests/test_commands.py
+++ b/quodlibet/tests/test_commands.py
@@ -64,6 +64,7 @@ class TCommands(TestCase):
         self.__send("repeat 0")
         self.__send("set-browser 1")
         self.__send("set-rating 0.5")
+        self.__send("set-energy 0.5")
         self.__send("show-window")
         self.__send("song-list 1")
         self.__send("status")

--- a/quodlibet/tests/test_config.py
+++ b/quodlibet/tests/test_config.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 import os
-from quodlibet.config import RatingsPrefs
+from quodlibet.config import RatingsPrefs, EnergyPrefs
 from tests import TestCase, mkstemp
 from helper import capture_output
 
@@ -71,6 +71,46 @@ class TRatingsPrefs(TestCase):
     def test_all(self):
         self.prefs.number = 5
         # Remember zero is a possible rating too
+        self.failUnlessEqual(len(self.prefs.all), 6)
+        self.failUnlessEqual(self.prefs.all, [0, 0.2, 0.4, 0.6, 0.8, 1.0])
+
+    def tearDown(self):
+        config.quit()
+
+
+class TEnergyPrefs(TestCase):
+    initial_number = int(config.INITIAL["settings"]["energy_levels"])
+
+    def setUp(self):
+        config.init()
+        self.prefs = EnergyPrefs()
+
+    def test_getters(self):
+        # A little pointless, and brittle, but still.
+        self.failUnlessEqual(self.prefs.number, self.initial_number)
+        self.failUnlessEqual(self.prefs.precision, 1.0 / self.initial_number)
+        self.failUnlessEqual(self.prefs.full_symbol, config.INITIAL[
+            "settings"]["energy_symbol_full"].decode("utf-8"))
+        self.failUnlessEqual(self.prefs.blank_symbol, config.INITIAL[
+            "settings"]["energy_symbol_blank"].decode("utf-8"))
+
+    def test_caching(self):
+        self.failUnlessEqual(self.prefs.number, self.initial_number)
+        self.prefs.number = 10
+        self.prefs.default = 0.1
+        # Read it back, and it's fine
+        self.failUnlessEqual(self.prefs.number, 10)
+        self.failUnlessEqual(self.prefs.default, 0.1)
+        # .. but modify behind the scenes (unsupported)...
+        config.reset("settings", "energy_levels")
+        config.reset("settings", "default_energy")
+        # ...and caching will return the old one
+        self.failUnlessEqual(self.prefs.number, 10)
+        self.failUnlessEqual(self.prefs.default, 0.1)
+
+    def test_all(self):
+        self.prefs.number = 5
+        # Remember zero is a possible energy too
         self.failUnlessEqual(len(self.prefs.all), 6)
         self.failUnlessEqual(self.prefs.all, [0, 0.2, 0.4, 0.6, 0.8, 1.0])
 

--- a/quodlibet/tests/test_formats__audio.py
+++ b/quodlibet/tests/test_formats__audio.py
@@ -362,7 +362,8 @@ class TAudioFile(TestCase):
     def test_to_dump(self):
         dump = bar_1_1.to_dump()
         num = len(set(bar_1_1.keys()) | INTERN_NUM_DEFAULT)
-        self.failUnlessEqual(dump.count("\n"), num + 2)
+        # The +3 is for the extra \n, rating, and energy.
+        self.failUnlessEqual(dump.count("\n"), num + 3)
         for key, value in bar_1_1.items():
             self.failUnless(key in dump)
             self.failUnless(value in dump)
@@ -378,7 +379,8 @@ class TAudioFile(TestCase):
         b["~#length"] = 200000000000L
         dump = b.to_dump()
         num = len(set(bar_1_1.keys()) | INTERN_NUM_DEFAULT)
-        self.failUnlessEqual(dump.count("\n"), num + 2)
+        # The +3 is for the extra \n, rating, and energy.
+        self.failUnlessEqual(dump.count("\n"), num + 3)
 
         n = AudioFile()
         n.from_dump(dump)

--- a/quodlibet/tests/test_qltk_energymenu.py
+++ b/quodlibet/tests/test_qltk_energymenu.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+# Copyright 2012,2013 Christoph Reiter
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 as
+# published by the Free Software Foundation
+
+from tests import TestCase
+from quodlibet import config
+from quodlibet.qltk.energymenu import EnergyMenuItem
+from quodlibet.util.path import fsnative
+from quodlibet.library import SongLibrary, SongLibrarian
+from quodlibet.formats._audio import AudioFile
+
+
+class TEnergyMenuItem(TestCase):
+
+    def setUp(self):
+        config.init()
+
+    def tearDown(self):
+        config.quit()
+
+    def test_menuitem(self):
+        library = SongLibrary()
+        library.librarian = SongLibrarian()
+        a = AudioFile({"~filename": fsnative(u"/foo")})
+        a.sanitize()
+        x = EnergyMenuItem([a], library)
+        x.set_energy(0, [a], library)
+        x.destroy()
+        library.destroy()
+        library.librarian.destroy()

--- a/quodlibet/tests/test_qltk_songlistcolumns.py
+++ b/quodlibet/tests/test_qltk_songlistcolumns.py
@@ -21,7 +21,8 @@ class TSongListColumns(TestCase):
         view = Gtk.TreeView()
         model = ObjectStore()
         view.set_model(model)
-        song = AudioFile({"~filename": "/dev/null", "~#rating": 0.6666})
+        song = AudioFile({"~filename": "/dev/null", "~#rating": 0.6666,
+                          "~#energy": 0.6666})
         song.update(kwargs)
         model.append(row=[song])
         view.append_column(column)
@@ -57,6 +58,15 @@ class TSongListColumns(TestCase):
         self.assertNotEqual(text, "0.67")
 
         column = create_songlist_column("~#rating")
+        text = self._render_column(column)
+        self.assertEqual(text, "0.67")
+
+    def test_energy(self):
+        column = create_songlist_column("~energy")
+        text = self._render_column(column)
+        self.assertNotEqual(text, "0.67")
+
+        column = create_songlist_column("~#energy")
         text = self._render_column(column)
         self.assertEqual(text, "0.67")
 

--- a/quodlibet/tests/test_qltk_songsmenu.py
+++ b/quodlibet/tests/test_qltk_songsmenu.py
@@ -25,7 +25,7 @@ class TSongsMenu(TestCase):
         self.menu = SongsMenu(self.library, self.songs, plugins=False,
                               playlists=False, queue=False, devices=False,
                               remove=False, delete=False, edit=False,
-                              ratings=False)
+                              ratings=False, energy=False)
         self.failUnlessEqual(0, len(self.menu))
 
     def test_simple(self):
@@ -35,7 +35,7 @@ class TSongsMenu(TestCase):
         self.menu = SongsMenu(
             self.library, self.songs, plugins=False, playlists=True,
             queue=False, devices=False, remove=False, delete=False, edit=False,
-            ratings=False)
+            ratings=False, energy=False)
         self.failUnlessEqual(1, len(self.menu))
         self.failUnless(self.menu.get_children()[0].props.sensitive)
 
@@ -43,7 +43,7 @@ class TSongsMenu(TestCase):
         self.menu = SongsMenu(
             self.library, self.songs, plugins=False, playlists=True,
             queue=False, devices=False, remove=False, delete=False, edit=False,
-            ratings=False)
+            ratings=False, energy=False)
         self.failUnlessEqual(1, len(self.menu))
         self.failIf(self.menu.get_children()[0].props.sensitive)
 
@@ -51,7 +51,7 @@ class TSongsMenu(TestCase):
         self.menu = SongsMenu(
             self.library, self.songs, plugins=False, playlists=False,
             queue=True, devices=False, remove=False, delete=False, edit=False,
-            ratings=False)
+            ratings=False, energy=False)
         self.failUnlessEqual(1, len(self.menu))
         self.failUnless(self.menu.get_children()[0].props.sensitive)
 
@@ -59,7 +59,7 @@ class TSongsMenu(TestCase):
         self.menu = SongsMenu(
             self.library, self.songs, plugins=False, playlists=False,
             queue=True, devices=False, remove=False, delete=False, edit=False,
-            ratings=False)
+            ratings=False, energy=False)
         self.failUnlessEqual(1, len(self.menu))
         self.failIf(self.menu.get_children()[0].props.sensitive)
 
@@ -67,7 +67,7 @@ class TSongsMenu(TestCase):
         self.menu = SongsMenu(
             self.library, self.songs, plugins=False, playlists=False,
             queue=False, devices=True, remove=False, delete=False, edit=False,
-            ratings=False)
+            ratings=False, energy=False)
         from quodlibet import browsers
         if browsers.media.MediaDevices in browsers.browsers:
             self.failUnlessEqual(1, len(self.menu))
@@ -78,7 +78,7 @@ class TSongsMenu(TestCase):
         self.menu = SongsMenu(
             self.library, self.songs, plugins=False, playlists=False,
             queue=False, devices=False, remove=True, delete=False, edit=False,
-            ratings=False)
+            ratings=False, energy=False)
         self.failUnlessEqual(1, len(self.menu))
         self.failIf(self.menu.get_children()[0].props.sensitive)
 
@@ -87,7 +87,7 @@ class TSongsMenu(TestCase):
         self.menu = SongsMenu(
             self.library, self.songs, plugins=False, playlists=False,
             queue=False, devices=False, remove=True, delete=False, edit=False,
-            ratings=False)
+            ratings=False, energy=False)
         self.failUnlessEqual(1, len(self.menu))
         self.failUnless(self.menu.get_children()[0].props.sensitive)
 
@@ -95,7 +95,7 @@ class TSongsMenu(TestCase):
         self.menu = SongsMenu(
             self.library, self.songs, plugins=False, playlists=False,
             queue=False, devices=False, remove=False, delete=True, edit=False,
-            ratings=False)
+            ratings=False, energy=False)
         self.failUnlessEqual(1, len(self.menu))
         self.failUnless(self.menu.get_children()[0].props.sensitive)
 
@@ -103,7 +103,7 @@ class TSongsMenu(TestCase):
         self.menu = SongsMenu(
             self.library, self.songs, plugins=False, playlists=False,
             queue=False, devices=False, remove=False, delete=True, edit=False,
-            ratings=False)
+            ratings=False, energy=False)
         self.failUnlessEqual(1, len(self.menu))
         self.failIf(self.menu.get_children()[0].props.sensitive)
 


### PR DESCRIPTION
This patch adds an arbitrary "energy" rating for songs that operates just like regular song ratings for most intents and purposes.

If a user has a wide gamut of musical tastes, this allows them to filter for more or less "intense" songs (or whatever they decide "energy" means), depending on what they are in the mood for, without making huge manual playlists, or usually unsatisfactory genre, artist or album filters.

This is probably too niche a feature to merge. Just thought I'd post it in case people are interested. I've been using it since 3.0.1 and have been enjoying the easy mood filtering.