### PR TITLE
Add authentication for MPDServer plugin

### DIFF
--- a/quodlibet/quodlibet/ext/events/mpdserver/__init__.py
+++ b/quodlibet/quodlibet/ext/events/mpdserver/__init__.py
@@ -17,6 +17,7 @@ import threading
 
 from gi.repository import Gtk, GLib
 
+from quodlibet.plugins import PluginConfigMixin
 from quodlibet.plugins.events import EventPlugin
 from quodlibet import app
 from quodlibet import qltk
@@ -58,7 +59,7 @@ def set_port_num(value):
     return config.set("plugins", "mpdserver_port", str(value))
 
 
-class MPDServerPlugin(EventPlugin):
+class MPDServerPlugin(EventPlugin, PluginConfigMixin):
     PLUGIN_ID = "mpd_server"
     PLUGIN_NAME = _("MPD Server")
     PLUGIN_DESC = _("Allows remote control of Quod Libet using an MPD Client. "
@@ -66,10 +67,12 @@ class MPDServerPlugin(EventPlugin):
                     "are not supported.")
     PLUGIN_ICON = Icons.NETWORK_WORKGROUP
 
+    CONFIG_SECTION = "mpdserver"
+
     _server = None
 
     def PluginPreferences(self, parent):
-        table = Gtk.Table(n_rows=2, n_columns=3)
+        table = Gtk.Table(n_rows=3, n_columns=3)
         table.set_col_spacings(6)
         table.set_row_spacings(6)
 
@@ -121,6 +124,18 @@ class MPDServerPlugin(EventPlugin):
         table.attach(label, 0, 1, 1, 2,
                      xoptions=Gtk.AttachOptions.FILL |
                      Gtk.AttachOptions.SHRINK)
+
+        label = Gtk.Label(label=_("P_assword:"), use_underline=True)
+        label.set_alignment(0.0, 0.5)
+        table.attach(label, 0, 1, 2, 3,
+                     xoptions=Gtk.AttachOptions.FILL |
+                     Gtk.AttachOptions.SHRINK)
+
+        entry = UndoEntry()
+        entry.set_text(self.config_get("password"))
+        entry.connect('changed', self.config_entry_changed, "password")
+
+        table.attach(entry, 1, 3, 2, 3)
 
         entry = UndoEntry()
         entry.set_text("...")

--- a/quodlibet/quodlibet/ext/events/mpdserver/__init__.py
+++ b/quodlibet/quodlibet/ext/events/mpdserver/__init__.py
@@ -172,7 +172,7 @@ namelessdev.mpdroid">MPDroid 1.06</a> (Android)<small>
     def _enable_server(self):
         port_num = get_port_num()
         print_d("Starting MPD server on port %d" % port_num)
-        self._server = MPDServer(app, port_num)
+        self._server = MPDServer(app, self, port_num)
         try:
             self._server.start()
         except ServerError as e:

--- a/quodlibet/quodlibet/ext/events/mpdserver/main.py
+++ b/quodlibet/quodlibet/ext/events/mpdserver/main.py
@@ -574,6 +574,9 @@ class MPDConnection(BaseTCPConnection):
             return
 
         cmd, do_ack, permission = self._commands[command]
+        if permission != (self.permission & permission):
+            raise MPDRequestError("Insufficient permission",
+                    AckError.PERMISSION)
 
         cmd(self, self.service, args)
 

--- a/quodlibet/quodlibet/ext/events/mpdserver/main.py
+++ b/quodlibet/quodlibet/ext/events/mpdserver/main.py
@@ -475,6 +475,13 @@ class MPDConnection(BaseTCPConnection):
 
     #  ------------ rest ------------
 
+    def authenticate(self, password):
+        if password == self.service._config.config_get("password"):
+            self.permission = Permissions.PERMISSION_ALL
+        else:
+            self.permission = self.service.default_permission
+            raise MPDRequestError("Password incorrect", AckError.PASSWORD)
+
     def log(self, msg):
         if const.DEBUG:
             print_d("[%s] %s" % (self.name, msg))
@@ -639,6 +646,12 @@ def _cmd_idle(conn, service, args):
 @MPDConnection.Command("ping")
 def _cmd_ping(conn, service, args):
     return
+
+
+@MPDConnection.Command("password")
+def _cmd_password(conn, service, args):
+    _verify_length(args, 1)
+    conn.authenticate(args[0])
 
 
 @MPDConnection.Command("noidle")

--- a/quodlibet/tests/plugin/test_mpdserver.py
+++ b/quodlibet/tests/plugin/test_mpdserver.py
@@ -69,11 +69,12 @@ class TMPDCommands(PluginTestCase):
         config.init()
         init_fake_app()
 
+        MPDServerPlugin = self.mod.MPDServerPlugin
         MPDConnection = self.mod.main.MPDConnection
         MPDService = self.mod.main.MPDService
 
         class Server(object):
-            service = MPDService(app)
+            service = MPDService(app, MPDServerPlugin())
 
             def _remove_connection(self, conn):
                 pass


### PR DESCRIPTION
MPD supports (plaintext) authentication using the "password" command. This is a minimal implementation that just supports a single all-powerful password.