### PR TITLE
Improve lyrics-in-tags support (globally and for ID3 tags in particular)

### DIFF
--- a/quodlibet/quodlibet/ext/events/viewlyrics.py
+++ b/quodlibet/quodlibet/ext/events/viewlyrics.py
@@ -16,8 +16,6 @@
 # You can get a copy of the GNU General Public License at:
 # http://www.gnu.org/licenses/gpl-2.0.html
 
-import os
-
 from gi.repository import Gtk, Gdk
 
 from quodlibet import app
@@ -71,12 +69,14 @@ class ViewLyrics(EventPlugin):
         If there are lyrics associated with `song`, load them into the
         lyrics viewer. Otherwise, hides the lyrics viewer.
         """
-        if (song is not None) and os.path.exists(song.lyric_filename):
-            with open(song.lyric_filename, 'r') as lyric_file:
-                self.textbuffer.set_text(lyric_file.read())
-            self.adjustment.set_value(0)    # Scroll to the top.
-            self.expander.show()
-        else:
+        if song is not None:
+            lyrics = song("~lyrics")
+            if lyrics:
+                self.textbuffer.set_text(lyrics)
+                self.adjustment.set_value(0)    # Scroll to the top.
+                self.expander.show()
+
+        if not lyrics:
             self.expander.hide()
 
     def key_press_event_cb(self, widget, event):

--- a/quodlibet/quodlibet/formats/_audio.py
+++ b/quodlibet/quodlibet/formats/_audio.py
@@ -370,6 +370,14 @@ class AudioFile(dict, ImageContainer):
                 except (ValueError, IndexError, TypeError, KeyError):
                     return default
             elif key == "lyrics":
+                # First, try the embedded lyrics.
+                try:
+                    return self[key]
+                except KeyError:
+                    pass
+
+                # If there are no embedded lyrics, try to read them from
+                # the external file.
                 try:
                     fileobj = open(self.lyric_filename, "rU")
                 except EnvironmentError:

--- a/quodlibet/quodlibet/qltk/lyrics.py
+++ b/quodlibet/quodlibet/qltk/lyrics.py
@@ -38,12 +38,11 @@ class LyricsPane(Gtk.VBox):
         view.set_wrap_mode(Gtk.WrapMode.WORD)
         sw.set_policy(Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.AUTOMATIC)
 
-        lyricname = song.lyric_filename
         buffer = view.get_buffer()
 
         refresh.connect('clicked', self.__refresh, add, buffer, song)
-        save.connect('clicked', self.__save, lyricname, buffer, delete)
-        delete.connect('clicked', self.__delete, lyricname, save)
+        save.connect('clicked', self.__save, song, buffer, delete)
+        delete.connect('clicked', self.__delete, song, save)
         add.connect('clicked', self.__add, song)
 
         sw.set_shadow_type(Gtk.ShadowType.IN)
@@ -59,9 +58,10 @@ class LyricsPane(Gtk.VBox):
         save.set_sensitive(False)
         add.set_sensitive(True)
 
-        if os.path.exists(lyricname):
-            with open(lyricname) as h:
-                buffer.set_text(h.read())
+        lyrics = song("~lyrics")
+
+        if lyrics:
+            buffer.set_text(lyrics)
         else:
             #buffer.set_text(_("No lyrics found.\n\nYou can click the "
             #                  "Download button to have Quod Libet search "
@@ -113,23 +113,45 @@ class LyricsPane(Gtk.VBox):
             GLib.idle_add(buffer.set_text, text)
             GLib.idle_add(refresh.set_sensitive, True)
 
-    def __save(self, save, lyricname, buffer, delete):
+    def __save(self, save, song, buffer, delete):
+        start, end = buffer.get_bounds()
+        text = buffer.get_text(start, end, True)
+
+        # First, write back to the tags.
+        song["lyrics"] = text.decode("utf-8")
+        try:
+            song.write()
+        except NotImplementedError:
+            pass
+
+        # Then, write to file.
+        # TODO: write to file only if could not write to tags, otherwise delete
+        # the file.
+        lyricname = song.lyric_filename
         try:
             os.makedirs(os.path.dirname(lyricname))
         except EnvironmentError as err:
             pass
 
-        start, end = buffer.get_bounds()
         try:
             with open(lyricname, "w") as f:
-                f.write(buffer.get_text(start, end, True))
+                f.write(text)
         except EnvironmentError as err:
             encoding = util.get_locale_encoding()
             print_w(err.strerror.decode(encoding, "replace"))
         delete.set_sensitive(True)
         save.set_sensitive(False)
 
-    def __delete(self, delete, lyricname, save):
+    def __delete(self, delete, song, save):
+        # First, delete from the tags.
+        song.remove("lyrics")
+        try:
+            song.write()
+        except NotImplementedError:
+            pass
+
+        # Then, delete the file.
+        lyricname = song.lyric_filename
         try:
             os.unlink(lyricname)
         except EnvironmentError:


### PR DESCRIPTION
* add support for filling `lyrics` tag from `USLT` frame of ID3v2 tags
(only empty desc and empty lang — others are ignored but not deleted)
* synthesize tag `~lyrics` by looking both at the tags and the external file (in this order)
* in the lyrics pane and the lyrics editor, use tag `~lyrics` for reading
* in the lyrics editor, write both to the `lyrics` tag and to the file

This should fix #919.