### PR TITLE
Internet is a proper noun

### DIFF
--- a/quodlibet/docs/index.rst
+++ b/quodlibet/docs/index.rst
@@ -15,7 +15,7 @@ tags you want in the file, for all the file formats it supports.
 Unlike some, Quod Libet will scale to libraries with tens of thousands of
 songs. It also supports most of the :ref:`features <Features>` you'd expect
 from a modern media player: Unicode support, advanced tag editing, Replay
-Gain, podcasts & internet radio, album art support and all major audio
+Gain, podcasts & Internet radio, album art support and all major audio
 formats - see the :ref:`screenshots <Screenshots>`.
 
 **Ex Falso** is a program that uses the same **tag editing** back-end as


### PR DESCRIPTION
Just capitalized "Internet" as it is a proper noun, at least according to the Chicago Manual of Style and a billion other style guides. Likewise, it is recommend to capitalize it if it is modifying another noun -- in this case radio.