### PR TITLE
Fix error when query divides by 0

### DIFF
--- a/quodlibet/quodlibet/query/_match.py
+++ b/quodlibet/quodlibet/query/_match.py
@@ -318,7 +318,10 @@ class NumexprBinary(Numexpr):
         val = self.__expr.evaluate(data, time, use_date)
         val2 = self.__expr2.evaluate(data, time, use_date)
         if val is not None and val2 is not None:
-            return self.__op(val, val2)
+            try:
+                return self.__op(val, val2)
+            except ZeroDivisionError:
+                return val * float('inf')
         return None
 
     def __repr__(self):

--- a/quodlibet/tests/test_query.py
+++ b/quodlibet/tests/test_query.py
@@ -424,6 +424,7 @@ class TQuery(TestCase):
         self.failUnless(Query("#(40 seconds < length/5 < 1 minute)")
                         .search(self.s1))
         self.failUnless(Query("#(2+3 * 5 = 17)").search(self.s1))
+        self.failUnless(Query("#(playcount / 0 > 0)").search(self.s1))
 
         self.failIf(Query("#(track + 1 != 13)").search(self.s2))
 


### PR DESCRIPTION
Minor bug fix so that queries like `#(tag1 / tag2 > tag3)` won't throw an exception if `tag2` is equal to 0. The value of the division by 0 expression is now ±infinify (depending on the sign of the divident) so that ratios like `#(playcount / skipcount > 3)` will work the same as `#(playcount > 3*skipcount)` even when `skipcount` is 0.