### PR TITLE
Support ReplayGain in mp4

### DIFF
--- a/quodlibet/quodlibet/formats/mp4.py
+++ b/quodlibet/quodlibet/formats/mp4.py
@@ -57,11 +57,11 @@ class MP4File(AudioFile):
             "musicbrainz_albumtype",
         "----:com.apple.iTunes:MusicBrainz Album Release Country":
             "releasecountry",
-    
-		'----:com.apple.iTunes:replaygain_album_gain': 'replaygain_album_gain',
-		'----:com.apple.iTunes:replaygain_album_peak': 'replaygain_album_peak',
-		'----:com.apple.iTunes:replaygain_track_gain': 'replaygain_track_gain',
-		'----:com.apple.iTunes:replaygain_track_peak': 'replaygain_track_peak',          
+
+        '----:com.apple.iTunes:replaygain_album_gain': 'replaygain_album_gain',
+        '----:com.apple.iTunes:replaygain_album_peak': 'replaygain_album_peak',
+        '----:com.apple.iTunes:replaygain_track_gain': 'replaygain_track_gain',
+        '----:com.apple.iTunes:replaygain_track_peak': 'replaygain_track_peak',
     }
     __rtranslate = dict([(v, k) for k, v in iteritems(__translate)])
 

--- a/quodlibet/quodlibet/formats/mp4.py
+++ b/quodlibet/quodlibet/formats/mp4.py
@@ -57,6 +57,11 @@ class MP4File(AudioFile):
             "musicbrainz_albumtype",
         "----:com.apple.iTunes:MusicBrainz Album Release Country":
             "releasecountry",
+    
+		'----:com.apple.iTunes:replaygain_album_gain': 'replaygain_album_gain',
+		'----:com.apple.iTunes:replaygain_album_peak': 'replaygain_album_peak',
+		'----:com.apple.iTunes:replaygain_track_gain': 'replaygain_track_gain',
+		'----:com.apple.iTunes:replaygain_track_peak': 'replaygain_track_peak',          
     }
     __rtranslate = dict([(v, k) for k, v in iteritems(__translate)])
 

--- a/quodlibet/tests/test_formats_mp4.py
+++ b/quodlibet/tests/test_formats_mp4.py
@@ -64,6 +64,12 @@ class TMP4File(TestCase):
         self._assert_tag_supported("mood")
         self._assert_tag_supported("conductor")
 
+    def test_replaygain_tags(self):
+        self._assert_tag_supported('replaygain_album_gain', '-5.67 dB')
+        self._assert_tag_supported('replaygain_album_peak', '1.0')
+        self._assert_tag_supported('replaygain_track_gain', '-5.67 dB')
+        self._assert_tag_supported('replaygain_track_peak', '1.0')
+
     def test_length(self):
         self.assertAlmostEqual(self.song("~#length"), 3.7079, 3)
 


### PR DESCRIPTION
Now QL and the QL ReplayGain Scanner will read and write ReplayGain tags from mp4/m4a files in the format used by the foobar2000 and deadbeef media players. There are no standard ReplayGain tags for mp4, it is simply the flac/vorbiscomment named tags and data format as mp4 freeform tags. 

This is not support for Apple's "SoundCheck" iTunNorm tag.