### PR TITLE
use sort tags in paned browser; union tied tags in paned browser

### DIFF
--- a/quodlibet/quodlibet/browsers/paned/models.py
+++ b/quodlibet/quodlibet/browsers/paned/models.py
@@ -203,7 +203,6 @@ class PaneModel(ObjectStore):
     def add_songs(self, songs):
         """Add new songs to the list, creating new rows"""
 
-        print "\nAdding", len(songs), "entries to", len(self), "entries" # pfps
         collection = {}
         unknown = UnknownEntry()
         human_sort = self.__human_sort_key
@@ -230,13 +229,6 @@ class PaneModel(ObjectStore):
         items = sorted(collection.iteritems(),
                        key=lambda s: s[1][1],
                        reverse=True)
-
-        if len(self) < 100: # pfps
-            for iterr, entry in self.iterrows(): # pfps
-                print "Self Row", iterr, entry, entry.sort # pfps
-        if len(items) < 100: # pfps
-            for item in items: # pfps
-                print "New Item", item # pfps
 
         # fast path
         if not len(self):

--- a/quodlibet/quodlibet/browsers/paned/models.py
+++ b/quodlibet/quodlibet/browsers/paned/models.py
@@ -207,12 +207,14 @@ class PaneModel(ObjectStore):
             keys = self.get_format_keys(song)
             if not keys:
                 unknown.songs.add(song)
-            for key in keys:
+            for ks in keys:
+                sort = ks[1] if isinstance(ks, tuple) else ks
+                key = ks[0] if isinstance(ks, tuple) else ks
                 if key in collection:
                     collection[key][0].songs.add(song)
-                else:
+                else: # first key sets up sorting
                     entry = SongsEntry(key)
-                    collection[key] = (entry, human_sort(key))
+                    collection[key] = (entry, human_sort(sort))
                     entry.songs.add(song)
 
         items = sorted(collection.iteritems(),
@@ -304,8 +306,9 @@ class PaneModel(ObjectStore):
 
         for path in paths:
             entry = self.get_value(self.get_iter(path))
-            if entry.key in keys:
-                return True
+            for key in keys:
+                if entry.key == (key[0] if isinstance(key, tuple) else key):
+                    return True
 
         return False
 

--- a/quodlibet/quodlibet/browsers/paned/models.py
+++ b/quodlibet/quodlibet/browsers/paned/models.py
@@ -212,8 +212,9 @@ class PaneModel(ObjectStore):
                 unknown.songs.add(song)
             for ks in keys:
                 key = ks[0] if isinstance(ks, tuple) else ks
-                sort = ks[1] if isinstance(ks, tuple) else ks
-                srtp = isinstance(ks, tuple)
+                sort = ((ks[1] if ks[1] != "" else ks[0])
+                        if isinstance(ks, tuple) else ks)
+                srtp = isinstance(ks, tuple) and ks[1] != ""
                 if key in collection:
                     if srtp and not collection[key][2]: # first actual sort key
                         hsort = human_sort(sort)

--- a/quodlibet/quodlibet/formats/_audio.py
+++ b/quodlibet/quodlibet/formats/_audio.py
@@ -29,6 +29,7 @@ from quodlibet.compat import iteritems, string_types
 
 from ._image import ImageContainer
 
+from itertools import izip_longest
 
 MIGRATE = {"~#playcount", "~#laststarted", "~#lastplayed", "~#added",
            "~#skipcount", "~#rating", "~bookmark"}
@@ -532,25 +533,35 @@ class AudioFile(dict, ImageContainer):
             v = self.get(key)
             return [] if v is None else v.split("\n")
 
-    def list_separate(self, key, connector=" - "):
-        """Similar to list, but will return a list of all values
-        for tied tags instead of one comma separated string.
-
-        In case of tied tags the result will be unicode, otherwise
-        it returns the same as list()
+    def list_sort(self, key):
+        """Like list but return display,sort pairs when appropriate
+        and work on all tags
         """
+        display = decode_value(key,self.__call__(key))
+        display = display.split("\n") if display else []
+        sort = []
+        if key in TAG_TO_SORT:
+            sort = decode_value(TAG_TO_SORT[key],self.__call__(TAG_TO_SORT[key]))
+            # it would be better to use something that doesn't fall back
+            # to the key itself, but what?
+            sort = sort.split("\n") if sort else []
+        if len(display) > 0 and len(sort) > 0 and display != sort:
+            return [(d if d is not None and d != "" else s,
+                     s if s is not None and s != "" else d)
+                    for d, s in izip_longest(display, sort)]
+        else:
+            return display if len(display) > 0 else sort
 
-        if key[:1] == "~" and "~" in key[1:]:
-            vals = \
-                filter(None,
-                map(lambda x: isinstance(x, basestring) and x or str(x),
-                map(lambda x: (isinstance(x, float) and "%.2f" % x) or x,
-                (self(tag) for tag in util.tagsplit(key)))))
-            vals = (val.split("\n") for val in vals)
+    def list_separate(self, key):
+        """For tied tags return the list union of the display,sort values 
+           otherwise just do list_sort
+        """
+        if key[:1] == "~" and "~" in key[1:]: # tied tag
+            vals = [self.list_sort(tag) for tag in util.tagsplit(key)]
             r = [j for i in vals for j in i]
             return r
         else:
-            return self.list(key)
+            return self.list_sort(key)
 
     def list_unique(self, keys):
         """Returns a combined value of all values in keys; duplicate values

--- a/quodlibet/quodlibet/formats/_audio.py
+++ b/quodlibet/quodlibet/formats/_audio.py
@@ -546,9 +546,8 @@ class AudioFile(dict, ImageContainer):
             # to the key itself, but what?
             sort = sort.split("\n") if sort else []
         if len(display) > 0 and len(sort) > 0 and display != sort:
-            return [(d if d is not None and d != "" else s,
-                     s if s is not None and s != "" else d)
-                    for d, s in izip_longest(display, sort)]
+            return [((d if d != "" else s, s) if s != "" else d)
+                    for d, s in izip_longest(display, sort, fillvalue="")]
         else:
             return display if len(display) > 0 else sort
 

--- a/quodlibet/quodlibet/formats/_audio.py
+++ b/quodlibet/quodlibet/formats/_audio.py
@@ -533,7 +533,7 @@ class AudioFile(dict, ImageContainer):
             return [] if v is None else v.split("\n")
 
     def list_separate(self, key, connector=" - "):
-        """Similar to list, but will return a list of all combinations
+        """Similar to list, but will return a list of all values
         for tied tags instead of one comma separated string.
 
         In case of tied tags the result will be unicode, otherwise
@@ -541,15 +541,14 @@ class AudioFile(dict, ImageContainer):
         """
 
         if key[:1] == "~" and "~" in key[1:]:
-            vals = []
-            for v in map(self.__call__, util.tagsplit(key)):
-                v = decode_value(key, v)
-                if v:
-                    vals.append(v.split("\n"))
-            r = [[]]
-            for x in vals:
-                r = [i + [y] for y in x for i in r]
-            return map(connector.join, r)
+            vals = \
+                filter(None,
+                map(lambda x: isinstance(x, basestring) and x or str(x),
+                map(lambda x: (isinstance(x, float) and "%.2f" % x) or x,
+                (self(tag) for tag in util.tagsplit(key)))))
+            vals = (val.split("\n") for val in vals)
+            r = [j for i in vals for j in i]
+            return r
         else:
             return self.list(key)
 

--- a/quodlibet/quodlibet/formats/_audio.py
+++ b/quodlibet/quodlibet/formats/_audio.py
@@ -537,11 +537,12 @@ class AudioFile(dict, ImageContainer):
         """Like list but return display,sort pairs when appropriate
         and work on all tags
         """
-        display = decode_value(key,self.__call__(key))
+        display = decode_value(key, self.__call__(key))
         display = display.split("\n") if display else []
         sort = []
         if key in TAG_TO_SORT:
-            sort = decode_value(TAG_TO_SORT[key],self.__call__(TAG_TO_SORT[key]))
+            sort = decode_value(TAG_TO_SORT[key],
+                                self.__call__(TAG_TO_SORT[key]))
             # it would be better to use something that doesn't fall back
             # to the key itself, but what?
             sort = sort.split("\n") if sort else []
@@ -552,7 +553,7 @@ class AudioFile(dict, ImageContainer):
             return display if len(display) > 0 else sort
 
     def list_separate(self, key):
-        """For tied tags return the list union of the display,sort values 
+        """For tied tags return the list union of the display,sort values
            otherwise just do list_sort
         """
         if key[:1] == "~" and "~" in key[1:]: # tied tag

--- a/quodlibet/quodlibet/formats/_audio.py
+++ b/quodlibet/quodlibet/formats/_audio.py
@@ -29,7 +29,10 @@ from quodlibet.compat import iteritems, string_types
 
 from ._image import ImageContainer
 
-from itertools import izip_longest
+try:
+    from itertools import izip_longest
+except ImportError:  # python3.x
+    izip = zip
 
 MIGRATE = {"~#playcount", "~#laststarted", "~#lastplayed", "~#added",
            "~#skipcount", "~#rating", "~bookmark"}
@@ -546,11 +549,11 @@ class AudioFile(dict, ImageContainer):
             # it would be better to use something that doesn't fall back
             # to the key itself, but what?
             sort = sort.split("\n") if sort else []
-        if len(display) > 0 and len(sort) > 0 and display != sort:
-            return [((d if d != "" else s, s) if s != "" else d)
-                    for d, s in izip_longest(display, sort, fillvalue="")]
-        else:
-            return display if len(display) > 0 else sort
+        result = []
+        for d, s in izip_longest(display, sort):
+            if d is not None:
+                result.append((d, s if s is not None and s != "" else d))
+        return result
 
     def list_separate(self, key):
         """For tied tags return the list union of the display,sort values

--- a/quodlibet/quodlibet/formats/_audio.py
+++ b/quodlibet/quodlibet/formats/_audio.py
@@ -537,12 +537,12 @@ class AudioFile(dict, ImageContainer):
         """Like list but return display,sort pairs when appropriate
         and work on all tags
         """
-        display = decode_value(key, self.__call__(key))
+        display = decode_value(key, self(key))
         display = display.split("\n") if display else []
         sort = []
         if key in TAG_TO_SORT:
             sort = decode_value(TAG_TO_SORT[key],
-                                self.__call__(TAG_TO_SORT[key]))
+                                self(TAG_TO_SORT[key]))
             # it would be better to use something that doesn't fall back
             # to the key itself, but what?
             sort = sort.split("\n") if sort else []

--- a/quodlibet/quodlibet/pattern/_pattern.py
+++ b/quodlibet/quodlibet/pattern/_pattern.py
@@ -270,7 +270,8 @@ class PatternFormatter(object):
                            else r + val)
                          for r in vals]
         if self._post:
-            vals = (self._post(v, song) for v in vals)
+            vals = (self._post(v[0] if isinstance(v, tuple) else v, song)
+                    for v in vals)
         return set(vals)
 
     __mod__ = format

--- a/quodlibet/quodlibet/pattern/_pattern.py
+++ b/quodlibet/quodlibet/pattern/_pattern.py
@@ -242,36 +242,25 @@ class PatternFormatter(object):
         return value
 
     def format_list(self, song):
-        """Returns a set of formatted patterns with all tag combinations:
-        <performer>-bla returns [performer1-bla, performer2-bla]
-        if there are only display results,
-        otherwise a pair of display and sort results
+        """Formats the output of a list pattern, generating all the combinations
+        always returns pairs of display and sort values.
         The returned set will never be empty (e.g. for an empty pattern).
         """
-        vals = [u""]
+        vals = [(u"", u"")]
         for val in self.__list_func(self.SongProxy(song, self._format)):
             if not val:
                 continue
             if isinstance(val, tuple): # tuple of display,sort pair to add
-                vals = [((r[0] + val[0], r[1] + val[1]) if isinstance(r, tuple)
-                           else (r + val[0], r + val[1]))
-                         for r in vals]
+                vals = [(r[0] + val[0], r[1] + val[1]) for r in vals]
             elif isinstance(val, list): # list of strings or pairs
-                vals = [(((r[0] + part[0], r[1] + part[1])
-                             if isinstance(part, tuple)
-                             else (r[0] + part, r[1] + part))
-                           if isinstance(r, tuple)
-                           else ((r + part[0], r + part[1])
-                                  if isinstance(part, tuple)
-                                  else r + part))
-                         for part in val for r in vals]
+                vals = [((r[0] + part[0], r[1] + part[1])
+                         if isinstance(part, tuple)
+                         else (r[0] + part, r[1] + part))
+                        for part in val for r in vals]
             else: # just a display string to concatenate
-                vals = [((r[0] + val, r[1] + val) if isinstance(r, tuple)
-                           else r + val)
-                         for r in vals]
+                vals = [((r[0] + val, r[1] + val)) for r in vals]
         if self._post:
-            vals = (self._post(v[0] if isinstance(v, tuple) else v, song)
-                    for v in vals)
+            vals = ((self._post(v[0], song), v[1]) for v in vals)
         return set(vals)
 
     __mod__ = format

--- a/quodlibet/quodlibet/pattern/_pattern.py
+++ b/quodlibet/quodlibet/pattern/_pattern.py
@@ -260,7 +260,8 @@ class PatternFormatter(object):
             else: # just a display string to concatenate
                 vals = [((r[0] + val, r[1] + val)) for r in vals]
         if self._post:
-            vals = ((self._post(v[0], song), v[1]) for v in vals)
+            vals = ((self._post(v[0], song), self._post(v[1], song))
+                    for v in vals)
         return set(vals)
 
     __mod__ = format

--- a/quodlibet/quodlibet/qltk/filesel.py
+++ b/quodlibet/quodlibet/qltk/filesel.py
@@ -6,7 +6,7 @@
 # published by the Free Software Foundation
 
 import os
-import urlparse
+from quodlibet.compat import urlparse
 import errno
 
 from gi.repository import Gtk, GObject, Gdk, Gio, Pango

--- a/quodlibet/quodlibet/util/tags.py
+++ b/quodlibet/quodlibet/util/tags.py
@@ -74,7 +74,7 @@ _TAGS = dict((t.name, t) for t in [
     T("arranger", "u", _("arranger"), _("arrangers"), _("arrangement")),
     T("artist", "us", _("artist"), _("artists")),
     T("author", "u", _("author"), _("authors")),
-    T("composer", "u", _("composer"), _("composers"), _("composition")),
+    T("composer", "us", _("composer"), _("composers"), _("composition")),
     T("conductor", "u", _("conductor"), _("conductors"), _("conducting")),
     T("contact", "u", _("contact")),
     T("copyright", "u", _("copyright")),

--- a/quodlibet/quodlibet/util/tags.py
+++ b/quodlibet/quodlibet/util/tags.py
@@ -74,7 +74,7 @@ _TAGS = dict((t.name, t) for t in [
     T("arranger", "u", _("arranger"), _("arrangers"), _("arrangement")),
     T("artist", "us", _("artist"), _("artists")),
     T("author", "u", _("author"), _("authors")),
-    T("composer", "us", _("composer"), _("composers"), _("composition")),
+    T("composer", "u", _("composer"), _("composers"), _("composition")),
     T("conductor", "u", _("conductor"), _("conductors"), _("conducting")),
     T("contact", "u", _("contact")),
     T("copyright", "u", _("copyright")),

--- a/quodlibet/tests/test_browsers_paned.py
+++ b/quodlibet/tests/test_browsers_paned.py
@@ -180,7 +180,7 @@ class TPaneConfig(TestCase):
         self.failUnlessEqual(p.title, "Title / Artist")
         self.failUnlessEqual(p.tags, {"title", "artist"})
 
-        self.failUnlessEqual(p.format(SONGS[0]), ["three - boris"])
+        self.failUnlessEqual(p.format(SONGS[0]), ["three", "boris"])
         self.failIf(p.has_markup)
 
     def test_pattern(self):

--- a/quodlibet/tests/test_browsers_paned.py
+++ b/quodlibet/tests/test_browsers_paned.py
@@ -212,7 +212,7 @@ class TPaneConfig(TestCase):
 class TPaneEntry(TestCase):
 
     def test_all_have(self):
-        sel = SongsEntry("foo", SONGS)
+        sel = SongsEntry("foo", "foo", SONGS)
         self.assertFalse(sel.all_have("artist", "one"))
         self.assertFalse(sel.all_have("~#mtime", 4))
         self.assertTrue(sel.all_have("foo", "bar"))
@@ -237,7 +237,7 @@ class TPaneEntry(TestCase):
         repr(entry)
 
     def test_songs(self):
-        entry = SongsEntry("key", SONGS)
+        entry = SongsEntry("key", "key", SONGS)
         self.assertEqual(entry.key, "key")
         conf = PaneConfig("title:artist")
         self.assertTrue("boris" in entry.get_count_text(conf))
@@ -246,7 +246,7 @@ class TPaneEntry(TestCase):
         repr(entry)
 
     def test_songs_markup(self):
-        entry = SongsEntry("key", SONGS)
+        entry = SongsEntry("key", "key", SONGS)
         conf = PaneConfig("<title>")
         self.assertEqual(entry.get_text(conf), (True, "key"))
 

--- a/quodlibet/tests/test_browsers_paned.py
+++ b/quodlibet/tests/test_browsers_paned.py
@@ -163,7 +163,7 @@ class TPaneConfig(TestCase):
         self.failUnlessEqual(p.title, "Title")
         self.failUnlessEqual(p.tags, {"title"})
 
-        self.failUnlessEqual(p.format(SONGS[0]), ["three"])
+        self.failUnlessEqual(p.format(SONGS[0]), [("three", "three")])
         self.failUnless(str(len(ALBUM.songs)) in p.format_display(ALBUM))
         self.failIf(p.has_markup)
 
@@ -180,7 +180,8 @@ class TPaneConfig(TestCase):
         self.failUnlessEqual(p.title, "Title / Artist")
         self.failUnlessEqual(p.tags, {"title", "artist"})
 
-        self.failUnlessEqual(p.format(SONGS[0]), ["three", "boris"])
+        self.failUnlessEqual(p.format(SONGS[0]),
+                             [("three", "three"), ("boris", "boris")])
         self.failIf(p.has_markup)
 
     def test_pattern(self):

--- a/quodlibet/tests/test_formats__audio.py
+++ b/quodlibet/tests/test_formats__audio.py
@@ -164,15 +164,15 @@ class TAudioFile(TestCase):
             self.failUnlessEqual(bar_1_1.list_separate(key), [bar_1_1(key)])
 
         self.failUnlessEqual(bar_2_1.list_separate("~artist~album"),
-                             ['Foo - Bar', 'I have two artists - Bar'])
+                             ['Foo', 'I have two artists', 'Bar'])
 
         self.failUnlessEqual(bar_2_1.list_separate("~artist~~#track"),
-                             ['Foo - 1', 'I have two artists - 1'])
+                             ['Foo', 'I have two artists', '1'])
 
     def test_list_list_separate_types(self):
         res = bar_2_1.list_separate("~~#track~artist~~filename")
-        self.assertEqual(res, [u'1 - Foo - does not/exist',
-                               u'1 - I have two artists - does not/exist'])
+        self.assertEqual(res, [u'1', u'Foo', 
+                               u'I have two artists', u'does not/exist'])
 
     def test_comma(self):
         for key in bar_1_1.realkeys():

--- a/quodlibet/tests/test_formats__audio.py
+++ b/quodlibet/tests/test_formats__audio.py
@@ -19,6 +19,7 @@ bar_1_1 = AudioFile({
 bar_1_2 = AudioFile({
     "~filename": fsnative(u"/fakepath/2"),
     "title": "Perhaps another",
+    "titlesort": "Titles don't sort",
     "discnumber": "1", "tracknumber": "2/3",
     "artist": "Lali-ho!", "album": "Bar",
     "date": "2004-12-12", "originaldate": "2005-01-01",
@@ -27,7 +28,9 @@ bar_2_1 = AudioFile({
     "~filename": fsnative(u"does not/exist"),
     "title": "more songs",
     "discnumber": "2/2", "tracknumber": "1",
-    "artist": "Foo\nI have two artists", "album": "Bar",
+    "artist": "Foo\nI have two artists", 
+    "artistsort": "Foosort\n\nThird artist",
+    "album": "Bar",
     "lyricist": "Foo", "composer": "Foo", "performer": "I have two artists"})
 bar_va = AudioFile({
     "~filename": "/fakepath/3",
@@ -159,20 +162,40 @@ class TAudioFile(TestCase):
         self.failUnlessEqual(bar_2_1.list("artist"),
                              bar_2_1["artist"].split("\n"))
 
+    def test_list_sort(self):
+        for key in bar_1_1.realkeys():
+            self.failUnlessEqual(bar_1_1.list_sort(key), [bar_1_1(key)])
+
+        self.failUnlessEqual(quux.list_sort("artist"), [])
+        self.failUnlessEqual(quux.list_sort("title"), [quux("title")])
+        self.failUnlessEqual(quux.list_sort("not a key"), [])
+
+        self.failUnlessEqual(bar_1_2.list_sort("title"), ["Perhaps another"])
+        self.failUnlessEqual(bar_2_1.list_sort("artist"),
+                             [("Foo","Foosort"),
+                              "I have two artists", 
+                              ("Third artist", "Third artist")])
+        self.failUnlessEqual(bar_2_1.list_sort("~#track"),
+                             ['1'])
+
     def test_list_separate(self):
         for key in bar_1_1.realkeys():
             self.failUnlessEqual(bar_1_1.list_separate(key), [bar_1_1(key)])
 
         self.failUnlessEqual(bar_2_1.list_separate("~artist~album"),
-                             ['Foo', 'I have two artists', 'Bar'])
+                             [('Foo','Foosort'), 'I have two artists',
+                              (u'Third artist', u'Third artist'), 'Bar'])
 
         self.failUnlessEqual(bar_2_1.list_separate("~artist~~#track"),
-                             ['Foo', 'I have two artists', '1'])
+                             [('Foo','Foosort'), 'I have two artists',
+                              (u'Third artist', u'Third artist'), '1'])
 
     def test_list_list_separate_types(self):
         res = bar_2_1.list_separate("~~#track~artist~~filename")
-        self.assertEqual(res, [u'1', u'Foo',
-                               u'I have two artists', u'does not/exist'])
+        self.assertEqual(res, [u'1', (u'Foo',u'Foosort'),
+                               u'I have two artists', 
+                               (u'Third artist', u'Third artist'),
+                               u'does not/exist'])
 
     def test_comma(self):
         for key in bar_1_1.realkeys():

--- a/quodlibet/tests/test_formats__audio.py
+++ b/quodlibet/tests/test_formats__audio.py
@@ -171,7 +171,7 @@ class TAudioFile(TestCase):
 
     def test_list_list_separate_types(self):
         res = bar_2_1.list_separate("~~#track~artist~~filename")
-        self.assertEqual(res, [u'1', u'Foo', 
+        self.assertEqual(res, [u'1', u'Foo',
                                u'I have two artists', u'does not/exist'])
 
     def test_comma(self):

--- a/quodlibet/tests/test_formats__audio.py
+++ b/quodlibet/tests/test_formats__audio.py
@@ -28,7 +28,7 @@ bar_2_1 = AudioFile({
     "~filename": fsnative(u"does not/exist"),
     "title": "more songs",
     "discnumber": "2/2", "tracknumber": "1",
-    "artist": "Foo\nI have two artists", 
+    "artist": "Foo\nI have two artists",
     "artistsort": "Foosort\n\nThird artist",
     "album": "Bar",
     "lyricist": "Foo", "composer": "Foo", "performer": "I have two artists"})
@@ -172,8 +172,8 @@ class TAudioFile(TestCase):
 
         self.failUnlessEqual(bar_1_2.list_sort("title"), ["Perhaps another"])
         self.failUnlessEqual(bar_2_1.list_sort("artist"),
-                             [("Foo","Foosort"),
-                              "I have two artists", 
+                             [("Foo", "Foosort"),
+                              "I have two artists",
                               ("Third artist", "Third artist")])
         self.failUnlessEqual(bar_2_1.list_sort("~#track"),
                              ['1'])
@@ -183,17 +183,17 @@ class TAudioFile(TestCase):
             self.failUnlessEqual(bar_1_1.list_separate(key), [bar_1_1(key)])
 
         self.failUnlessEqual(bar_2_1.list_separate("~artist~album"),
-                             [('Foo','Foosort'), 'I have two artists',
+                             [('Foo', 'Foosort'), 'I have two artists',
                               (u'Third artist', u'Third artist'), 'Bar'])
 
         self.failUnlessEqual(bar_2_1.list_separate("~artist~~#track"),
-                             [('Foo','Foosort'), 'I have two artists',
+                             [('Foo', 'Foosort'), 'I have two artists',
                               (u'Third artist', u'Third artist'), '1'])
 
     def test_list_list_separate_types(self):
         res = bar_2_1.list_separate("~~#track~artist~~filename")
-        self.assertEqual(res, [u'1', (u'Foo',u'Foosort'),
-                               u'I have two artists', 
+        self.assertEqual(res, [u'1', (u'Foo', u'Foosort'),
+                               u'I have two artists',
                                (u'Third artist', u'Third artist'),
                                u'does not/exist'])
 

--- a/quodlibet/tests/test_formats__audio.py
+++ b/quodlibet/tests/test_formats__audio.py
@@ -163,39 +163,45 @@ class TAudioFile(TestCase):
                              bar_2_1["artist"].split("\n"))
 
     def test_list_sort(self):
-        for key in bar_1_1.realkeys():
-            self.failUnlessEqual(bar_1_1.list_sort(key), [bar_1_1(key)])
+        self.failUnlessEqual(bar_1_1.list_sort("title"),
+                             [("A song", "A song")])
+        self.failUnlessEqual(bar_1_1.list_sort("artist"),
+                             [("Foo", "Foo")])
 
         self.failUnlessEqual(quux.list_sort("artist"), [])
-        self.failUnlessEqual(quux.list_sort("title"), [quux("title")])
+        self.failUnlessEqual(quux.list_sort("title"),
+                             [(quux("title"), quux("title"))])
         self.failUnlessEqual(quux.list_sort("not a key"), [])
 
-        self.failUnlessEqual(bar_1_2.list_sort("title"), ["Perhaps another"])
+        self.failUnlessEqual(bar_1_2.list_sort("title"),
+                             [("Perhaps another", "Perhaps another")])
         self.failUnlessEqual(bar_2_1.list_sort("artist"),
                              [("Foo", "Foosort"),
-                              "I have two artists",
-                              ("Third artist", "Third artist")])
+                              ("I have two artists", "I have two artists")])
         self.failUnlessEqual(bar_2_1.list_sort("~#track"),
-                             ['1'])
+                             [('1', '1')])
 
     def test_list_separate(self):
-        for key in bar_1_1.realkeys():
-            self.failUnlessEqual(bar_1_1.list_separate(key), [bar_1_1(key)])
+        self.failUnlessEqual(bar_1_1.list_separate("title"),
+                             [("A song", "A song")])
+        self.failUnlessEqual(bar_1_1.list_separate("artist"),
+                             [("Foo", "Foo")])
 
         self.failUnlessEqual(bar_2_1.list_separate("~artist~album"),
-                             [('Foo', 'Foosort'), 'I have two artists',
-                              (u'Third artist', u'Third artist'), 'Bar'])
+                             [('Foo', 'Foosort'),
+                              ('I have two artists', 'I have two artists'),
+                              ('Bar', 'Bar')])
 
         self.failUnlessEqual(bar_2_1.list_separate("~artist~~#track"),
-                             [('Foo', 'Foosort'), 'I have two artists',
-                              (u'Third artist', u'Third artist'), '1'])
+                             [('Foo', 'Foosort'),
+                              ('I have two artists', 'I have two artists'),
+                              ('1', '1')])
 
     def test_list_list_separate_types(self):
         res = bar_2_1.list_separate("~~#track~artist~~filename")
-        self.assertEqual(res, [u'1', (u'Foo', u'Foosort'),
-                               u'I have two artists',
-                               (u'Third artist', u'Third artist'),
-                               u'does not/exist'])
+        self.assertEqual(res, [(u'1', u'1'), (u'Foo', u'Foosort'),
+                               (u'I have two artists', u'I have two artists'),
+                               (u'does not/exist', u'does not/exist')])
 
     def test_comma(self):
         for key in bar_1_1.realkeys():

--- a/quodlibet/tests/test_pattern.py
+++ b/quodlibet/tests/test_pattern.py
@@ -418,10 +418,10 @@ class TPatternFormatList(_TPattern):
                           {'aa', 'ab', 'ba', 'bb'})
         pat = Pattern('<~performer~artist>')
         s.failUnlessEqual(pat.format_list(s.d),
-                          {'a - foo', 'b - foo', 'a - bar', 'b - bar'})
+                          {'a', 'b', 'bar', 'foo'})
         pat = Pattern('<performer~artist>')
         s.failUnlessEqual(pat.format_list(s.d),
-                          {'a - foo', 'b - foo', 'a - bar', 'b - bar'})
+                          {'a', 'b', 'bar', 'foo'})
         pat = Pattern('<artist|<artist>.|<performer>>')
         s.failUnlessEqual(pat.format_list(s.d), {'foo.', 'bar.'})
         pat = Pattern('<artist|<artist|<artist>.|<performer>>>')

--- a/quodlibet/tests/test_pattern.py
+++ b/quodlibet/tests/test_pattern.py
@@ -443,27 +443,33 @@ class TPatternFormatList(_TPattern):
 
     def test_sort(s):
         pat = Pattern('<album>')
+        s.failUnlessEqual(pat.format_list(s.f), {u'Best Of'})
+        pat = Pattern('<album>')
         s.failUnlessEqual(pat.format_list(s.h), {(u'Album5', u'SortAlbum5')})
         pat = Pattern('<artist>')
         s.failUnlessEqual(pat.format_list(s.h), {(u'Artist1', u'SortA1'),
                                                  (u'SortA2', u'SortA2'),
-                                                 (u'Artist3', u'Artist3')})
+                                                 u'Artist3'})
+        pat = Pattern('<artist> x')
+        s.failUnlessEqual(pat.format_list(s.h), {(u'Artist1 x', u'SortA1 x'),
+                                                 (u'SortA2 x', u'SortA2 x'),
+                                                 u'Artist3 x'})
 
     def test_sort_tied(s):
         pat = Pattern('<~artist~album>')
         s.failUnlessEqual(pat.format_list(s.h), {(u'Artist1', u'SortA1'),
                                                  (u'SortA2', u'SortA2'),
-                                                 (u'Artist3', u'Artist3'),
+                                                 u'Artist3',
                                                  (u'Album5', u'SortAlbum5')})
         pat = Pattern('<~album~artist>')
         s.failUnlessEqual(pat.format_list(s.h), {(u'Artist1', u'SortA1'),
                                                  (u'SortA2', u'SortA2'),
-                                                 (u'Artist3', u'Artist3'),
+                                                 u'Artist3', 
                                                  (u'Album5', u'SortAlbum5')})
         pat = Pattern('<~artist~artist>')
         s.failUnlessEqual(pat.format_list(s.h), {(u'Artist1', u'SortA1'),
                                                  (u'SortA2', u'SortA2'),
-                                                 (u'Artist3', u'Artist3')})
+                                                 u'Artist3'})
 
     def test_sort_combine(s):
         pat = Pattern('<album> <artist>')
@@ -503,7 +509,7 @@ class TPatternFormatList(_TPattern):
                            (u'Artist3 SortA2', u'Artist3 SortA2'),
                            (u'Artist1 Artist3', u'SortA1 Artist3'),
                            (u'SortA2 Artist3', u'SortA2 Artist3'),
-                           (u'Artist3 Artist3', u'Artist3 Artist3')})
+                           u'Artist3 Artist3'})
 
     def test_missing_value(self):
         pat = Pattern('<genre> - <artist>')

--- a/quodlibet/tests/test_pattern.py
+++ b/quodlibet/tests/test_pattern.py
@@ -412,108 +412,118 @@ class TRealTags(TestCase):
 class TPatternFormatList(_TPattern):
     def test_same(s):
         pat = Pattern('<~basename> <title>')
-        s.failUnlessEqual(pat.format_list(s.a), {pat.format(s.a)})
+        s.failUnlessEqual(pat.format_list(s.a),
+                          {(pat.format(s.a), pat.format(s.a))})
         pat = Pattern('/a<genre|/<genre>>/<title>')
-        s.failUnlessEqual(pat.format_list(s.a), {pat.format(s.a)})
+        s.failUnlessEqual(pat.format_list(s.a),
+                          {(pat.format(s.a), pat.format(s.a))})
 
     def test_same2(s):
         fpat = FileFromPattern('<~filename>')
         pat = Pattern('<~filename>')
         s.assertEquals(fpat.format_list(s.a), {fpat.format(s.a)})
-        s.assertEquals(pat.format_list(s.a), {pat.format(s.a)})
+        s.assertEquals(pat.format_list(s.a),
+                       {(pat.format(s.a), pat.format(s.a))})
 
     def test_tied(s):
         pat = Pattern('<genre>')
-        s.failUnlessEqual(pat.format_list(s.c), {'/', '/'})
+        s.failUnlessEqual(pat.format_list(s.c), {('/', '/')})
         pat = Pattern('<performer>')
-        s.failUnlessEqual(pat.format_list(s.d), {'a', 'b'})
+        s.failUnlessEqual(pat.format_list(s.d), {('a', 'a'), ('b', 'b')})
         pat = Pattern('<performer><performer>')
         s.failUnlessEqual(set(pat.format_list(s.d)),
-                          {'aa', 'ab', 'ba', 'bb'})
+                          {('aa', 'aa'), ('ab', 'ab'),
+                           ('ba', 'ba'), ('bb', 'bb')})
         pat = Pattern('<~performer~artist>')
         s.failUnlessEqual(pat.format_list(s.d),
-                          {'a', 'b', 'bar', 'foo'})
+                          {('a', 'a'), ('b', 'b'),
+                           ('bar', 'bar'), ('foo', 'foo')})
         pat = Pattern('<performer~artist>')
         s.failUnlessEqual(pat.format_list(s.d),
-                          {'a', 'b', 'bar', 'foo'})
+                          {('a', 'a'), ('b', 'b'),
+                           ('bar', 'bar'), ('foo', 'foo')})
         pat = Pattern('<artist|<artist>.|<performer>>')
-        s.failUnlessEqual(pat.format_list(s.d), {'foo.', 'bar.'})
+        s.failUnlessEqual(pat.format_list(s.d),
+                          {('foo.', 'foo.'), ('bar.', 'bar.')})
         pat = Pattern('<artist|<artist|<artist>.|<performer>>>')
-        s.failUnlessEqual(pat.format_list(s.d), {'foo.', 'bar.'})
+        s.failUnlessEqual(pat.format_list(s.d),
+                          {('foo.', 'foo.'), ('bar.', 'bar.')})
 
     def test_sort(s):
         pat = Pattern('<album>')
-        s.failUnlessEqual(pat.format_list(s.f), {u'Best Of'})
+        s.failUnlessEqual(pat.format_list(s.f),
+                          {(u'Best Of', u'Best Of')})
         pat = Pattern('<album>')
         s.failUnlessEqual(pat.format_list(s.h), {(u'Album5', u'SortAlbum5')})
         pat = Pattern('<artist>')
         s.failUnlessEqual(pat.format_list(s.h), {(u'Artist1', u'SortA1'),
-                                                 (u'SortA2', u'SortA2'),
-                                                 u'Artist3'})
+                                                 (u'', u'SortA2'),
+                                                 (u'Artist3', u'Artist3')})
         pat = Pattern('<artist> x')
         s.failUnlessEqual(pat.format_list(s.h), {(u'Artist1 x', u'SortA1 x'),
-                                                 (u'SortA2 x', u'SortA2 x'),
-                                                 u'Artist3 x'})
+                                                 (u' x', u'SortA2 x'),
+                                                 (u'Artist3 x', u'Artist3 x')})
 
     def test_sort_tied(s):
         pat = Pattern('<~artist~album>')
         s.failUnlessEqual(pat.format_list(s.h), {(u'Artist1', u'SortA1'),
-                                                 (u'SortA2', u'SortA2'),
-                                                 u'Artist3',
+                                                 (u'', u'SortA2'),
+                                                 (u'Artist3', u'Artist3'),
                                                  (u'Album5', u'SortAlbum5')})
         pat = Pattern('<~album~artist>')
         s.failUnlessEqual(pat.format_list(s.h), {(u'Artist1', u'SortA1'),
-                                                 (u'SortA2', u'SortA2'),
-                                                 u'Artist3',
+                                                 (u'', u'SortA2'),
+                                                 (u'Artist3', u'Artist3'),
                                                  (u'Album5', u'SortAlbum5')})
         pat = Pattern('<~artist~artist>')
         s.failUnlessEqual(pat.format_list(s.h), {(u'Artist1', u'SortA1'),
-                                                 (u'SortA2', u'SortA2'),
-                                                 u'Artist3'})
+                                                 (u'', u'SortA2'),
+                                                 (u'Artist3', u'Artist3')})
 
     def test_sort_combine(s):
         pat = Pattern('<album> <artist>')
         s.failUnlessEqual(pat.format_list(s.h),
                           {(u'Album5 Artist1', u'SortAlbum5 SortA1'),
-                           (u'Album5 SortA2', u'SortAlbum5 SortA2'),
+                           (u'Album5 ', u'SortAlbum5 SortA2'),
                            (u'Album5 Artist3', u'SortAlbum5 Artist3')})
         pat = Pattern('x <artist> <album>')
         s.failUnlessEqual(pat.format_list(s.h),
                           {(u'x Artist1 Album5', u'x SortA1 SortAlbum5'),
-                           (u'x SortA2 Album5', u'x SortA2 SortAlbum5'),
+                           (u'x  Album5', u'x SortA2 SortAlbum5'),
                            (u'x Artist3 Album5', u'x Artist3 SortAlbum5')})
         pat = Pattern(' <artist> <album> xx')
         s.failUnlessEqual(pat.format_list(s.h),
                           {(u' Artist1 Album5 xx', u' SortA1 SortAlbum5 xx'),
-                           (u' SortA2 Album5 xx', u' SortA2 SortAlbum5 xx'),
+                           (u'  Album5 xx', u' SortA2 SortAlbum5 xx'),
                            (u' Artist3 Album5 xx', u' Artist3 SortAlbum5 xx')})
         pat = Pattern('<album> <tracknumber> <artist>')
         s.failUnlessEqual(pat.format_list(s.h),
                           {(u'Album5 7/8 Artist1', u'SortAlbum5 7/8 SortA1'),
-                           (u'Album5 7/8 SortA2', u'SortAlbum5 7/8 SortA2'),
+                           (u'Album5 7/8 ', u'SortAlbum5 7/8 SortA2'),
                            (u'Album5 7/8 Artist3', u'SortAlbum5 7/8 Artist3')})
         pat = Pattern('<tracknumber> <album> <artist>')
         s.failUnlessEqual(pat.format_list(s.h),
                           {(u'7/8 Album5 Artist1', u'7/8 SortAlbum5 SortA1'),
-                           (u'7/8 Album5 SortA2', u'7/8 SortAlbum5 SortA2'),
+                           (u'7/8 Album5 ', u'7/8 SortAlbum5 SortA2'),
                            (u'7/8 Album5 Artist3', u'7/8 SortAlbum5 Artist3')})
 
     def test_sort_multiply(s):
         pat = Pattern('<artist> <artist>')
         s.failUnlessEqual(pat.format_list(s.h),
                           {(u'Artist1 Artist1', u'SortA1 SortA1'),
-                           (u'SortA2 Artist1', u'SortA2 SortA1'),
+                           (u' Artist1', u'SortA2 SortA1'),
                            (u'Artist3 Artist1', u'Artist3 SortA1'),
-                           (u'Artist1 SortA2', u'SortA1 SortA2'),
-                           (u'SortA2 SortA2', u'SortA2 SortA2'),
-                           (u'Artist3 SortA2', u'Artist3 SortA2'),
+                           (u'Artist1 ', u'SortA1 SortA2'),
+                           (u' ', u'SortA2 SortA2'),
+                           (u'Artist3 ', u'Artist3 SortA2'),
                            (u'Artist1 Artist3', u'SortA1 Artist3'),
-                           (u'SortA2 Artist3', u'SortA2 Artist3'),
-                           u'Artist3 Artist3'})
+                           (u' Artist3', u'SortA2 Artist3'),
+                           (u'Artist3 Artist3', u'Artist3 Artist3')})
 
     def test_missing_value(self):
         pat = Pattern('<genre> - <artist>')
-        self.assertEqual(pat.format_list(self.a), {" - Artist"})
+        self.assertEqual(pat.format_list(self.a),
+                         {(" - Artist", " - Artist")})
 
         pat = Pattern('')
         self.assertEqual(pat.format_list(self.a), {""})

--- a/quodlibet/tests/test_pattern.py
+++ b/quodlibet/tests/test_pattern.py
@@ -464,7 +464,7 @@ class TPatternFormatList(_TPattern):
         pat = Pattern('<~album~artist>')
         s.failUnlessEqual(pat.format_list(s.h), {(u'Artist1', u'SortA1'),
                                                  (u'SortA2', u'SortA2'),
-                                                 u'Artist3', 
+                                                 u'Artist3',
                                                  (u'Album5', u'SortAlbum5')})
         pat = Pattern('<~artist~artist>')
         s.failUnlessEqual(pat.format_list(s.h), {(u'Artist1', u'SortA1'),

--- a/quodlibet/tests/test_pattern.py
+++ b/quodlibet/tests/test_pattern.py
@@ -421,7 +421,8 @@ class TPatternFormatList(_TPattern):
     def test_same2(s):
         fpat = FileFromPattern('<~filename>')
         pat = Pattern('<~filename>')
-        s.assertEquals(fpat.format_list(s.a), {fpat.format(s.a)})
+        s.assertEquals(fpat.format_list(s.a),
+                       {(fpat.format(s.a), fpat.format(s.a))})
         s.assertEquals(pat.format_list(s.a),
                        {(pat.format(s.a), pat.format(s.a))})
 
@@ -524,6 +525,9 @@ class TPatternFormatList(_TPattern):
         pat = Pattern('<genre> - <artist>')
         self.assertEqual(pat.format_list(self.a),
                          {(" - Artist", " - Artist")})
-
         pat = Pattern('')
-        self.assertEqual(pat.format_list(self.a), {""})
+        self.assertEqual(pat.format_list(self.a), {("", "")})
+
+    def test_string(s):
+        pat = Pattern('display')
+        s.assertEqual(pat.format_list(s.a), {("display", "display")})


### PR DESCRIPTION
Code changes:

1/ list_separate and list_sort (new) in quodlibet/formats/_audio.py
   Only uses are in the paned browser

a) Union all results for tied tags instead of concatenating them in list_separate.  (This is
   a change, but it only affects the paned browser.)

b) Return display,sort pairs when a tag has an associated sort key with 
   different values.

2/ list_separate and format_list in quodlibet/pattern/_pattern.py
   Only uses are in the paned browser

Handle display,sort pairs appropriately.

3/ paned browser

Use sort value for sorting if present.


User-visible changes:

1/ Paned browser uses sort tags when present.
2/ Paned browser unions results for tied tags.

Caveats:

1/ If a tag value has different sort values (including no sort value) in
   different songs then in panes using the tag songs with this tag value will
   sort to one of the sort values at random and may have more than one entry. 
2/ If multiple tag values have the same sort value then in panes using the
   tag sorting of these tag values will be non-deterministic and there may
   be multiple entries for some of the tag values.  (This problem already
   existed.)  
3/ Some changes to documentation are indicated.


