### PR TITLE
docs: fix typos

### DIFF
--- a/quodlibet/docs/development/formats.rst
+++ b/quodlibet/docs/development/formats.rst
@@ -149,7 +149,7 @@ for opening in a standard web browser (e.g. http, https, or ftp scheme). As
 it is an IRI, and not a URI, it should be stored in unescaped form. If an 
 application needs a URI, it should follow the procedure in RFC 3987 section 
 3.1 to convert a valid IRI to a valid URI. As per the Vorbis comment 
-specification, the tag must be a UTF-8 represention of the Unicode string.
+specification, the tag must be a UTF-8 representation of the Unicode string.
 
 This tag may occur any number of times in a file.
 

--- a/quodlibet/docs/development/testing.rst
+++ b/quodlibet/docs/development/testing.rst
@@ -4,7 +4,7 @@
 Testing
 =======
 
-Quod Libet uses the CPython unittest framwork for testing. All testing related
+Quod Libet uses the CPython unittest framework for testing. All testing related
 code can be found under ``quodlibet/quodlibet/tests``.
 
 To run the full tests suite simply execute::

--- a/quodlibet/docs/guide/browse/album.rst
+++ b/quodlibet/docs/guide/browse/album.rst
@@ -28,7 +28,7 @@ set of albums, presented on the left, rather than as a set of songs, via
 album-centric enhancements to viewing, sorting, and searching.
 
 You can (configurably) display the album art next to each album to allow 
-faster identifcation of your albums (plus *it's just prettier*...).
+faster identification of your albums (plus *it's just prettier*...).
 
 Extra features related to searching, sorting and presenting albums are 
 detailed below.
@@ -60,7 +60,7 @@ of the underlying songs' values together. The albums in an Album List also
 have a few tags which are computed in a particular manner. A few of the 
 interesting ones:
 
-  * ``~#length`` is computed as the the sum of the length of the underlying
+  * ``~#length`` is computed as the sum of the length of the underlying
     songs.
   * ``~#tracks`` and ``~#discs`` are the total number of songs and discs in
     an album.

--- a/quodlibet/docs/guide/browse/paned.rst
+++ b/quodlibet/docs/guide/browse/paned.rst
@@ -21,7 +21,7 @@ case you have a lot of multi-artist albums.
 
 The songlist is presented at the bottom, and the panes, which run from left 
 to right, are above. Clicking on an item (or items) in a pane will restrict 
-it to just songs matching those (e.g those artists, or dates, genres etc). 
+it to just songs matching those (e.g. those artists, or dates, genres etc). 
 This will update the counts and choices on the next pane, and the filtered 
 results will be updated automatically in the song list.
 

--- a/quodlibet/docs/guide/faq.rst
+++ b/quodlibet/docs/guide/faq.rst
@@ -105,7 +105,7 @@ How can I hide incomplete albums from the Album View?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 One way is to enter ``#(tracks > 5)`` into the search box above the
-album list - this will only show albums with greater than than 5 tracks.
+album list - this will only show albums with greater than 5 tracks.
 
 
 How can I list my tracks based on their ratings?

--- a/quodlibet/docs/guide/playback/replaygain.rst
+++ b/quodlibet/docs/guide/playback/replaygain.rst
@@ -22,7 +22,7 @@ select some songs, or some albums and activate the replaygain plugin in the
 plugin submenu. The replaygain plugin has to go through every bit of song 
 data so this can take some time.
 
-After the the analyzing part is finished you can save the calculated
+After the analyzing part is finished you can save the calculated
 values. They will be written into the song's metadata.
 
 The replay gain plugin calculates a peak and a gain value for each song and

--- a/quodlibet/docs/guide/searching.rst
+++ b/quodlibet/docs/guide/searching.rst
@@ -36,8 +36,8 @@ for classical music or songs by `The Smiths
 
     !|(classical, smiths)
 
-While these searches are easy to type in, they depend on the visible colums
-and the active browser, also the last one might exclude some songs wich
+While these searches are easy to type in, they depend on the visible columns
+and the active browser, also the last one might exclude some songs which
 happen to contain "smiths" in their album title.
 
 


### PR DESCRIPTION
These misspellings were found using [mwic](http://jwilk.net/software/mwic).