### PR TITLE
Display systray issue on plasma

### DIFF
--- a/quodlibet/quodlibet/util/environment.py
+++ b/quodlibet/quodlibet/util/environment.py
@@ -34,7 +34,7 @@ def xdg_get_current_desktop():
 def is_plasma():
     """If we are running under KDE/plasma"""
 
-    return "plasma" in xdg_get_session_desktop()
+    return "KDE" in xdg_get_session_desktop()
 
 
 def is_unity():


### PR DESCRIPTION
XDG_CURRENT_DESKTOP is set with "KDE". 

I asked #plasma on IRC and it's the expected value.

fix #1756 