### PR TITLE
Duration format prefs

### DIFF
--- a/quodlibet/quodlibet/config.py
+++ b/quodlibet/quodlibet/config.py
@@ -159,7 +159,7 @@ INITIAL = {
         "filename": "folder.jpg",
     },
     "display": {
-        "duration_format": "long"
+        "duration_format": "standard"
     }
 }
 

--- a/quodlibet/quodlibet/config.py
+++ b/quodlibet/quodlibet/config.py
@@ -9,6 +9,7 @@
 
 import shutil
 
+from quodlibet.util import enum
 from . import const
 from quodlibet.util.config import Config, Error
 from quodlibet.util import print_d, print_w
@@ -156,6 +157,9 @@ INITIAL = {
         "prefer_embedded": "false",
         "force_filename": "false",
         "filename": "folder.jpg",
+    },
+    "display": {
+        "duration_format": "long"
     }
 }
 
@@ -331,3 +335,22 @@ class HardCodedRatingsPrefs(RatingsPrefs):
 
 # Need an instance just for imports to work
 RATINGS = RatingsPrefs()
+
+
+@enum
+class DurationFormat(str):
+    LONG, SHORT = "long", "short"
+
+
+class DurationFormatPref(object):
+    @property
+    def format(self):
+        raw = get("display", "duration_format")
+        return DurationFormat.value_of(raw)
+
+    @format.setter
+    def format(self, value):
+        set("display", "duration_format", value)
+
+
+DURATION = DurationFormatPref()

--- a/quodlibet/quodlibet/config.py
+++ b/quodlibet/quodlibet/config.py
@@ -339,14 +339,15 @@ RATINGS = RatingsPrefs()
 
 @enum
 class DurationFormat(str):
-    LONG, SHORT = "long", "short"
+    NUMERIC, SECONDS = "numeric", "numeric-seconds"
+    STANDARD, FULL = "standard", "text-full"
 
 
 class DurationFormatPref(object):
     @property
     def format(self):
         raw = get("display", "duration_format")
-        return DurationFormat.value_of(raw)
+        return DurationFormat.value_of(raw, DurationFormat.STANDARD)
 
     @format.setter
     def format(self, value):

--- a/quodlibet/quodlibet/qltk/browser.py
+++ b/quodlibet/quodlibet/qltk/browser.py
@@ -253,7 +253,7 @@ class LibraryBrowser(Window, util.InstanceTracker, PersistentWindowMixin):
         self.add(Gtk.VBox())
 
         view = SongList(library, update=True)
-        view.info.connect("changed", self.__set_time)
+        view.info.connect("changed", self.__set_totals)
         self.songlist = view
 
         sw = ScrolledWindow()
@@ -345,9 +345,9 @@ class LibraryBrowser(Window, util.InstanceTracker, PersistentWindowMixin):
             view.popup_menu(menu, 0, Gtk.get_current_event_time())
         return True
 
-    def __set_time(self, info, songs):
+    def __set_totals(self, info, songs):
         i = len(songs)
         length = sum(song.get("~#length", 0) for song in songs)
         t = self.browser.status_text(count=i,
-                                     time=util.format_time_long(length))
+                                     time=util.format_time_preferred(length))
         self.__statusbar.set_text(t)

--- a/quodlibet/quodlibet/qltk/information.py
+++ b/quodlibet/quodlibet/qltk/information.py
@@ -259,7 +259,7 @@ class OneSong(qltk.Notebook):
                 return timestr.decode(encoding)
 
         fn = fsdecode(unexpand(song["~filename"]))
-        length = util.format_time_long(song.get("~#length", 0))
+        length = util.format_time_preferred(song.get("~#length", 0))
         size = util.format_size(
             song.get("~#filesize") or filesize(song["~filename"]))
         mtime = ftime(util.path.mtime(song["~filename"]))
@@ -347,7 +347,7 @@ class OneAlbum(qltk.Notebook):
                 len(songs)) % len(songs))
 
         text.append(", ".join(parts))
-        text.append(util.format_time_long(length))
+        text.append(util.format_time_preferred(length))
 
         if "location" in song:
             text.append(util.escape(song["location"]))
@@ -581,7 +581,7 @@ class ManySongs(qltk.Notebook):
         table.attach(Label(_("Total length:")), 0, 1, 0, 1,
                      xoptions=Gtk.AttachOptions.FILL)
         table.attach(
-            Label(util.format_time_long(length)), 1, 2, 0, 1)
+            Label(util.format_time_preferred(length)), 1, 2, 0, 1)
         table.attach(Label(_("Total size:")), 0, 1, 1, 2,
                      xoptions=Gtk.AttachOptions.FILL)
         table.attach(Label(util.format_size(size)), 1, 2, 1, 2)

--- a/quodlibet/quodlibet/qltk/prefs.py
+++ b/quodlibet/quodlibet/qltk/prefs.py
@@ -65,40 +65,7 @@ class PreferencesWindow(UniqueWindow):
                         tooltip=_("When the playing song changes, "
                                   "scroll to it in the song list"))
                 vbox.pack_start(c, False, True, 0)
-
-                model = Gtk.ListStore(str, str)
-
-                def on_changed(combo):
-                    it = combo.get_active_iter()
-                    if it is None:
-                        return
-                    DURATION.format = model[it][0]
-                    qltk.redraw_all_toplevels()
-
-                def draw_duration(column, cell, model, it, data):
-                    df, example = model[it]
-                    cell.set_property('text', example)
-
-                for df in sorted(DurationFormat.values):
-                    # 4954s == longest ever CD, FWIW
-                    model.append([df, format_time_preferred(4954, df)])
-                duration = Gtk.ComboBox(model=model)
-                cell = Gtk.CellRendererText()
-                duration.pack_start(cell, True)
-                duration.set_cell_data_func(cell, draw_duration, None)
-                index = list(DurationFormat.values).index(DURATION.format)
-                duration.set_active(index)
-                duration.connect('changed', on_changed)
-                hbox = Gtk.HBox(spacing=6)
-                label = Gtk.Label(label=_("Duration format"),
-                                  use_underline=True)
-                label.set_mnemonic_widget(duration)
-                hbox.pack_start(label, False, True, 0)
-                hbox.pack_start(duration, False, True, 0)
-
-                vbox.pack_start(hbox, False, True, 0)
-                frame = qltk.Frame(_("Behavior"), child=vbox)
-                return frame
+                return qltk.Frame(_("Behavior"), child=vbox)
 
             def create_visible_columns_frame():
                 buttons = {}
@@ -260,27 +227,65 @@ class PreferencesWindow(UniqueWindow):
         name = "browser"
 
         def __init__(self):
+            def create_display_frame():
+                vbox = Gtk.VBox(spacing=6)
+                model = Gtk.ListStore(str, str)
+
+                def on_changed(combo):
+                    it = combo.get_active_iter()
+                    if it is None:
+                        return
+                    DURATION.format = model[it][0]
+                    app.window.songlist.info.refresh()
+                    app.window.qexpander.refresh()
+                    # TODO: refresh info windows ideally too (but see #2019)
+
+                def draw_duration(column, cell, model, it, data):
+                    df, example = model[it]
+                    cell.set_property('text', example)
+
+                for df in sorted(DurationFormat.values):
+                    # 4954s == longest ever CD, FWIW
+                    model.append([df, format_time_preferred(4954, df)])
+                duration = Gtk.ComboBox(model=model)
+                cell = Gtk.CellRendererText()
+                duration.pack_start(cell, True)
+                duration.set_cell_data_func(cell, draw_duration, None)
+                index = list(DurationFormat.values).index(DURATION.format)
+                duration.set_active(index)
+                duration.connect('changed', on_changed)
+                hbox = Gtk.HBox(spacing=6)
+                label = Gtk.Label(label=_("Duration totals") + ":",
+                                  use_underline=True)
+                label.set_mnemonic_widget(duration)
+                hbox.pack_start(label, False, True, 0)
+                hbox.pack_start(duration, False, True, 0)
+
+                vbox.pack_start(hbox, False, True, 0)
+                return qltk.Frame(_("Display"), child=vbox)
+
+            def create_search_frame():
+                vb = Gtk.VBox(spacing=6)
+                hb = Gtk.HBox(spacing=6)
+                l = Gtk.Label(label=_("_Global filter:"))
+                l.set_use_underline(True)
+                e = ValidatingEntry(Query.validator)
+                e.set_text(config.get("browsers", "background"))
+                e.connect('changed', self._entry, 'background', 'browsers')
+                e.set_tooltip_text(
+                    _("Apply this query in addition to all others"))
+                l.set_mnemonic_widget(e)
+                hb.pack_start(l, False, True, 0)
+                hb.pack_start(e, True, True, 0)
+                vb.pack_start(hb, False, True, 0)
+                # Translators: The heading of the preference group, no action
+                return qltk.Frame(C_("heading", "Search"), child=vb)
+
             super(PreferencesWindow.Browsers, self).__init__(spacing=12)
             self.set_border_width(12)
             self.title = _("Browsers")
-
-            # Search
-            vb = Gtk.VBox(spacing=6)
-            hb = Gtk.HBox(spacing=6)
-            l = Gtk.Label(label=_("_Global filter:"))
-            l.set_use_underline(True)
-            e = ValidatingEntry(Query.validator)
-            e.set_text(config.get("browsers", "background"))
-            e.connect('changed', self._entry, 'background', 'browsers')
-            e.set_tooltip_text(_("Apply this query in addition to all others"))
-            l.set_mnemonic_widget(e)
-            hb.pack_start(l, False, True, 0)
-            hb.pack_start(e, True, True, 0)
-            vb.pack_start(hb, False, True, 0)
-
-            # Translators: The heading of the preference group, no action
-            f = qltk.Frame(C_("heading", "Search"), child=vb)
-            self.pack_start(f, False, True, 0)
+            self.pack_start(create_search_frame(), False, True, 0)
+            self.pack_start(create_display_frame(), False, True, 0)
 
             # Ratings
             vb = Gtk.VBox(spacing=6)

--- a/quodlibet/quodlibet/qltk/prefs.py
+++ b/quodlibet/quodlibet/qltk/prefs.py
@@ -85,7 +85,7 @@ class PreferencesWindow(UniqueWindow):
                 duration = Gtk.ComboBox(model=model)
                 cell = Gtk.CellRendererText()
                 duration.pack_start(cell, True)
-                duration.set_cell_data_func(cell, draw_duration,None)
+                duration.set_cell_data_func(cell, draw_duration, None)
                 index = list(DurationFormat.values).index(DURATION.format)
                 duration.set_active(index)
                 duration.connect('changed', on_changed)

--- a/quodlibet/quodlibet/qltk/prefs.py
+++ b/quodlibet/quodlibet/qltk/prefs.py
@@ -79,7 +79,7 @@ class PreferencesWindow(UniqueWindow):
                     df, example = model[it]
                     cell.set_property('text', example)
 
-                for df in DurationFormat.values:
+                for df in sorted(DurationFormat.values):
                     # 4954s == longest ever CD, FWIW
                     model.append([df, format_time_preferred(4954, df)])
                 duration = Gtk.ComboBox(model=model)

--- a/quodlibet/quodlibet/qltk/queue.py
+++ b/quodlibet/quodlibet/qltk/queue.py
@@ -14,7 +14,7 @@ from quodlibet import config
 from quodlibet import util
 from quodlibet import qltk
 
-from quodlibet.util import connect_obj, connect_destroy
+from quodlibet.util import connect_obj, connect_destroy, format_time_preferred
 from quodlibet.qltk import Icons, gtk_version, add_css
 from quodlibet.qltk.ccb import ConfigCheckButton
 from quodlibet.qltk.songlist import SongList, DND_QL, DND_URI_LIST
@@ -206,7 +206,7 @@ class QueueExpander(Gtk.Expander):
             text = ngettext("%(count)d song (%(time)s)",
                             "%(count)d songs (%(time)s)",
                             len(model)) % {
-                "count": len(model), "time": util.format_time_display(time)}
+                "count": len(model), "time": format_time_preferred(time)}
         lab.set_text(text)
 
     def __check_expand(self, model, path, iter, lab):

--- a/quodlibet/quodlibet/qltk/queue.py
+++ b/quodlibet/quodlibet/qltk/queue.py
@@ -105,7 +105,7 @@ class QueueExpander(Gtk.Expander):
         b.set_relief(Gtk.ReliefStyle.NONE)
         left.pack_start(b, False, False, 0)
 
-        count_label = Gtk.Label()
+        self.count_label = count_label = Gtk.Label()
         left.pack_start(count_label, False, True, 0)
 
         outer.pack_start(left, True, True, 0)
@@ -175,6 +175,9 @@ class QueueExpander(Gtk.Expander):
     @property
     def model(self):
         return self.queue.model
+
+    def refresh(self):
+        self.__update_count(self.model, None, self.count_label)
 
     def __update_state_icon(self, player, song, state_icon):
         if self.model.sourced:

--- a/quodlibet/quodlibet/qltk/quodlibetwindow.py
+++ b/quodlibet/quodlibet/qltk/quodlibetwindow.py
@@ -847,7 +847,7 @@ class QuodLibetWindow(Window, PersistentWindowMixin):
         self.songlist.connect('popup-menu', self.__songs_popup_menu)
         self.songlist.connect('columns-changed', self.__cols_changed)
         self.songlist.connect('columns-changed', self.__hide_headers)
-        self.songlist.info.connect("changed", self.__set_time)
+        self.songlist.info.connect("changed", self.__set_totals)
 
         lib = library.librarian
         connect_destroy(lib, 'changed', self.__song_changed, player)
@@ -1526,8 +1526,8 @@ class QuodLibetWindow(Window, PersistentWindowMixin):
             self.browser.filter_text(query.encode('utf-8'))
             self.browser.activate()
 
-    def __set_time(self, info, songs):
+    def __set_totals(self, info, songs):
         length = sum(song.get("~#length", 0) for song in songs)
         t = self.browser.status_text(count=len(songs),
-                                     time=util.format_time_long(length))
+                                     time=util.format_time_preferred(length))
         self.statusbar.set_default_text(t)

--- a/quodlibet/quodlibet/qltk/songlist.py
+++ b/quodlibet/quodlibet/qltk/songlist.py
@@ -35,7 +35,7 @@ from quodlibet.util.path import uri_to_path
 DND_QL, DND_URI_LIST = range(2)
 
 
-class SongInfoSelection(GObject.Object):
+class SongSelectionInfo(GObject.Object):
     """
     Songs which get included in the status bar summary.
 
@@ -64,7 +64,7 @@ class SongInfoSelection(GObject.Object):
     }
 
     def __init__(self, songlist):
-        super(SongInfoSelection, self).__init__()
+        super(SongSelectionInfo, self).__init__()
 
         self.__idle = None
         self.__songlist = songlist
@@ -380,7 +380,7 @@ class SongList(AllTreeView, SongListDnDMixin, DragScroll,
         super(SongList, self).__init__()
         self._register_instance(SongList)
         self.set_model(model_cls())
-        self.info = SongInfoSelection(self)
+        self.info = SongSelectionInfo(self)
         self.set_size_request(200, 150)
         self.set_rules_hint(True)
         self.get_selection().set_mode(Gtk.SelectionMode.MULTIPLE)

--- a/quodlibet/quodlibet/qltk/songlist.py
+++ b/quodlibet/quodlibet/qltk/songlist.py
@@ -78,6 +78,11 @@ class SongSelectionInfo(GObject.Object):
         if self.__idle:
             GLib.source_remove(self.__idle)
 
+    def refresh(self):
+        songlist = self.__songlist
+        songs = songlist.get_selected_songs() or songlist.get_songs()
+        self.emit('changed', songs)
+
     def _update_songs(self, songs):
         """After making changes (filling the list) call this to
         skip any queued changes and emit the passed songs instead"""

--- a/quodlibet/quodlibet/util/__init__.py
+++ b/quodlibet/quodlibet/util/__init__.py
@@ -1,11 +1,12 @@
 # -*- coding: utf-8 -*-
 # Copyright 2004-2009 Joe Wreschnig, Michael Urman, Steven Robertson
-#           2011,2013 Nick Boultbee
+#           2011-2016 Nick Boultbee
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as
 # published by the Free Software Foundation
 
+import locale
 import os
 import random
 import re
@@ -388,6 +389,11 @@ def format_time_display(time):
     return format_time(time).replace(":", u"\u2236")
 
 
+def format_time_seconds(time):
+    time_str = locale.format("%d", time, grouping=True)
+    return ngettext("%s second", "%s seconds", time) % time_str
+
+
 def format_time_long(time, limit=2):
     """Turn a time value in seconds into x hours, x minutes, etc.
 
@@ -428,8 +434,15 @@ def format_time_preferred(t, fmt=None):
     """Returns duration formatted to user's preference"""
     from quodlibet.config import DurationFormat, DURATION
     fmt = fmt or DURATION.format
-    return (format_time_long(t) if fmt == DurationFormat.LONG
-            else format_time_display(t))
+
+    if fmt == DurationFormat.STANDARD:
+        return format_time_long(t, 2)
+    elif fmt == DurationFormat.NUMERIC:
+        return format_time_display(t)
+    elif fmt == DurationFormat.FULL:
+        return format_time_long(t, 5)
+    else:
+        return format_time_seconds(t)
 
 
 def capitalize(str):

--- a/quodlibet/quodlibet/util/__init__.py
+++ b/quodlibet/quodlibet/util/__init__.py
@@ -424,6 +424,14 @@ def format_time_long(time, limit=2):
     return ", ".join(time_str)
 
 
+def format_time_preferred(t, fmt=None):
+    """Returns duration formatted to user's preference"""
+    from quodlibet.config import DurationFormat, DURATION
+    fmt = fmt or DURATION.format
+    return (format_time_long(t) if fmt == DurationFormat.LONG
+            else format_time_display(t))
+
+
 def capitalize(str):
     """Capitalize a string, not affecting any character after the first."""
     return str[:1].upper() + str[1:]

--- a/quodlibet/tests/test_util.py
+++ b/quodlibet/tests/test_util.py
@@ -627,7 +627,6 @@ class TFormatTimePreferred(TestCase):
         while x < 100000000:
             s.assertEquals(f(x), f2(x))
             x = x * 3 / 2 + 1
-            print ("%s = %s" % (x, f(x)))
 
     def test_acts_like_display(s):
         def fmt_numeric(x):

--- a/quodlibet/tests/test_util.py
+++ b/quodlibet/tests/test_util.py
@@ -12,11 +12,12 @@ import traceback
 import time
 
 from quodlibet.compat import text_type, PY2
-from quodlibet.config import HardCodedRatingsPrefs
+from quodlibet.config import HardCodedRatingsPrefs, DurationFormat
 from quodlibet import config
 from quodlibet import util
 from quodlibet.util.dprint import print_exc, format_exception, extract_tb
-from quodlibet.util import format_time_long as f_t_l
+from quodlibet.util import format_time_long as f_t_l, format_time_preferred, \
+    format_time_display
 from quodlibet.util import re_escape
 from quodlibet.util.library import set_scan_dirs, get_scan_dirs
 from quodlibet.util.path import is_fsnative, fsnative2glib, glib2fsnative, \
@@ -611,6 +612,26 @@ class Tformat_time_long(TestCase):
 
     def test_limit(s):
         s.assertEquals(len(f_t_l(2 ** 31).split(", ")), 2)
+
+
+class TFormatTimePreferred(TestCase):
+
+    def test_default_setting_is_long(s):
+        s.assertEquals(config.DURATION.format, DurationFormat.LONG)
+
+    def test_acts_like_long(s):
+        s._fuzz_loop(format_time_preferred, f_t_l)
+
+    def _fuzz_loop(s, f, f2):
+        x = 1
+        while x < 100000000:
+            s.assertEquals(f(x), f2(x))
+            x = x * 3 / 2 + 1
+            print ("%s = %s" % (x, f(x)))
+
+    def test_acts_like_display(s):
+        s._fuzz_loop(lambda x: format_time_preferred(x, DurationFormat.SHORT),
+                     format_time_display)
 
 
 class Tspawn(TestCase):

--- a/quodlibet/tests/test_util.py
+++ b/quodlibet/tests/test_util.py
@@ -17,7 +17,7 @@ from quodlibet import config
 from quodlibet import util
 from quodlibet.util.dprint import print_exc, format_exception, extract_tb
 from quodlibet.util import format_time_long as f_t_l, format_time_preferred, \
-    format_time_display
+    format_time_display, format_time_seconds
 from quodlibet.util import re_escape
 from quodlibet.util.library import set_scan_dirs, get_scan_dirs
 from quodlibet.util.path import is_fsnative, fsnative2glib, glib2fsnative, \
@@ -617,7 +617,7 @@ class Tformat_time_long(TestCase):
 class TFormatTimePreferred(TestCase):
 
     def test_default_setting_is_long(s):
-        s.assertEquals(config.DURATION.format, DurationFormat.LONG)
+        s.assertEquals(config.DURATION.format, DurationFormat.STANDARD)
 
     def test_acts_like_long(s):
         s._fuzz_loop(format_time_preferred, f_t_l)
@@ -630,8 +630,14 @@ class TFormatTimePreferred(TestCase):
             print ("%s = %s" % (x, f(x)))
 
     def test_acts_like_display(s):
-        s._fuzz_loop(lambda x: format_time_preferred(x, DurationFormat.SHORT),
-                     format_time_display)
+        def fmt_numeric(x):
+            return format_time_preferred(x, DurationFormat.NUMERIC)
+        s._fuzz_loop(fmt_numeric, format_time_display)
+
+    def test_seconds(s):
+        def fmt_seconds(x):
+            return format_time_preferred(x, DurationFormat.SECONDS)
+        s._fuzz_loop(fmt_seconds, format_time_seconds)
 
 
 class Tspawn(TestCase):

--- a/quodlibet/tests/test_util.py
+++ b/quodlibet/tests/test_util.py
@@ -616,8 +616,12 @@ class Tformat_time_long(TestCase):
 
 class TFormatTimePreferred(TestCase):
 
-    def test_default_setting_is_long(s):
+    def test_default_setting_is_standard(s):
         s.assertEquals(config.DURATION.format, DurationFormat.STANDARD)
+
+    def test_raw_config_is_standard(s):
+        s.assertEquals(config.get('display', 'duration_format'),
+                       DurationFormat.STANDARD)
 
     def test_acts_like_long(s):
         s._fuzz_loop(format_time_preferred, f_t_l)


### PR DESCRIPTION
Add configurable (by new preferences widget) display of durations around the app, notably in the Queue, the songlist (selection) info area (i.e. bottom right), and the Information window(s).

Fixes #1727, #1967.