### PR TITLE
tests: switch to pytest as the main test runner

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,8 +29,8 @@ install:
  - if [ "$APT_PACKAGES" != "" ]; then sudo apt-get update -q || true; fi
  - if [ "$APT_PACKAGES" != "" ]; then travis_retry sudo apt-get install -y $(echo $APT_PACKAGES); fi
  - if [ "$TYPE" == "linux" ]; then travis_retry pip install --upgrade pep8 pyflakes; fi
- - if [ "$TYPE" == "osx" ]; then travis_retry wget https://bitbucket.org/lazka/quodlibet/downloads/QuodLibet-3.7.-1.dmg; fi
- - if [ "$TYPE" == "osx" ]; then hdiutil attach -readonly -mountpoint _mount QuodLibet-3.7.-1.dmg; fi
+ - if [ "$TYPE" == "osx" ]; then travis_retry wget https://bitbucket.org/lazka/quodlibet/downloads/QuodLibet-3.8.-1.dmg; fi
+ - if [ "$TYPE" == "osx" ]; then hdiutil attach -readonly -mountpoint _mount QuodLibet-3.8.-1.dmg; fi
  - if [ "$TYPE" == "windows" ]; then travis_retry wget https://bitbucket.org/lazka/quodlibet/downloads/quodlibet-3.8-win-sdk.tar.xz; fi
  - if [ "$TYPE" == "windows" ]; then tar -xJf quodlibet-3.8-win-sdk.tar.xz; fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,8 +31,8 @@ install:
  - if [ "$TYPE" == "linux" ]; then travis_retry pip install --upgrade pep8 pyflakes; fi
  - if [ "$TYPE" == "osx" ]; then travis_retry wget https://bitbucket.org/lazka/quodlibet/downloads/QuodLibet-3.7.-1.dmg; fi
  - if [ "$TYPE" == "osx" ]; then hdiutil attach -readonly -mountpoint _mount QuodLibet-3.7.-1.dmg; fi
- - if [ "$TYPE" == "windows" ]; then travis_retry wget https://bitbucket.org/lazka/quodlibet/downloads/quodlibet-3.7-win-sdk.tar.xz; fi
- - if [ "$TYPE" == "windows" ]; then tar -xJf quodlibet-3.7-win-sdk.tar.xz; fi
+ - if [ "$TYPE" == "windows" ]; then travis_retry wget https://bitbucket.org/lazka/quodlibet/downloads/quodlibet-3.8-win-sdk.tar.xz; fi
+ - if [ "$TYPE" == "windows" ]; then tar -xJf quodlibet-3.8-win-sdk.tar.xz; fi
 
 script:
  - cd quodlibet

--- a/osx_bundle/misc/bundle/app.bundle
+++ b/osx_bundle/misc/bundle/app.bundle
@@ -159,6 +159,9 @@
   <data>${prefix}/lib/python2.7/site-packages/musicbrainzngs</data>
   <data>${prefix}/lib/python2.7/site-packages/mutagen</data>
   <data>${prefix}/lib/python2.7/site-packages/certifi</data>
+  <data>${prefix}/lib/python2.7/site-packages/py</data>
+  <data>${prefix}/lib/python2.7/site-packages/_pytest</data>
+  <data>${prefix}/lib/python2.7/site-packages/pytest.py</data>
   <!-- pyObjC -->
   <data>${prefix}/lib/python2.7/distutils</data>
   <data>${prefix}/lib/python2.7/site-packages/pkg_resources.py</data>

--- a/osx_bundle/modulesets/quodlibet.modules
+++ b/osx_bundle/modulesets/quodlibet.modules
@@ -65,6 +65,7 @@
       <dep package="meta-gtk-osx-python-gtk3"/>
       <dep package="pyobjc"/>
       <dep package="certifi"/>
+      <dep package="pytest"/>
     </dependencies>
   </metamodule>
 
@@ -222,6 +223,23 @@
         version="1.0.1" md5sum="b461c526cb2a80ab302b4953ae950379"/>
     <dependencies>
     <dep package="setuptools"/>
+    </dependencies>
+  </distutils>
+
+  <distutils id="py">
+    <branch repo="pypi" checkoutdir="py-1.4.31" module="f4/9a/8dfda23f36600dd701c6722316ba8a3ab4b990261f83e7d3ffc6dfedf7ef/py-1.4.31.tar.gz"
+        version="1.4.31" md5sum="5d2c63c56dc3f2115ec35c066ecd582b"/>
+    <dependencies>
+    <dep package="setuptools"/>
+    </dependencies>
+  </distutils>
+
+  <distutils id="pytest">
+    <branch repo="pypi" checkoutdir="pytest-2.9.2" module="f0/ee/6e2522c968339dca7d9abfd5e71312abeeb5ee902e09b4daf44f07b2f907/pytest-2.9.2.tar.gz"
+        version="2.9.2" md5sum="b65c2944dfaa0efb62c0239afb424f5b"/>
+    <dependencies>
+    <dep package="setuptools"/>
+    <dep package="py"/>
     </dependencies>
   </distutils>
 

--- a/quodlibet/tests/__init__.py
+++ b/quodlibet/tests/__init__.py
@@ -3,9 +3,6 @@
 # it under the terms of the GNU General Public License version 2 as
 # published by the Free Software Foundation
 
-import fnmatch
-import inspect
-from math import log
 import os
 import sys
 import unittest
@@ -13,8 +10,13 @@ import tempfile
 import shutil
 import atexit
 import subprocess
+
+try:
+    import pytest
+except ImportError:
+    raise SystemExit("pytest missing: sudo apt-get install python-pytest")
+
 from quodlibet.compat import PY3
-from quodlibet.util.dprint import Colorise, print_
 from quodlibet.util.path import fsnative, is_fsnative, xdg_get_cache_home
 from quodlibet.util.misc import environ
 from quodlibet import util
@@ -37,12 +39,6 @@ class TestCase(OrigTestCase):
 skip = unittest.skip
 skipUnless = unittest.skipUnless
 skipIf = unittest.skipIf
-_NO_NETWORK = False
-
-
-def skipUnlessNetwork(*args, **kwargs):
-    return skipIf(_NO_NETWORK, "no network")(*args, **kwargs)
-
 
 DATA_DIR = os.path.join(util.get_module_dir(), "data")
 assert is_fsnative(DATA_DIR)
@@ -104,70 +100,6 @@ def destroy_fake_app():
 
     app.window = app.library = app.player = app.name = app.id = None
     app.cover_manager = None
-
-
-class Result(unittest.TestResult):
-    TOTAL_WIDTH = 80
-    TEST_RESULTS_WIDTH = 50
-    TEST_NAME_WIDTH = TOTAL_WIDTH - TEST_RESULTS_WIDTH - 3
-    MAJOR_SEPARATOR = '=' * TOTAL_WIDTH
-    MINOR_SEPARATOR = '-' * TOTAL_WIDTH
-
-    CHAR_SUCCESS, CHAR_ERROR, CHAR_FAILURE = '+', 'E', 'F'
-
-    def __init__(self, test_name, num_tests, out=sys.stdout, failfast=False):
-        super(Result, self).__init__()
-        self.out = out
-        self.failfast = failfast
-        if hasattr(out, "flush"):
-            out.flush()
-        pref = '%s (%d): ' % (Colorise.bold(test_name), num_tests)
-        line = pref + " " * (self.TEST_NAME_WIDTH - len(test_name)
-                             - 7 - int(num_tests and log(num_tests, 10) or 0))
-        print_(line, end="")
-
-    def addSuccess(self, test):
-        unittest.TestResult.addSuccess(self, test)
-        print_(Colorise.green(self.CHAR_SUCCESS), end="")
-
-    def addError(self, test, err):
-        unittest.TestResult.addError(self, test, err)
-        print_(Colorise.red(self.CHAR_ERROR), end="")
-
-    def addFailure(self, test, err):
-        unittest.TestResult.addFailure(self, test, err)
-        print_(Colorise.red(self.CHAR_FAILURE), end="")
-
-    def printErrors(self):
-        succ = self.testsRun - (len(self.errors) + len(self.failures))
-        v = Colorise.bold("%3d" % succ)
-        cv = Colorise.green(v) if succ == self.testsRun else Colorise.red(v)
-        count = self.TEST_RESULTS_WIDTH - self.testsRun
-        print_((" " * count) + cv)
-        self.printErrorList('ERROR', self.errors)
-        self.printErrorList('FAIL', self.failures)
-
-    def printErrorList(self, flavour, errors):
-        for test, err in errors:
-            print_(self.MAJOR_SEPARATOR)
-            print_(Colorise.red("%s: %s" % (flavour, str(test))))
-            print_(self.MINOR_SEPARATOR)
-            # tracebacks can contain encoded paths, not sure
-            # what the right fix is here, so use repr
-            for line in err.splitlines():
-                print_(repr(line)[1:-1])
-
-
-class Runner(object):
-
-    def run(self, test, failfast=False):
-        suite = unittest.makeSuite(test)
-        if suite.countTestCases() == 0:
-            return 0, 0, 0
-        result = Result(test.__name__, len(suite._tests), failfast=failfast)
-        suite(result)
-        result.printErrors()
-        return len(result.failures), len(result.errors), len(suite._tests)
 
 
 _BUS_INFO = None
@@ -253,16 +185,9 @@ init_test_environ()
 atexit.register(exit_test_environ)
 
 
-def unit(run=[], filter_func=None, main=False, subdirs=None,
-               strict=False, stop_first=False, no_network=False):
-
-    global _NO_NETWORK
-
-    path = util.get_module_dir()
-    if subdirs is None:
-        subdirs = []
-
-    _NO_NETWORK = no_network
+def unit(run=[], suite=None, strict=False, exitfirst=False, network=True,
+         quality=False):
+    """Returns 0 if everything passed"""
 
     # make glib warnings fatal
     if strict:
@@ -272,46 +197,30 @@ def unit(run=[], filter_func=None, main=False, subdirs=None,
             GLib.LogLevelFlags.LEVEL_ERROR |
             GLib.LogLevelFlags.LEVEL_WARNING)
 
-    suites = []
+    args = []
 
-    def discover_tests(mod):
-        for k in vars(mod):
-            value = getattr(mod, k)
+    if run:
+        args.append("-k")
+        args.append(" or ".join(run))
 
-            if value is not TestCase and \
-                    inspect.isclass(value) and issubclass(value, TestCase):
-                suites.append(value)
+    skip_markers = []
 
-    if main:
-        for name in os.listdir(path):
-            if fnmatch.fnmatch(name, "test_*.py"):
-                mod = __import__(".".join([__name__, name[:-3]]), {}, {}, [])
-                discover_tests(getattr(mod, name[:-3]))
+    if not quality:
+        skip_markers.append("quality")
 
-    if main:
-        # include plugin tests by default
-        subdirs = (subdirs or []) + ["plugin"]
+    if not network:
+        skip_markers.append("network")
 
-    for subdir in subdirs:
-        sub_path = os.path.join(path, subdir)
-        for name in os.listdir(sub_path):
-            if fnmatch.fnmatch(name, "test_*.py"):
-                mod = __import__(
-                    ".".join([__name__, subdir, name[:-3]]), {}, {}, [])
-                discover_tests(getattr(getattr(mod, subdir), name[:-3]))
+    if skip_markers:
+        args.append("-m")
+        args.append(" and ".join(["not %s" % m for m in skip_markers]))
 
-    runner = Runner()
-    failures = errors = all_ = 0
-    use_suites = filter(filter_func, suites)
-    for test in sorted(use_suites, key=repr):
-        if (not run
-                or test.__name__ in run
-                or test.__module__[11:] in run):
-            df, de, num = runner.run(test, failfast=stop_first)
-            failures += df
-            errors += de
-            all_ += num
-            if stop_first and (df or de):
-                break
+    if exitfirst:
+        args.append("-x")
 
-    return failures, errors, all_
+    if suite is None:
+        args.append("tests")
+    else:
+        args.append(os.path.join("tests", suite))
+
+    pytest.main(args=args)

--- a/quodlibet/tests/quality/test_pep8.py
+++ b/quodlibet/tests/quality/test_pep8.py
@@ -10,9 +10,12 @@ import glob
 import errno
 import subprocess
 
+import pytest
+
 from tests import TestCase
 
 
+@pytest.mark.quality
 class TPEP8(TestCase):
     # E12x popped up in pep8 1.4 compared to 1.2..
     # drop them once 1.4 is common enough

--- a/quodlibet/tests/quality/test_pyflakes.py
+++ b/quodlibet/tests/quality/test_pyflakes.py
@@ -9,6 +9,8 @@ import os
 import sys
 import re
 
+import pytest
+
 try:
     from pyflakes.scripts import pyflakes
 except ImportError:
@@ -47,6 +49,7 @@ class FakeStream(object):
             raise Exception("\n" + "\n".join(self.lines))
 
 
+@pytest.mark.quality
 class TPyFlakes(TestCase):
 
     def __check_path(self, path):

--- a/quodlibet/tests/test_https.py
+++ b/quodlibet/tests/test_https.py
@@ -5,15 +5,16 @@
 # it under the terms of the GNU General Public License version 2 as
 # published by the Free Software Foundation.
 
+import pytest
 from gi.repository import Gio, Soup, GLib
 
-from tests import TestCase, skipIf, skipUnlessNetwork
+from tests import TestCase, skipIf
 
 from quodlibet.util import is_linux, is_osx, get_ca_file
 from quodlibet.compat import urlopen, build_opener
 
 
-@skipUnlessNetwork
+@pytest.mark.network
 @skipIf(is_linux(), "not on linux")
 class Thttps(TestCase):
     """For Windows/OSX to check if we can create a TLS connection

--- a/win_installer/_base.sh
+++ b/win_installer/_base.sh
@@ -39,6 +39,9 @@ baf089121710c36ce317d9f107d552a3c7ec14dfcaa9618b809c4b25ef775619  mutagen-$MUTAG
 1750556a9c797ec157ac837c531fef05f60a5595d2a1553c7d3f5be7bc085b70  pygi-aio-$PYGI_AIO_VER-setup.exe
 3ac291535bcf15fd5a15bcd29b066570e8d2a0cab4f3b92a2372f41aa09a4f48  python-2.7.12.msi
 ec447bcab906fe7c4dbd714a1dff1b00adcd20d0011968df1a740e6b1fb09cb5  python-musicbrainzngs-0.6.tar.gz
+12c18abb9a09a5b2802dba75c7a2d7d6c8c0f1258abd8243e7688415d87ad1d8  pytest-2.9.2.tar.gz
+a6501963c725fc2554dabfece8ae9a8fb5e149c0ac0a42fd2b02c5c1c57fc114  py-1.4.31.tar.gz
+f4945bf52ae49da0728fe730a33c18744803752fc948f154f29dc0c4f9f2f9cc  colorama-0.3.7.zip
 547c24748705ad4b6e3f3944f38d0416c5cdd2de6ebe3d65a1840bd2b82519a4  7z1602.msi
 8a94f6ff1ee9562a2216d2096b87d0e54a5eb5c9391874800e5032033a1c8e85  libmodplug-1.dll
 2b53c7bb3a92218f8ff197d259b7769754ec9a578561e69578739fcbdbb53da3  libgstdirectsoundsink.dll
@@ -60,9 +63,12 @@ ec447bcab906fe7c4dbd714a1dff1b00adcd20d0011968df1a740e6b1fb09cb5  python-musicbr
         wget -P "$BIN" -c http://bitbucket.org/lazka/quodlibet/downloads/libgstopus.dll
         wget -P "$BIN" -c http://bitbucket.org/lazka/quodlibet/downloads/libgstdirectsoundsink.dll
 
-        pip download --dest="$BIN" --no-binary=":all:" "mutagen==$MUTAGEN_VER"
-        pip download --dest="$BIN" --no-binary=":all:" "feedparser==5.2.1"
-        pip download --dest="$BIN" --no-binary=":all:" "certifi==2016.2.28"
+        pip download --dest="$BIN" --no-deps --no-binary=":all:" "mutagen==$MUTAGEN_VER"
+        pip download --dest="$BIN" --no-deps --no-binary=":all:" "feedparser==5.2.1"
+        pip download --dest="$BIN" --no-deps --no-binary=":all:" "certifi==2016.2.28"
+        pip download --dest="$BIN" --no-deps --no-binary=":all:" "pytest==2.9.2"
+        pip download --dest="$BIN" --no-deps --no-binary=":all:" "py==1.4.31"
+        pip download --dest="$BIN" --no-deps --no-binary=":all:" "colorama==0.3.7"
 
         # check again
         (cd "$BIN" && echo "$FILEHASHES" |  sha256sum --strict -c -) || exit
@@ -225,6 +231,10 @@ function install_pydeps {
     local PYTHON="$PYDIR"/python.exe
     (
     cd "$BUILD_ENV"/bin
+
+    wine $PYTHON -m pip install colorama-0.3.7.zip
+    wine $PYTHON -m pip install py-1.4.31.tar.gz
+    wine $PYTHON -m pip install pytest-2.9.2.tar.gz
     wine $PYTHON -m pip install "mutagen-$MUTAGEN_VER.tar.gz"
     wine $PYTHON -m pip install feedparser-5.2.1.zip
     wine $PYTHON -m pip install certifi-2016.2.28.tar.gz


### PR DESCRIPTION
Allows us to get rid of a bunch of test discovery code
and gives us a few new features.

"--to-run=TFoo,TBar" still works by passing the class
names to pytest using the "-k" switch. This accepts
more stuff, but for the basic class name list it
should give the same results.

To skip network and code quality tests pytest markers
are used:
  @pytest.mark.quality
  @pytest.mark.network