### PR TITLE
Add a setting to enable/disable rating hotkeys.

### DIFF
--- a/quodlibet/quodlibet/config.py
+++ b/quodlibet/quodlibet/config.py
@@ -67,6 +67,7 @@ INITIAL = {
         "collection_headers": "~people 0",
         "radio": "", # radio filter selection
         "rating_click": "true", # click to rate song, on/off
+        "rating_hotkeys": "true", # press number keys to rate song on/off
         "rating_confirm_multiple": "false", # confirm rating multiple songs
         "cover_size": "-1", # max cover height/width, <= 0 is default
         "search_limit": "false", # Show the limit widgets for SearchBar

--- a/quodlibet/quodlibet/qltk/prefs.py
+++ b/quodlibet/quodlibet/qltk/prefs.py
@@ -243,15 +243,9 @@ class PreferencesWindow(UniqueWindow):
                      tooltip=_("Enable rating by clicking on the rating "
                                "column in the song list"))
 
-            c3 = CCB(_("Enable rating _hotkeys"),
-                     'browsers', 'rating_hotkeys', populate=True,
-                     tooltip=_("Enable rating by pressing the 0-%d keys " %
-                               min(9, config.RATINGS.number)))
-
             vbox = Gtk.VBox(spacing=6)
             vbox.pack_start(c1, False, True, 0)
             vbox.pack_start(c2, False, True, 0)
-            vbox.pack_start(c3, False, True, 0)
             f = qltk.Frame(_("Ratings"), child=vbox)
             self.pack_start(f, False, True, 0)
 

--- a/quodlibet/quodlibet/qltk/prefs.py
+++ b/quodlibet/quodlibet/qltk/prefs.py
@@ -243,9 +243,15 @@ class PreferencesWindow(UniqueWindow):
                      tooltip=_("Enable rating by clicking on the rating "
                                "column in the song list"))
 
+            c3 = CCB(_("Enable rating _hotkeys"),
+                     'browsers', 'rating_hotkeys', populate=True,
+                     tooltip=_("Enable rating by pressing the 0-%d keys " %
+                               min(9, config.RATINGS.number)))
+
             vbox = Gtk.VBox(spacing=6)
             vbox.pack_start(c1, False, True, 0)
             vbox.pack_start(c2, False, True, 0)
+            vbox.pack_start(c3, False, True, 0)
             f = qltk.Frame(_("Ratings"), child=vbox)
             self.pack_start(f, False, True, 0)
 

--- a/quodlibet/quodlibet/qltk/songlist.py
+++ b/quodlibet/quodlibet/qltk/songlist.py
@@ -618,7 +618,8 @@ class SongList(AllTreeView, SongListDnDMixin, DragScroll,
         rating_accels = [
             "<ctrl>%d" % i for i in range(min(10, config.RATINGS.number + 1))]
 
-        if qltk.is_accel(event, *rating_accels):
+        if (qltk.is_accel(event, *rating_accels) and
+                config.getboolean("browsers", "rating_hotkeys")):
             rating = int(chr(event.keyval)) * config.RATINGS.precision
             self.__set_rating(rating, self.get_selected_songs(), librarian)
             return True


### PR DESCRIPTION
This is sort-of a continuation of #1401.

Changing the hotkeys to `<ctrl>-[0-x]` nearly eliminated mis-ratings for me, but now I have another app that uses `<ctrl>-[0-9]` in it's UI, so I updated this patch just to be safe. :wink: