### PR TITLE
Write musicbrainz release track ids

### DIFF
--- a/quodlibet/quodlibet/ext/songsmenu/brainz/widgets.py
+++ b/quodlibet/quodlibet/ext/songsmenu/brainz/widgets.py
@@ -276,6 +276,7 @@ def build_song_data(release, track):
     meta["artist"] = join([a.name for a in track.artists])
     meta["artistsort"] = join([a.sort_name for a in track.artists])
     meta["musicbrainz_artistid"] = join([a.id for a in track.artists])
+    meta["musicbrainz_releasetrackid"] = track.id
 
     # clean up "redundant" data
     if meta["albumartist"] == meta["albumartistsort"]:

--- a/quodlibet/quodlibet/formats/_id3.py
+++ b/quodlibet/quodlibet/formats/_id3.py
@@ -77,6 +77,7 @@ class ID3File(AudioFile):
     # http://bugs.musicbrainz.org/ticket/1383
     # http://musicbrainz.org/doc/MusicBrainzTag
     TXXX_MAP = {
+        u"MusicBrainz Release Track Id": "musicbrainz_releasetrackid",
         u"MusicBrainz Artist Id": "musicbrainz_artistid",
         u"MusicBrainz Album Id": "musicbrainz_albumid",
         u"MusicBrainz Album Artist Id": "musicbrainz_albumartistid",

--- a/quodlibet/quodlibet/formats/mp4.py
+++ b/quodlibet/quodlibet/formats/mp4.py
@@ -48,6 +48,8 @@ class MP4File(AudioFile):
         "----:com.apple.iTunes:MusicBrainz Artist Id":
             "musicbrainz_artistid",
         "----:com.apple.iTunes:MusicBrainz Track Id": "musicbrainz_trackid",
+        "----:com.apple.iTunes:MusicBrainz Release Track Id":
+            "musicbrainz_releasetrackid",
         "----:com.apple.iTunes:MusicBrainz Album Id": "musicbrainz_albumid",
         "----:com.apple.iTunes:MusicBrainz Album Artist Id":
             "musicbrainz_albumartistid",

--- a/quodlibet/quodlibet/formats/wma.py
+++ b/quodlibet/quodlibet/formats/wma.py
@@ -45,6 +45,7 @@ class WMAFile(AudioFile):
         "WM/Mood": "mood",
         "WM/EncodedBy": "encodedby",
         "MusicBrainz/Track Id": "musicbrainz_trackid",
+        "MusicBrainz/Release Track Id": "musicbrainz_releasetrackid",
         "MusicBrainz/Album Id": "musicbrainz_albumid",
         "MusicBrainz/Artist Id": "musicbrainz_artistid",
         "MusicBrainz/Album Artist Id": "musicbrainz_albumartistid",

--- a/quodlibet/tests/plugin/test_brainz.py
+++ b/quodlibet/tests/plugin/test_brainz.py
@@ -220,6 +220,26 @@ class TBrainz(PluginTestCase):
         self.assertEqual(dummy("date"), u'2003')
         self.assertEqual(dummy("title"), u'h\xb3\xe6')
 
+    def test_build_mbids(self):
+        Release = brainz.mb.Release
+        build_song_data = brainz.widgets.build_song_data
+        apply_options = brainz.widgets.apply_options
+        apply_to_song = brainz.widgets.apply_to_song
+
+        release = Release(TEST_DATA)
+        track = release.tracks[1]
+        meta = build_song_data(release, track)
+        apply_options(meta, True, False, False, True)
+        dummy = AudioFile()
+        apply_to_song(meta, dummy)
+
+        self.assertEqual(dummy("musicbrainz_releasetrackid"), track.id)
+        self.assertEqual(dummy("musicbrainz_albumid"), release.id)
+        self.assertEqual(
+            dummy.list("musicbrainz_artistid"),
+            [u'410c9baf-5469-44f6-9852-826524b80c61',
+             u'146c01d0-d3a2-44c3-acb5-9208bce75e14'])
+
     def test_pregap(self):
         Release = brainz.mb.Release
 

--- a/quodlibet/tests/test_formats__id3.py
+++ b/quodlibet/tests/test_formats__id3.py
@@ -299,6 +299,21 @@ class TID3File(TestCase):
         f = mutagen.File(self.filename)
         self.failIf(f.tags.get("UFID:http://musicbrainz.org"))
 
+    def test_mb_release_track_id(self):
+        f = mutagen.File(self.filename)
+        f.tags.add(
+            mutagen.id3.TXXX(encoding=3, desc=u"MusicBrainz Release Track Id",
+                             text=["bla"]))
+        f.save()
+        song = MP3File(self.filename)
+        self.assertEqual(song["musicbrainz_releasetrackid"], u"bla")
+        song["musicbrainz_releasetrackid"] = u"foo"
+        song.write()
+        f = mutagen.File(self.filename)
+        frames = f.tags.getall("TXXX:MusicBrainz Release Track Id")
+        self.assertTrue(frames)
+        self.assertEqual(frames[0].text, [u"foo"])
+
     def test_load_comment(self):
         # comm with empty descriptions => comment
         f = mutagen.File(self.filename)

--- a/quodlibet/tests/test_formats_mp4.py
+++ b/quodlibet/tests/test_formats_mp4.py
@@ -46,6 +46,19 @@ class TMP4File(TestCase):
     def test_encoding(self):
         self.assertEqual(self.song("~encoding"), "FAAC 1.24")
 
+    def test_mb_release_track_id(self):
+        tag = mutagen.mp4.MP4(self.f)
+        tag["----:com.apple.iTunes:MusicBrainz Release Track Id"] = [b"foo"]
+        tag.save()
+        song = MP4File(self.f)
+        self.assertEqual(song("musicbrainz_releasetrackid"), u"foo")
+        song["musicbrainz_releasetrackid"] = u"bla"
+        song.write()
+        tag = mutagen.mp4.MP4(self.f)
+        self.assertEqual(
+            tag["----:com.apple.iTunes:MusicBrainz Release Track Id"],
+            [b"bla"])
+
     def test_basic(self):
         self._assert_tag_supported("title")
         self._assert_tag_supported("artist")

--- a/quodlibet/tests/test_formats_wma.py
+++ b/quodlibet/tests/test_formats_wma.py
@@ -101,6 +101,17 @@ class TWMAFile(TestCase):
         self.assertEqual(self.song3("~encoding"),
                          u"Microsoft G.723.1\n8 kHz Mono, 5333 Bit/s")
 
+    def test_mb_release_track_id(self):
+        tag = asf.ASF(self.f)
+        tag["MusicBrainz/Release Track Id"] = [u"foo"]
+        tag.save()
+        song = WMAFile(self.f)
+        self.assertEqual(song("musicbrainz_releasetrackid"), u"foo")
+        song["musicbrainz_releasetrackid"] = u"bla"
+        song.write()
+        tag = asf.ASF(self.f)
+        self.assertEqual(tag["MusicBrainz/Release Track Id"], [u"bla"])
+
     def test_invalid(self):
         path = os.path.join(DATA_DIR, 'empty.xm')
         self.assertTrue(os.path.exists(path))


### PR DESCRIPTION
Save them in the musicbrainz plugin and write them to files.

Fixes #1963