### PR TITLE
Add a plugin for editing ~#playcount and ~#skipcount.

### DIFF
--- a/quodlibet/po/POTFILES.in
+++ b/quodlibet/po/POTFILES.in
@@ -86,6 +86,7 @@ quodlibet/ext/songsmenu/cddb.py
 quodlibet/ext/songsmenu/console.py
 quodlibet/ext/songsmenu/custom_commands.py
 quodlibet/ext/songsmenu/duplicates.py
+quodlibet/ext/songsmenu/editplaycount.py
 quodlibet/ext/songsmenu/embedded.py
 quodlibet/ext/songsmenu/exact_rating.py
 quodlibet/ext/songsmenu/filterall.py

--- a/quodlibet/quodlibet/ext/songsmenu/editplaycount.py
+++ b/quodlibet/quodlibet/ext/songsmenu/editplaycount.py
@@ -1,0 +1,109 @@
+# -*- coding: utf-8 -*-
+# Copyright 2012-2015 Ryan "ZDBioHazard" Turner <zdbiohazard2@gmail.com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 as
+# published by the Free Software Foundation
+
+from gi.repository import Gtk
+
+from quodlibet.plugins.songsmenu import SongsMenuPlugin
+
+
+class EditPlaycount(SongsMenuPlugin):
+    PLUGIN_ID = "editplaycount"
+    PLUGIN_NAME = _("Edit Playcount")
+    PLUGIN_DESC = _("Edit a song's ~#playcount and ~#skipcount."
+                    "\n\n"
+                    "When multiple songs are selected, counts will be "
+                    "incremented, rather than set."
+                    "\n\n"
+                    "When setting a song's ~#playcount to 0, the "
+                    "~#lastplayed and ~#laststarted entries will be cleared. "
+                    "However, when setting a 0-play song to a positive play "
+                    "count, no play times will be created.")
+    PLUGIN_ICON = "gtk-edit"
+    PLUGIN_VERSION = "1.2"
+
+    def plugin_songs(self, songs):
+        # This is just here so the spinner has something to call. >.>
+        def response(win, response_id):
+            dlg.response(response_id)
+            return
+
+        # Create a dialog.
+        dlg = Gtk.Dialog(title=_("Edit Playcount"),
+                         flags=(Gtk.DialogFlags.MODAL |
+                                Gtk.DialogFlags.DESTROY_WITH_PARENT),
+                         buttons=(Gtk.STOCK_CANCEL, Gtk.ResponseType.REJECT,
+                                  Gtk.STOCK_APPLY, Gtk.ResponseType.APPLY))
+        dlg.set_default_response(Gtk.ResponseType.APPLY)
+        dlg.set_border_width(4)
+        dlg.vbox.set_spacing(4)
+
+        # Create some spinners.
+        play = Gtk.SpinButton()
+        play.set_adjustment(Gtk.Adjustment(0, -1000, 1000, 1, 1))
+        skip = Gtk.SpinButton()
+        skip.set_adjustment(Gtk.Adjustment(0, -1000, 1000, 1, 1))
+
+        # Connect the signals.
+        play.connect("activate", response, Gtk.ResponseType.APPLY)
+        skip.connect("activate", response, Gtk.ResponseType.APPLY)
+
+        # Set some defaults.
+        play.set_numeric(True)
+        skip.set_numeric(True)
+
+        # Put all this stuff in a pretty table.
+        table = Gtk.Table(rows=2, columns=2)
+        table.set_row_spacings(4)
+        table.set_col_spacings(4)
+        table.attach(Gtk.Label(_("Play Count")), 0, 1, 0, 1)
+        table.attach(Gtk.Label(_("Skip Count")), 0, 1, 1, 2)
+        table.attach(play, 1, 2, 0, 1)
+        table.attach(skip, 1, 2, 1, 2)
+        dlg.vbox.add(table)
+
+        # Make a couple tweaks based on the current mode.
+        if len(songs) == 1:
+            play.set_adjustment(Gtk.Adjustment(0, 0, 9999, 1, 1))
+            skip.set_adjustment(Gtk.Adjustment(0, 0, 9999, 1, 1))
+            play.set_value(songs[0].get('~#playcount', 0))
+            skip.set_value(songs[0].get('~#skipcount', 0))
+        else:
+            note = Gtk.Label()
+            note.set_justify(Gtk.Justification.CENTER)
+            note.set_markup("<b>Multiple files selected.</b>\n"
+                            "Counts will be incremented.")
+            dlg.vbox.add(note)
+
+        dlg.show_all()
+
+        # Only operate if apply is pressed.
+        if dlg.run() == Gtk.ResponseType.APPLY:
+            for song in songs:
+                # Increment when not in single mode.
+                if len(songs) == 1:
+                    song['~#playcount'] = play.get_value_as_int()
+                    song['~#skipcount'] = skip.get_value_as_int()
+                else:  # Can't use += here because these tags might not exist.
+                    song['~#playcount'] = max(0, (song.get('~#playcount', 0) +
+                                                  play.get_value_as_int()))
+                    song['~#skipcount'] = max(0, (song.get('~#skipcount', 0) +
+                                                  skip.get_value_as_int()))
+
+                # When the playcount is set to 0, delete the playcount
+                # itself and the last played/started time. We don't
+                # want unused or impossible data floating around.
+                if song.get('~#playcount', 0) == 0:
+                    for tag in ['~#playcount', '~#lastplayed',
+                                '~#laststarted']:
+                        song.pop(tag, None)
+
+                # Also delete the skip count if it's zero.
+                if song.get('~#skipcount', 0) == 0:
+                    song.pop('~#skipcount', None)
+
+        dlg.destroy()
+        return


### PR DESCRIPTION
This songs menu plugin lets you easily edit the `~#playcount` and `~#skipcount` of selected songs.

It supports incrementing multiple songs, and resets `~#laststarted` and `~#lastplayed` when setting `~#playcount` to 0.