### PR TITLE
Use App indicator when running under Enlightenment

### DIFF
--- a/quodlibet/quodlibet/ext/events/trayicon/__init__.py
+++ b/quodlibet/quodlibet/ext/events/trayicon/__init__.py
@@ -11,7 +11,8 @@ from quodlibet import app
 from quodlibet.plugins.events import EventPlugin
 from quodlibet.qltk import is_wayland, Icons
 from quodlibet.qltk.window import Window
-from quodlibet.util import is_unity, is_osx, is_plasma, print_exc
+from quodlibet.util import (is_unity, is_osx, is_plasma, is_enlightenment,
+                            print_exc)
 
 from .prefs import Preferences
 from .util import pconfig
@@ -29,7 +30,8 @@ if is_osx():
 def get_indicator_impl():
     """Returns a BaseIndicator implementation depending on the environ"""
 
-    use_app_indicator = (is_unity() or is_wayland() or is_plasma())
+    use_app_indicator = (is_unity() or is_wayland() or is_plasma() or
+                         is_enlightenment())
 
     print_d("use app indicator: %s" % use_app_indicator)
     if not use_app_indicator:

--- a/quodlibet/quodlibet/util/environment.py
+++ b/quodlibet/quodlibet/util/environment.py
@@ -43,6 +43,12 @@ def is_unity():
     return _dbus_name_owned("com.canonical.Unity")
 
 
+def is_enlightenment():
+    """If we are running under Enlightenment"""
+
+    return _dbus_name_owned("org.enlightenment.wm.service")
+
+
 def is_linux():
     """If we are on Linux (or similar)"""
 


### PR DESCRIPTION
Some time ago, Enlightenment dropped its XEmbed support since it had never functioned well anyway (See e.g. <https://twitter.com/_Enlightenment_/status/538000507315314688>). Therefore, an app indicator has to be used when running under Enlightenment as well.

I'm not a Python programmer, so I'm not quite sure whether the way I indented the long lines is "correct" and I couldn't find good examples in QL's source tree within a reasonable amount of time.