### PR TITLE
Audio Feeds: avoid loading doubles

### DIFF
--- a/quodlibet/quodlibet/browsers/audiofeeds.py
+++ b/quodlibet/quodlibet/browsers/audiofeeds.py
@@ -264,13 +264,16 @@ class AudioFeeds(Browser):
 
     @classmethod
     def init(klass, library):
+        uris = set()
         try:
             feeds = pickle.load(file(FEEDS, "rb"))
         except (pickle.PickleError, EnvironmentError, EOFError):
             pass
         else:
             for feed in feeds:
-                klass.__feeds.append(row=[feed])
+                if feed.uri not in uris:
+                    klass.__feeds.append(row=[feed])
+                    uris.add(feed.uri)
         GLib.idle_add(klass.__do_check)
 
     @classmethod


### PR DESCRIPTION
I wrote a plugin that manipulates the feeds pickle database. To avoid double entries in the Audio Feeds Browser, check for doubles during AudioFeeds.init() – which I also can call in my plugin.