### PR TITLE
Fixes #1461: Store ratings in the tags, even if they're the default value.

### DIFF
--- a/quodlibet/quodlibet/formats/_id3.py
+++ b/quodlibet/quodlibet/formats/_id3.py
@@ -10,7 +10,6 @@ import mutagen.id3
 
 from quodlibet import config, const, print_d
 from quodlibet import util
-from quodlibet.config import RATINGS
 from quodlibet.compat import iteritems
 from quodlibet.util.iso639 import ISO_639_2
 from quodlibet.util.path import get_temp_cover_file

--- a/quodlibet/quodlibet/formats/_id3.py
+++ b/quodlibet/quodlibet/formats/_id3.py
@@ -423,8 +423,7 @@ class ID3File(AudioFile):
                 tag.add(f)
 
         if (config.getboolean("editing", "save_to_songs") and
-                (self("~#rating") != RATINGS.default or
-                 self.get("~#playcount", 0) != 0)):
+                (self.has_rating or self.get("~#playcount", 0) != 0)):
             email = config.get("editing", "save_email").strip()
             email = email or const.EMAIL
             t = mutagen.id3.POPM(email=email,

--- a/quodlibet/quodlibet/formats/xiph.py
+++ b/quodlibet/quodlibet/formats/xiph.py
@@ -255,9 +255,8 @@ class MutagenVCFile(AudioFile):
 
         if config.getboolean("editing", "save_to_songs"):
             email = email or const.EMAIL
-            rating = self("~#rating")
-            if rating != RATINGS.default:
-                comments["rating:" + email] = str(rating)
+            if self.has_rating:
+                comments["rating:" + email] = str(self("~#rating"))
             playcount = self.get("~#playcount", 0)
             if playcount != 0:
                 comments["playcount:" + email] = str(playcount)

--- a/quodlibet/quodlibet/formats/xiph.py
+++ b/quodlibet/quodlibet/formats/xiph.py
@@ -15,7 +15,6 @@ from mutagen.id3 import ID3
 
 from quodlibet import config
 from quodlibet import const
-from quodlibet.config import RATINGS
 from quodlibet.util.path import get_temp_cover_file
 
 from ._audio import AudioFile


### PR DESCRIPTION
Currently, if a rating is the same as the default value (usually `0.5`), the rating isn't stored in the tags. Since QL can now internally differentiate between a song that has a rating and one that has the default value, this pull request makes use of that.