### PR TITLE
Fix #1726: Enable accels for ViewSearchBar etc.

### DIFF
--- a/quodlibet/quodlibet/qltk/quodlibetwindow.py
+++ b/quodlibet/quodlibet/qltk/quodlibetwindow.py
@@ -1110,7 +1110,7 @@ class QuodLibetWindow(Window, PersistentWindowMixin):
             first_action = first_action or act
             if name == current:
                 act.set_active(True)
-            ag.add_action(act)
+            ag.add_action_with_accel(act, None)
         assert first_action
         self._browser_action = first_action
 


### PR DESCRIPTION
This fixes the bug, described in issue #1726, that lines like:
`(gtk_accel_path "<Actions>/QuodLibetWindowActions/ViewSearchBar" "<Primary>s")`
in a user's accel file would not be recognized.