### PR TITLE
Fixes #1475: WaitLoadWindow was always on top, on every workspace

### DIFF
--- a/quodlibet/quodlibet/qltk/wlw.py
+++ b/quodlibet/quodlibet/qltk/wlw.py
@@ -114,7 +114,8 @@ class WaitLoadWindow(WaitLoadBase, Gtk.Window):
 
     def __init__(self, parent, *args):
         """parent: the parent window, or None"""
-        Gtk.Window.__init__(self, type=Gtk.WindowType.POPUP)
+        Gtk.Window.__init__(self, type=Gtk.WindowType.TOPLEVEL)
+        self.set_decorated(False)
         WaitLoadBase.__init__(self)
         self.setup(*args)
 


### PR DESCRIPTION
This changes the type of the WaitLoadWindow as suggested by @julien-f to `TOPLEVEL`, so that it isn't always on top of every other window and on every workspace.