### PR TITLE
Play order updates

### DIFF
--- a/quodlibet/quodlibet/cli.py
+++ b/quodlibet/quodlibet/cli.py
@@ -75,8 +75,8 @@ def process_arguments(argv):
     controls = ["next", "previous", "play", "pause", "play-pause", "stop",
                 "hide-window", "show-window", "toggle-window",
                 "focus", "quit", "unfilter", "refresh", "force-previous"]
-    controls_opt = ["seek", "order", "repeat", "query", "volume", "filter",
-                    "set-rating", "set-browser", "open-browser", "random",
+    controls_opt = ["seek", "repeat", "query", "volume", "filter",
+                    "set-rating", "set-browser", "open-browser", "shuffle",
                     "song-list", "queue", "stop-after"]
 
     options = util.OptionParser(
@@ -117,8 +117,7 @@ def process_arguments(argv):
 
     for opt, help, arg in [
         ("seek", _("Seek within the playing song"), _("[+|-][HH:]MM:SS")),
-        ("order", _("Set or toggle the playback order"),
-            "[order]|toggle"),
+        ("shuffle", _("Set or toggle shuffle mode"), "[0|1|t"),
         ("repeat", _("Turn repeat off, on, or toggle it"), "0|1|t"),
         ("volume", _("Set the volume"), "(+|-|)0..100"),
         ("query", _("Search your audio library"), _("query")),
@@ -174,8 +173,7 @@ def process_arguments(argv):
             return True
 
     validators = {
-        "order": ["0", "1", "t", "toggle", "inorder", "shuffle",
-                  "weighted", "onesong"].__contains__,
+        "shuffle": ["0", "1", "t", "on", "off", "toggle"].__contains__,
         "repeat": ["0", "1", "t", "on", "off", "toggle"].__contains__,
         "volume": is_vol,
         "seek": is_time,

--- a/quodlibet/quodlibet/commands.py
+++ b/quodlibet/quodlibet/commands.py
@@ -163,7 +163,7 @@ def _order(app, value):
     order = app.window.order
 
     if value in ["t", "toggle"]:
-        order.set_shuffle(not order.get_shuffle())
+        order.shuffled = not order.shuffled
         return
 
     try:
@@ -192,11 +192,11 @@ def _stop_after(app, value):
 def _repeat(app, value):
     repeat = app.window.repeat
     if value in ["0", "off"]:
-        repeat.set_active(False)
+        repeat.enabled = False
     elif value in ["1", "on"]:
-        repeat.set_active(True)
+        repeat.enabled = True
     elif value in ["t", "toggle"]:
-        repeat.set_active(not repeat.get_active())
+        repeat.enabled = not repeat.enabled
 
 
 @registry.register("seek", args=1)
@@ -393,7 +393,7 @@ def _status(app):
     strings.append(type(app.browser).__name__)
     strings.append("%0.3f" % player.volume)
     strings.append(window.order.get_active_name())
-    strings.append((window.repeat.get_active() and "on") or "off")
+    strings.append("on" if window.repeat.enabled else "off")
     progress = 0
     if player.info:
         length = player.info.get("~#length", 0)

--- a/quodlibet/quodlibet/commands.py
+++ b/quodlibet/quodlibet/commands.py
@@ -158,23 +158,6 @@ def _volume(app, value):
     app.player.volume = min(1.0, max(0.0, volume))
 
 
-@registry.register("order", args=1)
-def _order(app, value):
-    order = app.window.order
-
-    if value in ["t", "toggle"]:
-        order.shuffled = not order.shuffled
-        return
-
-    try:
-        order.set_active_by_name(value.lower())
-    except ValueError:
-        try:
-            order.set_active_by_index(int(value))
-        except (ValueError, IndexError):
-            pass
-
-
 @registry.register("stop-after", args=1)
 def _stop_after(app, value):
     po = app.player_options
@@ -188,15 +171,27 @@ def _stop_after(app, value):
         raise CommandError("Invalid value %r" % value)
 
 
+@registry.register("shuffle", args=1)
+def _shuffle(app, value):
+    po = app.player_options
+    if value in ["0", "off"]:
+        po.shuffle = False
+    elif value in ["1", "on"]:
+        po.shuffle = True
+    elif value in ["t", "toggle"]:
+        po.shuffle = not po.shuffle
+
+
 @registry.register("repeat", args=1)
 def _repeat(app, value):
-    repeat = app.window.repeat
+    po = app.player_options
     if value in ["0", "off"]:
-        repeat.enabled = False
+        po.repeat = False
     elif value in ["1", "on"]:
-        repeat.enabled = True
+        print_d("Enabling repeat")
+        po.repeat = True
     elif value in ["t", "toggle"]:
-        repeat.enabled = not repeat.enabled
+        po.repeat = not po.repeat
 
 
 @registry.register("seek", args=1)

--- a/quodlibet/quodlibet/config.py
+++ b/quodlibet/quodlibet/config.py
@@ -48,9 +48,16 @@ INITIAL = {
         "queue_expanded": "false", # on or off
         "shufflequeue": "false", # on or off
         "sortby": "0album", # <reversed?>tagname, song list sort
-        "order": "inorder",
-        "order_shuffle": "shuffle",
+
+        # Repeat on or off
+        "repeat": "false",
+        # The Repeat (Order) to use
+        "repeat_mode": "repeat_song",
+
+        # Shuffle on or off
         "shuffle": "false",
+        # The Shuffle (Order) to use
+        "shuffle_mode": "random",
         "plugin_selection": "", # selected plugin in manager
         "column_widths": "", # column widths in c1,w1,c2,w2... format
         "column_expands": "",
@@ -97,9 +104,6 @@ INITIAL = {
 
         # rating symbol (hollow star)
         "rating_symbol_blank": "\xe2\x98\x86",
-
-        # probably belongs in memory
-        "repeat": "false",
 
         # Now deprecated: space-separated headers column
         #"headers": " ".join(const.DEFAULT_COLUMNS),

--- a/quodlibet/quodlibet/ext/events/mpdserver/main.py
+++ b/quodlibet/quodlibet/ext/events/mpdserver/main.py
@@ -727,7 +727,7 @@ def _cmd_repeat(conn, service, args):
 def _cmd_random(conn, service, args):
     _verify_length(args, 1)
     value = _parse_bool(args[0])
-    service.shuffle(value)
+    service.random(value)
 
 
 @MPDConnection.Command("single")

--- a/quodlibet/quodlibet/ext/events/mpdserver/main.py
+++ b/quodlibet/quodlibet/ext/events/mpdserver/main.py
@@ -152,7 +152,7 @@ class MPDService(object):
         def options_changed(*args):
             self.emit_changed("options")
 
-        self._options.connect("notify::random", options_changed)
+        self._options.connect("notify::shuffle", options_changed)
         self._options.connect("notify::repeat", options_changed)
         self._options.connect("notify::single", options_changed)
 

--- a/quodlibet/quodlibet/ext/events/mpdserver/main.py
+++ b/quodlibet/quodlibet/ext/events/mpdserver/main.py
@@ -287,7 +287,7 @@ class MPDService(object):
         self._options.repeat = value
 
     def random(self, value):
-        self._options.random = value
+        self._options.shuffle = value
 
     def single(self, value):
         self._options.single = value
@@ -321,7 +321,7 @@ class MPDService(object):
         status = [
             ("volume", int((app.player.volume ** (1.0 / 3.0)) * 100)),
             ("repeat", int(self._options.repeat)),
-            ("random", int(self._options.random)),
+            ("random", int(self._options.shuffle)),
             ("single", int(self._options.single)),
             ("consume", 0),
             ("playlist", self._pl_ver),
@@ -727,7 +727,7 @@ def _cmd_repeat(conn, service, args):
 def _cmd_random(conn, service, args):
     _verify_length(args, 1)
     value = _parse_bool(args[0])
-    service.random(value)
+    service.shuffle(value)
 
 
 @MPDConnection.Command("single")

--- a/quodlibet/quodlibet/ext/events/mpris/mpris1.py
+++ b/quodlibet/quodlibet/ext/events/mpris/mpris1.py
@@ -90,11 +90,10 @@ class MPRIS1Player(MPRISObject):
         super(MPRIS1Player, self).__init__(name, self.PATH)
 
         player_options = app.player_options
-        # FIXME: this
         self.__sigs = [
             player_options.connect("notify::repeat", self.__update_status),
             player_options.connect("notify::single", self.__update_status),
-            player_options.connect("notify::random", self.__update_status),
+            player_options.connect("notify::shuffle", self.__update_status),
         ]
 
         self.__lsig = app.librarian.connect(

--- a/quodlibet/quodlibet/ext/events/mpris/mpris1.py
+++ b/quodlibet/quodlibet/ext/events/mpris/mpris1.py
@@ -90,6 +90,7 @@ class MPRIS1Player(MPRISObject):
         super(MPRIS1Player, self).__init__(name, self.PATH)
 
         player_options = app.player_options
+        # FIXME: this
         self.__sigs = [
             player_options.connect("notify::repeat", self.__update_status),
             player_options.connect("notify::single", self.__update_status),

--- a/quodlibet/quodlibet/ext/events/mpris/mpris1.py
+++ b/quodlibet/quodlibet/ext/events/mpris/mpris1.py
@@ -76,7 +76,7 @@ class MPRIS1DummyTracklist(MPRISObject):
 
     @dbus.service.method(IFACE, in_signature="b")
     def SetRandom(self, value):
-        app.player_options.random = value
+        app.player_options.shuffle = value
 
 
 class MPRIS1Player(MPRISObject):
@@ -190,7 +190,7 @@ class MPRIS1Player(MPRISObject):
             play = 0 if not app.player.paused else 1
         else:
             play = 2
-        shuffle = app.player_options.random
+        shuffle = app.player_options.shuffle
         repeat_one = app.player_options.single
         repeat_all = app.player_options.repeat
 

--- a/quodlibet/quodlibet/ext/events/mpris/mpris2.py
+++ b/quodlibet/quodlibet/ext/events/mpris/mpris2.py
@@ -317,7 +317,7 @@ value="false"/>
             elif name == "Rate":
                 pass
             elif name == "Shuffle":
-                player_options.random = value
+                player_options.shuffle = value
             elif name == "Volume":
                 player.volume = value
 
@@ -362,7 +362,7 @@ value="false"/>
             elif name == "Rate":
                 return 1.0
             elif name == "Shuffle":
-                return player_options.random
+                return player_options.shuffle
             elif name == "Metadata":
                 return self.__get_metadata()
             elif name == "Volume":

--- a/quodlibet/quodlibet/ext/events/mpris/mpris2.py
+++ b/quodlibet/quodlibet/ext/events/mpris/mpris2.py
@@ -108,7 +108,7 @@ value="false"/>
         self.__repeat_id = player_options.connect(
             "notify::repeat", self.__repeat_changed)
         self.__random_id = player_options.connect(
-            "notify::random", self.__random_changed)
+            "notify::shuffle", self.__shuffle_changed)
         self.__single_id = player_options.connect(
             "notify::single", self.__single_changed)
 
@@ -135,9 +135,8 @@ value="false"/>
     def __repeat_changed(self, *args):
         self.emit_properties_changed(self.PLAYER_IFACE, ["LoopStatus"])
 
-    def __random_changed(self, *args):
-        self.emit_properties_changed(self.PLAYER_IFACE,
-                                     ["Shuffle", "LoopStatus"])
+    def __shuffle_changed(self, *args):
+        self.emit_properties_changed(self.PLAYER_IFACE, ["Shuffle"])
 
     def __single_changed(self, *args):
         self.emit_properties_changed(self.PLAYER_IFACE, ["LoopStatus"])

--- a/quodlibet/quodlibet/ext/events/randomalbum.py
+++ b/quodlibet/quodlibet/ext/events/randomalbum.py
@@ -160,8 +160,8 @@ class RandomAlbum(EventPlugin):
         return [(score, name) for name, score in scores.items()]
 
     def plugin_on_song_started(self, song):
-        if (song is None and config.get("memory", "order") != "onesong" and
-            not app.player.paused):
+        one_song = config.get("memory", "repeat") != "one_song"
+        if song is None and one_song and not app.player.paused:
             browser = app.window.browser
 
             if not browser.can_filter('album'):

--- a/quodlibet/quodlibet/ext/events/randomalbum.py
+++ b/quodlibet/quodlibet/ext/events/randomalbum.py
@@ -160,7 +160,7 @@ class RandomAlbum(EventPlugin):
         return [(score, name) for name, score in scores.items()]
 
     def plugin_on_song_started(self, song):
-        one_song = config.get("memory", "repeat") != "one_song"
+        one_song = app.player_options.single
         if song is None and one_song and not app.player.paused:
             browser = app.window.browser
 

--- a/quodlibet/quodlibet/ext/events/trayicon/menu.py
+++ b/quodlibet/quodlibet/ext/events/trayicon/menu.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Copyright 2004-2009 Joe Wreschnig, Michael Urman, Steven Robertson
-#           2011,2013 Nick Boultbee
+#      2011,2013,2016 Nick Boultbee
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as
@@ -73,9 +73,9 @@ class IndicatorMenu(Gtk.Menu):
         player_options = app.player_options
 
         shuffle = Gtk.CheckMenuItem(label=_("_Shuffle"), use_underline=True)
-        player_options.bind_property("random", shuffle, "active",
+        player_options.bind_property("shuffle", shuffle, "active",
                                      GObject.BindingFlags.BIDIRECTIONAL)
-        player_options.notify("random")
+        player_options.notify("shuffle")
 
         repeat = Gtk.CheckMenuItem(label=_("_Repeat"), use_underline=True)
         player_options.bind_property("repeat", repeat, "active",

--- a/quodlibet/quodlibet/ext/playorder/follow.py
+++ b/quodlibet/quodlibet/ext/playorder/follow.py
@@ -6,25 +6,25 @@
 # it under the terms of the GNU General Public License version 2 as
 # published by the Free Software Foundation.
 
-from quodlibet.plugins.playorder import PlayOrderPlugin, \
-    PlayOrderRememberedMixin, PlayOrderInOrderMixin
+from quodlibet.plugins.playorder import ShufflePlugin
+from quodlibet.qltk.playorder import OrderInOrder, OrderRemembered
 
 from quodlibet import app
 from quodlibet.qltk import Icons
 
 
-class FollowOrder(PlayOrderPlugin, PlayOrderRememberedMixin,
-    PlayOrderInOrderMixin):
+class FollowOrder(ShufflePlugin, OrderInOrder, OrderRemembered):
     PLUGIN_ID = "follow"
     PLUGIN_NAME = _("Follow Cursor")
     PLUGIN_ICON = Icons.GO_JUMP
-    PLUGIN_DESC = _("Playback follows your selection.")
+    PLUGIN_DESC = _("Playback follows your selection, "
+                    "or the next song in the list once exhausted.")
 
     __last_path = None
 
     def next(self, playlist, iter):
-        next_fallback = PlayOrderInOrderMixin.next(self, playlist, iter)
-        PlayOrderRememberedMixin.next(self, playlist, iter)
+        next_fallback = OrderInOrder.next(self, playlist, iter)
+        OrderRemembered.next(self, playlist, iter)
 
         selected = app.window.songlist.get_selected_songs()
         if not selected:

--- a/quodlibet/quodlibet/ext/playorder/playcounteq.py
+++ b/quodlibet/quodlibet/ext/playorder/playcounteq.py
@@ -9,15 +9,18 @@
 import math
 import random
 
-from quodlibet.plugins.playorder import PlayOrderPlugin, PlayOrderShuffleMixin
+from quodlibet.qltk.playorder import OrderRemembered
+
+from quodlibet.plugins.playorder import ShufflePlugin
 from quodlibet.qltk import Icons
 
 
-class PlaycountEqualizer(PlayOrderPlugin, PlayOrderShuffleMixin):
+class PlaycountEqualizer(ShufflePlugin, OrderRemembered):
     PLUGIN_ID = "playcounteq"
     PLUGIN_NAME = _("Playcount Equalizer")
     PLUGIN_DESC = _("Shuffle, preferring songs with fewer total plays.")
-    PLUGIN_ICON = Icons.VIEW_REFRESH
+    PLUGIN_ICON = Icons.MEDIA_PLAYLIST_SHUFFLE
+    display_name = "Prefer less played"
 
     # Select the next track.
     def next(self, playlist, current):

--- a/quodlibet/quodlibet/ext/playorder/queue.py
+++ b/quodlibet/quodlibet/ext/playorder/queue.py
@@ -1,17 +1,19 @@
 # -*- coding: utf-8 -*-
 # Copyright 2009 Steven Robertson
+#           2016 Nick Boultbee
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as
 # published by the Free Software Foundation.
 
-from quodlibet.plugins.playorder import PlayOrderPlugin, PlayOrderInOrderMixin
+from quodlibet.plugins.playorder import ShufflePlugin
+from quodlibet.qltk.playorder import OrderInOrder
 
 from quodlibet import app
 from quodlibet.qltk import Icons
 
 
-class QueueOrder(PlayOrderPlugin, PlayOrderInOrderMixin):
+class QueueOrder(ShufflePlugin, OrderInOrder):
     PLUGIN_ID = "queue"
     PLUGIN_NAME = _("Queue Only")
     PLUGIN_ICON = Icons.MEDIA_SKIP_FORWARD

--- a/quodlibet/quodlibet/ext/playorder/reverse.py
+++ b/quodlibet/quodlibet/ext/playorder/reverse.py
@@ -3,11 +3,12 @@
 # it under the terms of the GNU General Public License version 2 as
 # published by the Free Software Foundation
 
+from quodlibet.plugins.playorder import ShufflePlugin
 from quodlibet.qltk import Icons
-from quodlibet.plugins.playorder import PlayOrderPlugin, PlayOrderInOrderMixin
+from quodlibet.qltk.playorder import OrderInOrder
 
 
-class ReverseOrder(PlayOrderPlugin, PlayOrderInOrderMixin):
+class ReverseOrder(ShufflePlugin, OrderInOrder):
     PLUGIN_ID = "reverse"
     PLUGIN_NAME = _("Reverse")
     PLUGIN_ICON = Icons.MEDIA_SKIP_BACKWARD

--- a/quodlibet/quodlibet/ext/playorder/track_repeat.py
+++ b/quodlibet/quodlibet/ext/playorder/track_repeat.py
@@ -10,21 +10,20 @@ Repeats a given track a configurable number of times
 Useful for musicians practising / working out songs...
 or maybe you just REALLY like your playlist.
 
-TODO: notification of play count? Non-shuffle? Integration with main UI?
+TODO: notification of play count?
 """
 
 from gi.repository import Gtk
 
-from quodlibet.plugins.playorder import PlayOrderPlugin, PlayOrderShuffleMixin
+from quodlibet.plugins.playorder import RepeatPlugin
 from quodlibet.util.dprint import print_d
 from quodlibet.plugins import PluginConfigMixin
 from quodlibet.qltk import Icons
 
 
-class TrackRepeatOrder(PlayOrderPlugin,
-                       PlayOrderShuffleMixin, PluginConfigMixin):
+class TrackRepeatOrder(RepeatPlugin, PluginConfigMixin):
     PLUGIN_ID = "track_repeat"
-    PLUGIN_NAME = _("Track Repeat")
+    PLUGIN_NAME = _("Repeat Each Track")
     PLUGIN_ICON = Icons.MEDIA_PLAYLIST_REPEAT
     PLUGIN_DESC = _("Shuffle songs, "
                     "but repeat every track a set number of times.")
@@ -70,13 +69,10 @@ class TrackRepeatOrder(PlayOrderPlugin,
         self.restart_counting()
         return super(TrackRepeatOrder, self).next(*args)
 
-    def previous(self, *args):
-        return super(TrackRepeatOrder, self).previous(*args)
-
     def set(self, playlist, iter):
         self.restart_counting()
         return super(TrackRepeatOrder, self).set(playlist, iter)
 
     def reset(self, playlist):
-        super(TrackRepeatOrder, self).reset(playlist)
         self.play_count = 0
+        return super(TrackRepeatOrder, self).reset(playlist)

--- a/quodlibet/quodlibet/plugins/playorder.py
+++ b/quodlibet/quodlibet/plugins/playorder.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 # Copyright 2007 Joe Wreschnig
+#           2016 Nick Boultbee
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as
@@ -62,9 +63,14 @@ class PlayOrderPlugin(quodlibet.qltk.playorder.Order):
 
 
 class RepeatPlugin(PlayOrderPlugin, quodlibet.qltk.playorder.Repeat):
+    """Repeat plugins add new ways to repeat an existing,
+    possibly shuffled playlist.
+
+    Note that they must delegate to the underlying `Order` (typically a
+     `Reorder`) in order for the UI to function as intended"""
     pass
 
 
 class ShufflePlugin(PlayOrderPlugin, quodlibet.qltk.playorder.Reorder):
+    """Shuffle plugins add new ways to reorder a given song list"""
     pass
-

--- a/quodlibet/quodlibet/plugins/playorder.py
+++ b/quodlibet/quodlibet/plugins/playorder.py
@@ -61,22 +61,10 @@ class PlayOrderPlugin(quodlibet.qltk.playorder.Order):
     priority = quodlibet.qltk.playorder.Order.priority
 
 
-class PlayOrderRememberedMixin(quodlibet.qltk.playorder.OrderRemembered):
-    name = None
-    display_name = None
-    accelerated_name = None
-    priority = quodlibet.qltk.playorder.Order.priority
+class RepeatPlugin(PlayOrderPlugin, quodlibet.qltk.playorder.Repeat):
+    pass
 
 
-class PlayOrderInOrderMixin(quodlibet.qltk.playorder.OrderInOrder):
-    name = None
-    display_name = None
-    accelerated_name = None
-    priority = quodlibet.qltk.playorder.Order.priority
+class ShufflePlugin(PlayOrderPlugin, quodlibet.qltk.playorder.Reorder):
+    pass
 
-
-class PlayOrderShuffleMixin(quodlibet.qltk.playorder.OrderShuffle):
-    name = None
-    display_name = None
-    accelerated_name = None
-    priority = quodlibet.qltk.playorder.Order.priority

--- a/quodlibet/quodlibet/qltk/__init__.py
+++ b/quodlibet/quodlibet/qltk/__init__.py
@@ -270,6 +270,11 @@ def add_css(widget, css):
     context.add_provider(provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION)
 
 
+def remove_padding(widget):
+    """Removes padding on supplied widget"""
+    return add_css(widget, " * { padding: 0px; } ")
+
+
 def is_wayland():
     # FIXME: Is there no better way?
     display = Gdk.Display.get_default()

--- a/quodlibet/quodlibet/qltk/playorder.py
+++ b/quodlibet/quodlibet/qltk/playorder.py
@@ -429,7 +429,7 @@ class ToggledPlayOrderMenu(Gtk.Box):
                 label=order.accelerated_name,
                 use_underline=True,
                 group=group)
-            group.set_active(order.name == self.__current)
+            group.set_active(order == self.__current)
             group.connect("toggled", toggled_cb, order)
             menu.append(group)
         menu.show_all()

--- a/quodlibet/quodlibet/qltk/playorder.py
+++ b/quodlibet/quodlibet/qltk/playorder.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 # Copyright 2006 Joe Wreschnig
+#           2016 Nick Boultbee
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as
@@ -11,8 +12,10 @@ from gi.repository import Gtk, GObject
 
 from quodlibet import config
 from quodlibet import qltk
+from quodlibet.qltk import Icons
 from quodlibet.qltk.x import SymbolicIconImage, RadioMenuItem
-from quodlibet.plugins import PluginManager, PluginHandler
+from quodlibet.plugins import PluginManager
+from quodlibet.util.dprint import print_w, print_d
 
 
 class Order(object):
@@ -23,54 +26,108 @@ class Order(object):
     is_shuffle = False
     priority = 100
 
-    def __init__(self, playlist):
-        self.playlist = playlist
+    def __init__(self):
+        """Must have a zero-arg constructor"""
+        pass
 
-    # Not called directly, but the default implementation of
-    # next_explicit and next_implicit both just call this.
     def next(self, playlist, iter):
+        """Not called directly, but the default implementation of
+        `next_explicit` and `next_implicit` both just call this. """
         raise NotImplementedError
 
-    # Not called directly, but the default implementation of
-    # previous_explicit calls this. Right now there is no such thing
-    # as previous_implicit.
     def previous(self, playlist, iter):
+        """Not called directly, but the default implementation of
+        `previous_explicit` calls this.
+        Right now there is no such thing as `previous_implicit`."""
         raise NotImplementedError
 
-    # Not called directly, but the default implementations of
-    # set_explicit and set_implicit call this.
     def set(self, playlist, iter):
+        """Not called directly, but the default implementations of
+        `set_explicit` and `set_implicit` call this. """
         return iter
 
-    # Called when the user presses a "Next" button.
     def next_explicit(self, playlist, iter):
+        """Not called directly, but the default implementations of
+       `set_explicit` and `set_implicit` call this."""
         return self.next(playlist, iter)
 
-    # Called when a song ends passively, e.g. it plays through.
     def next_implicit(self, playlist, iter):
+        """Called when a song ends passively, e.g. it plays through."""
         return self.next(playlist, iter)
 
-    # Called when the user presses a "Previous" button.
     def previous_explicit(self, playlist, iter):
+        """Called when the user presses a "Previous" button."""
         return self.previous(playlist, iter)
 
-    # Called when the user manually selects a song (at iter).
-    # If desired the play order can override that, or just
-    # log it and return the iter again. If the play order returns
-    # None, no action will be taken by the player.
     def set_explicit(self, playlist, iter):
+        """Called when the user manually selects a song (at `iter`).
+        If desired the play order can override that, or just
+        log it and return the iter again.
+
+        If the play order returns `None`,
+        no action will be taken by the player."""
         return self.set(playlist, iter)
 
-    # Called when the song is set by a means other than the UI.
     def set_implicit(self, playlist, iter):
+        """Called when the song is set by a means other than the UI."""
         return self.set(playlist, iter)
 
     def reset(self, playlist):
+        """Called when there is no song ready to prepare for a new order.
+        Implementations should reset the state of the current order,
+        e.g. forgetting history / clearing pre-cached orders."""
         pass
+
+    def __str__(self):
+        """By default there is no interesting state"""
+        return "<%s>" % self.display_name
+
+
+class Reorder(Order):
+    """Marker for all Orders that potentially reorder the playlist,
+    and thus usually identify as a "shuffle" implementation."""
+    pass
+
+
+class Repeat(Order):
+    """How to repeat.
+    The implementation is essentially a delegate pattern,
+    though."""
+        
+    def __init__(self, wrapped):
+        super(Repeat, self).__init__()
+        assert isinstance(wrapped, Order)
+        self.wrapped = wrapped
+
+    def set(self, playlist, iter):
+        return self.wrapped.set(playlist, iter)
+
+    def next(self, playlist, iter):
+        """Override this"""
+        return self.wrapped.next(playlist, iter)
+
+    def previous(self, playlist, iter):
+        return self.wrapped.previous(playlist, iter)
+
+    def reset(self, playlist):
+        return self.wrapped.reset(playlist)
+
+    def __str__(self):
+        return "<%s ∘ %s>" % (self.display_name, self.wrapped.display_name)
+
+
+class RepeatSongForever(Repeat):
+    name = "repeat_song"
+    display_name = _("Repeat this track forever")
+    accelerated_name = _("Repeat this track forever")
+
+    def next(self, playlist, iter):
+        return iter
 
 
 class OrderInOrder(Order):
-    name = "inorder"
+    """Keep to the order of the supplied playlist"""
+    name = "in_order"
     display_name = _("In Order")
     accelerated_name = _("_In Order")
     replaygain_profiles = ["album", "track"]
@@ -80,10 +137,7 @@ class OrderInOrder(Order):
         if iter is None:
             return playlist.get_iter_first()
         else:
-            next = playlist.iter_next(iter)
-            if next is None and playlist.repeat:
-                next = playlist.get_iter_first()
-            return next
+            return playlist.iter_next(iter)
 
     def previous(self, playlist, iter):
         if len(playlist) == 0:
@@ -95,17 +149,15 @@ class OrderInOrder(Order):
             try:
                 return playlist.get_iter((path - 1,))
             except ValueError:
-                if playlist.repeat:
-                    return playlist[(len(playlist) - 1,)].iter
-        return None
+                return None
 
 
 class OrderRemembered(Order):
-    # Shared class for all the shuffle modes that keep a memory
-    # of their previously played songs.
+    """Shared class for all the shuffle modes that keep a memory
+    of their previously played songs."""
 
-    def __init__(self, playlist):
-        super(OrderRemembered, self).__init__(playlist)
+    def __init__(self):
+        super(OrderRemembered, self).__init__()
         self._played = []
 
     def next(self, playlist, iter):
@@ -129,10 +181,10 @@ class OrderRemembered(Order):
         del(self._played[:])
 
 
-class OrderShuffle(OrderRemembered):
-    name = "shuffle"
-    display_name = _("Shuffle")
-    accelerated_name = _("_Shuffle")
+class OrderShuffle(Reorder, OrderRemembered):
+    name = "random"
+    display_name = _("Random")
+    accelerated_name = _("_Random")
     is_shuffle = True
     priority = 1
 
@@ -144,18 +196,13 @@ class OrderShuffle(OrderRemembered):
 
         if remaining:
             return playlist.get_iter((random.choice(list(remaining)),))
-        elif playlist.repeat and not playlist.is_empty():
-            del(self._played[:])
-            return playlist.get_iter((random.choice(list(songs)),))
-        else:
-            del(self._played[:])
-            return None
+        return None
 
 
-class OrderWeighted(OrderRemembered):
+class OrderWeighted(Reorder, OrderRemembered):
     name = "weighted"
-    display_name = _("Weighted")
-    accelerated_name = _("_Weighted")
+    display_name = _("Prefer higher rated")
+    accelerated_name = _("Prefer higher rated")
     is_shuffle = True
     priority = 2
 
@@ -173,100 +220,215 @@ class OrderWeighted(OrderRemembered):
             return playlist.get_iter_first()
 
 
-class OrderOneSong(OrderInOrder):
-    name = "onesong"
-    display_name = _("One Song")
-    accelerated_name = _("_One Song")
-    priority = 3
+class Orders(GObject.Object):
+    """
+    A minimal list-like container for Order objects
+    that signals on changes
+    """
 
-    def next_implicit(self, playlist, iter):
-        if playlist.repeat:
-            return iter
-        else:
+    __gsignals__ = {
+        'updated': (GObject.SignalFlags.RUN_LAST, None, ()),
+    }
+
+    def __init__(self, initial=None):
+        super(Orders, self).__init__()
+        self.items = initial or []
+
+    def by_name(self, name):
+        if not name:
             return None
+        for cls in self.items:
+            if cls.name == name:
+                return cls
+        return None
 
-ORDERS = []
+    def __getitem__(self, y):
+        return self.items.__getitem__(y)
+
+    def __len__(self):
+        return self.items.__len__()
+
+    def append(self, x):
+        self.items.append(x)
+        self.emit('updated')
+
+    def remove(self, x):
+        self.items.remove(x)
+        self.emit('updated')
+
+    def __contains__(self, y):
+        return self.items.__contains__(y)
+
+    def sorted(self):
+        return sorted(self.items, key=lambda k: (k.priority, k.name))
+
+    def __str__(self):
+        return "<%s of %s>" % (type(self).__name__, self.items)
 
 
-def set_orders(orders):
-    ORDERS[:] = [OrderInOrder, OrderShuffle, OrderWeighted, OrderOneSong]
-    ORDERS.extend(orders)
-    ORDERS.sort(key=lambda k: (k.priority, k.name))
-set_orders([])
+class PluggableOrders(Orders, PluginManager):
+    """Registers as a Plugin Handler for various types of `Order` plugins"""
+    def __init__(self, orders, base_cls):
+        assert issubclass(base_cls, Order)
+        super(PluggableOrders, self).__init__(orders)
+        self.base_cls = base_cls
+        if PluginManager.instance:
+            PluginManager.instance.register_handler(self)
+        else:
+            print_w("No plugin manager found")
+
+    def plugin_handle(self, plugin):
+        return issubclass(plugin.cls, self.base_cls)
+
+    def plugin_enable(self, plugin):
+        plugin_cls = plugin.cls
+        if plugin_cls.name is None:
+            plugin_cls.name = plugin.name
+        if plugin_cls.display_name is None:
+            plugin_cls.display_name = str(plugin.name).capitalize()
+        if plugin_cls.accelerated_name is None:
+            plugin_cls.accelerated_name = plugin_cls.display_name
+        self.append(plugin_cls)
+
+    def plugin_disable(self, plugin):
+        self.remove(plugin.cls)
+
+DEFAULT_SHUFFLE_ORDERS = [OrderShuffle, OrderWeighted]
+DEFAULT_REPEAT_ORDERS = [RepeatSongForever]
 
 
-class ShuffleButton(Gtk.Box):
-    """A shuffle toggle button + a menu button.
+class ToggledPlayOrderMenu(Gtk.Box):
+    """A toggle button with a menu button.
+    Items displayed are all `PlayOrder`
 
-    In case the shuffle button gets toggled, 'toggled' gets emitted.
+    When the button is toggled, a `toggled` signal gets emitted.
     """
 
     __gsignals__ = {
         'toggled': (GObject.SignalFlags.RUN_LAST, None, ()),
+        'changed': (GObject.SignalFlags.RUN_LAST, None, (object,)),
     }
 
-    def __init__(self, arrow_down=False):
+    def __init__(self, icon_name, orders, current_order, enabled=False,
+                 tooltip=None, arrow_down=False):
         """arrow_down -- the direction of the menu and arrow icon"""
+        print_d("Building new Toggler set to %r" % enabled)
+        assert issubclass(current_order, Order)
+        if current_order not in orders:
+            raise ValueError("%s is not supported by %s"
+                             % (current_order.__name__, orders))
 
-        super(ShuffleButton, self).__init__()
+        super(ToggledPlayOrderMenu, self).__init__()
+        self.__inhibit = True
 
         context = self.get_style_context()
         context.add_class(Gtk.STYLE_CLASS_LINKED)
 
-        # shuffle button
-        b = Gtk.ToggleButton(image=SymbolicIconImage(
-            "media-playlist-shuffle", Gtk.IconSize.SMALL_TOOLBAR))
-        b.set_tooltip_text(_("Toggle shuffle mode"))
-        b.show_all()
-        qltk.add_css(b, """
-            * {
-                padding: 0px;
-            }
-        """)
-        b.set_size_request(26, 26)
-        self.pack_start(b, True, True, 0)
+        self._toggle_button = toggle = Gtk.ToggleButton(
+            image=SymbolicIconImage(icon_name, Gtk.IconSize.SMALL_TOOLBAR))
+        if tooltip:
+            toggle.set_tooltip_text(tooltip)
+        toggle.set_active(enabled)
+        toggle.show_all()
+        qltk.remove_padding(toggle)
+        toggle.set_size_request(26, 26)
+        self.pack_start(toggle, True, True, 0)
 
         def forward_signal(*args):
-            self.emit("toggled")
+            if self.__inhibit:
+                print_d("NOT forwarding programmatic toggled signal...")
+            else:
+                print_d("Forwarding toggled signal...")
+                self.emit("toggled")
 
-        b.connect("toggled", forward_signal)
-        self._toggle_button = b
+        toggle.connect("toggled", forward_signal)
+        self._toggle_button = toggle
 
-        # arrow
         from quodlibet.qltk.menubutton import MenuButton
-        b = MenuButton(arrow=True, down=arrow_down)
-        b.show_all()
-        b.set_size_request(20, 26)
-        qltk.add_css(b, """
-            * {
-                padding: 0px;
-            }
-        """)
-        self.pack_start(b, True, True, 0)
-        self._menu_button = b
+        arrow = MenuButton(arrow=True, down=arrow_down)
+        arrow.show_all()
+        arrow.set_size_request(20, 26)
+        qltk.remove_padding(arrow)
+        self.pack_start(arrow, True, True, 0)
+        self._menu_button = arrow
+        self.__current = current_order
+        self.__orders = orders
+        self.__rebuild_menu()
+        self.__inhibit = False
 
-    def set_active(self, value):
-        """Set if shuffle is active"""
-
-        self._toggle_button.set_active(value)
-
-    def get_active(self):
-        """Get if shuffle is active"""
-
+    @property
+    def enabled(self):
+        """Returns True if toggle button is active"""
         return self._toggle_button.get_active()
 
-    def set_menu(self, menu):
-        """Replace the current menu with a new one"""
+    @enabled.setter
+    def enabled(self, value):
+        """Set button to be active or inactive"""
+        print_d("Setting toggle %s to %s" % (self.__orders[0], value))
+        self.__inhibit = True
+        self._toggle_button.set_active(bool(value))
+        self.__inhibit = False
 
+    @property
+    def orders(self):
+        return self.__orders
+
+    @orders.setter
+    def orders(self, values):
+        self.__orders = values
+        if self.__current not in self.orders:
+            self.__current = None
+        self.__rebuild_menu()
+
+    @property
+    def current(self):
+        return self.__current
+
+    @current.setter
+    def current(self, value):
+        if value not in self.orders:
+            raise ValueError(
+                "Unknown order %s. Try: %s"
+                % (value, ", ".join([o.__name__ for o in self.__orders])))
+
+        self.__current = value
+        if not self.__inhibit:
+            self.emit('changed', self.__current)
+
+    def set_active_by_name(self, name):
+        for cls in self.__orders:
+            if cls.name == name:
+                self.current = cls
+                return
+        raise ValueError("Unknown order named \"%s\". Try: %s"
+                         % (name, [o.name for o in self.__orders]))
+
+    def set_orders(self, orders):
+        self.orders = orders
+
+    def __rebuild_menu(self):
+
+        def toggled_cb(item, order):
+            if item.get_active():
+                self.current = order
+
+        menu = Gtk.Menu()
+        group = None
+        for order in self.__orders:
+            group = RadioMenuItem(
+                label=order.accelerated_name,
+                use_underline=True,
+                group=group)
+            group.set_active(order.name == self.__current)
+            group.connect("toggled", toggled_cb, order)
+            menu.append(group)
+        menu.show_all()
         self._menu_button.set_menu(menu)
 
 
-class PlayOrder(Gtk.Box, PluginHandler):
-    """A play order selection widget.
-
+class PlayOrderWidget(Gtk.HBox):
+    """A combined play order selection widget.
     Whenever something changes the 'changed' signal gets emitted.
-
-    TODO: split up in UI and management part
     """
 
     __gsignals__ = {
@@ -274,147 +436,129 @@ class PlayOrder(Gtk.Box, PluginHandler):
     }
 
     def __init__(self, model, player):
-        super(PlayOrder, self).__init__()
+        super(PlayOrderWidget, self).__init__(spacing=6)
+        self.order = None
+        self.__inhibit = True
+        self.__playlist = model
+        self.__player = player
 
-        self._model = model
-        self._player = player
-        self._plugins = []
-        self._inhibit_save = False
+        def create_shuffle(orders):
+            shuffle = ToggledPlayOrderMenu(
+                Icons.MEDIA_PLAYLIST_SHUFFLE,
+                orders=orders,
+                current_order=self.__get_shuffle_class(),
+                enabled=(config.getboolean("memory", "shuffle", False)),
+                tooltip=_("Toggle shuffle mode"))
+            shuffle.connect('changed', self.__shuffle_updated)
+            shuffle.connect('toggled', self.__shuffle_toggled)
+            return shuffle
 
-        self._shuffle = shuffle = ShuffleButton()
-        self.pack_start(shuffle, True, True, 0)
+        self._shuffle_orders = PluggableOrders(DEFAULT_SHUFFLE_ORDERS, Reorder)
+        self.__shuffle_widget = create_shuffle(self._shuffle_orders)
+        self._shuffle_orders.connect('updated',
+                                     self.__shuffle_widget.set_orders)
 
-        if PluginManager.instance:
-            PluginManager.instance.register_handler(self)
+        def create_repeat(orders):
+            repeat = ToggledPlayOrderMenu(
+                Icons.MEDIA_PLAYLIST_REPEAT,
+                orders=orders,
+                current_order=self.__get_repeat_class(),
+                enabled=config.getboolean("memory", "repeat", False),
+                tooltip=_("Toggle repeat mode"))
+            repeat.connect('changed', self.__repeat_updated)
+            repeat.connect('toggled', self.__repeat_toggled)
+            return repeat
+        self._repeat_orders = PluggableOrders(DEFAULT_REPEAT_ORDERS, Repeat)
+        self.__repeat_widget = create_repeat(self._repeat_orders)
+        self._repeat_orders.connect('updated', self.__repeat_widget.set_orders)
 
-        self._set_order(
-            self._get_order(config.getboolean("memory", "shuffle")))
-        shuffle.connect("toggled", self._random_toggle)
+        self.__compose_order()
+        self.pack_start(self.__shuffle_widget, False, True, 0)
+        self.pack_start(self.__repeat_widget, False, True, 0)
+        self.__inhibit = False
 
-    def set_shuffle(self, value):
-        """Set shuffle, will change the order accordingly"""
+    @property
+    def shuffler(self):
+        return self.__shuffle_widget.current
 
-        self._shuffle.set_active(value)
+    @shuffler.setter
+    def shuffler(self, cls):
+        assert issubclass(cls, Reorder)
+        self.__shuffle_widget.current = cls
 
-    def get_shuffle(self):
-        """If the active order is a shuffle based one"""
+    @property
+    def repeater(self):
+        return self.__repeat_widget.current
 
-        return self._shuffle.get_active()
+    @repeater.setter
+    def repeater(self, cls):
+        assert issubclass(cls, Repeat)
+        self.__repeat_widget.current = cls
 
-    def set_active_by_name(self, name):
-        """Set the active play order via the order name.
+    @property
+    def shuffled(self):
+        return self.__shuffle_widget.enabled
 
-        Raises ValueError if not found.
-        """
+    @shuffled.setter
+    def shuffled(self, enabled):
+        self.__shuffle_widget.enabled = bool(enabled)
+        self.__compose_order()
 
-        for order in ORDERS:
-            if order.name == name:
-                self._set_order(order)
-                return
-        raise ValueError("order %r not available" % name)
+    @property
+    def repeated(self):
+        return self.__repeat_widget.enabled
 
-    def set_active_by_index(self, index):
-        """Set by index number in global order list.
+    @repeated.setter
+    def repeated(self, enabled):
+        self.__repeat_widget.enabled = bool(enabled)
+        self.__compose_order()
 
-        Raises IndexError
-        """
+    def __repeat_updated(self, widget, repeat_cls):
+        if self.__inhibit:
+            return
+        print_d("New repeat mode: %s" % repeat_cls.name)
+        config.set("memory", "repeat_mode", repeat_cls.name)
+        self.__compose_order()
 
-        self._set_order(ORDERS[index])
+    def __shuffle_updated(self, widget, shuffle_cls):
+        if self.__inhibit:
+            return
+        print_d("New shuffle mode: %s" % shuffle_cls.name)
+        config.set("memory", "shuffle_mode", shuffle_cls.name)
+        self.__compose_order()
 
-    def get_active(self):
-        """Get the active order"""
+    def __shuffle_toggled(self, widget):
+        if self.__inhibit:
+            return
+        print_d("Shuffle toggled")
+        config.set("memory", "shuffle", widget.enabled)
+        self.__compose_order()
 
-        return self._get_order(self.get_shuffle())
+    def __repeat_toggled(self, widget):
+        if self.__inhibit:
+            return
+        print_d("Repeat toggled")
+        config.set("memory", "repeat", widget.enabled)
+        self.__compose_order()
 
-    def get_active_name(self):
-        """Get the identifier name for the active play order"""
+    def __compose_order(self):
+        old_order = self.order
+        repeat_cls = self.__get_repeat_class()
+        shuffle_cls = self.__get_shuffle_class()
+        shuffler = (shuffle_cls() if self.shuffled else OrderInOrder())
+        self.order = repeat_cls(shuffler) if self.repeated else shuffler
+        print_d("Updating %s order to %s"
+                % (type(self.__playlist).__name__, self.order))
+        self.__playlist.order = self.order
+        self.__player.replaygain_profiles[2] = shuffler.replaygain_profiles
+        self.__player.reset_replaygain()
+        if self.order != old_order:
+            self.emit('changed')
 
-        return self.get_active().name
+    def __get_shuffle_class(self):
+        name = config.get("memory", "shuffle_mode", None)
+        return self._shuffle_orders.by_name(name) or OrderShuffle
 
-    def _get_order(self, shuffle):
-        """Get the active order for shuffle/inorder mode"""
-
-        first_matching = None
-        if shuffle:
-            name = config.get("memory", "order_shuffle")
-        else:
-            name = config.get("memory", "order")
-        for order in ORDERS:
-            if order.is_shuffle == shuffle:
-                first_matching = first_matching or order
-                if order.name == name:
-                    return order
-        return first_matching
-
-    def _set_order(self, order_cls):
-        """Set shuffle and order based on the passed class"""
-
-        self._model.order = order_cls(self._model)
-        is_shuffle = order_cls.is_shuffle
-
-        if not self._inhibit_save:
-            config.set("memory", "shuffle", is_shuffle)
-            if is_shuffle:
-                config.set("memory", "order_shuffle", order_cls.name)
-            else:
-                config.set("memory", "order", order_cls.name)
-        self.set_shuffle(is_shuffle)
-        self._refresh_menu()
-
-        self._player.replaygain_profiles[2] = order_cls.replaygain_profiles
-        self._player.reset_replaygain()
-        self.emit("changed")
-
-    def _refresh_menu(self):
-        is_shuffle = self._shuffle.get_active()
-
-        def toggled_cb(item, order):
-            if item.get_active():
-                self._set_order(order)
-
-        active_order = self._get_order(is_shuffle)
-
-        menu = Gtk.Menu()
-        group = None
-        for order in ORDERS:
-            if order.is_shuffle == is_shuffle:
-                group = RadioMenuItem(
-                    label=order.accelerated_name,
-                    use_underline=True,
-                    group=group)
-                group.set_active(order == active_order)
-                group.connect("toggled", toggled_cb, order)
-                menu.append(group)
-        menu.show_all()
-        self._shuffle.set_menu(menu)
-
-    def _random_toggle(self, button):
-        self._set_order(self._get_order(button.get_active()))
-
-    def plugin_handle(self, plugin):
-        from quodlibet.plugins.playorder import PlayOrderPlugin
-        return issubclass(plugin.cls, PlayOrderPlugin)
-
-    def plugin_enable(self, plugin):
-        plugin_cls = plugin.cls
-        if plugin_cls.name is None:
-            plugin_cls.name = plugin.name
-        if plugin_cls.display_name is None:
-            plugin_cls.display_name = plugin.name
-        if plugin_cls.accelerated_name is None:
-            plugin_cls.accelerated_name = plugin_cls.display_name
-
-        self._plugins.append(plugin_cls)
-        set_orders(self._plugins)
-        self._refresh_menu()
-
-    def plugin_disable(self, plugin):
-        order = plugin.cls
-        self._plugins.remove(order)
-        set_orders(self._plugins)
-
-        # Don't safe changes from plugin changes
-        # so that disables on shutdown don't change the config.
-        self._inhibit_save = True
-        self._set_order(self._get_order(self.get_shuffle()))
-        self._inhibit_save = False
+    def __get_repeat_class(self):
+        name = config.get("memory", "repeat_mode", None)
+        return self._repeat_orders.by_name(name) or RepeatSongForever

--- a/quodlibet/quodlibet/qltk/queue.py
+++ b/quodlibet/quodlibet/qltk/queue.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 # Copyright 2004-2005 Joe Wreschnig, Michael Urman, Iñigo Serna
+#                2016 Nick Boultbee
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as
@@ -220,10 +221,7 @@ class QueueExpander(Gtk.Expander):
         self.queue.emit('drag-data-received', *args)
 
     def __queue_shuffle(self, button, model):
-        if not button.get_active():
-            model.order = OrderInOrder(model)
-        else:
-            model.order = OrderShuffle(model)
+        model.order = OrderShuffle() if button.get_active() else OrderInOrder()
 
     def __expand(self, cb, prop, clear):
         expanded = self.get_expanded()

--- a/quodlibet/quodlibet/qltk/quodlibetwindow.py
+++ b/quodlibet/quodlibet/qltk/quodlibetwindow.py
@@ -92,8 +92,8 @@ class PlayerOptions(GObject.Object):
             self.notify("random")
             self.notify("single")
 
-        self._order = window.order
-        self._oid = self._order.connect("changed", order_changed)
+        self._order_widget = window.order
+        self._oid = self._order_widget.connect("changed", order_changed)
 
         window.connect("destroy", self._window_destroy)
 
@@ -101,9 +101,9 @@ class PlayerOptions(GObject.Object):
         self.destroy()
 
     def destroy(self):
-        if self._order:
-            self._order.disconnect(self._oid)
-            self._order = None
+        if self._order_widget:
+            self._order_widget.disconnect(self._oid)
+            self._order_widget = None
         if self._stop_after:
             self._stop_after.disconnect(self._said)
             self._stop_after = None
@@ -134,26 +134,24 @@ class PlayerOptions(GObject.Object):
             pass
 
     @property
-    def random(self):
-        """If a random based play order is active"""
+    def shuffle(self):
+        """If a shuffle-like (reordering) play order is active"""
 
-        return self._order.shuffled
+        return self._order_widget.shuffled
 
-    @random.setter
-    def random(self, value):
-        # raise NotImplementedError
-        pass
+    @shuffle.setter
+    def shuffle(self, value):
+        self._order_widget.shuffled = value
 
     @property
     def repeat(self):
-        """If the playlist will be restarted if it ended"""
+        """If the player is in some kind of repeat mode"""
 
-        return self._order.repeated
+        return self._order_widget.repeated
 
     @repeat.setter
     def repeat(self, value):
-        # raise NotImplementedError
-        pass
+        self._order_widget.repeated = value
 
     @property
     def stop_after(self):
@@ -163,7 +161,7 @@ class PlayerOptions(GObject.Object):
 
     @stop_after.setter
     def stop_after(self, value):
-        pass
+        self._stop_after.set_active(value)
 
 
 class DockMenu(Gtk.Menu):

--- a/quodlibet/quodlibet/qltk/quodlibetwindow.py
+++ b/quodlibet/quodlibet/qltk/quodlibetwindow.py
@@ -412,6 +412,7 @@ class StatusBarBox(Gtk.HBox):
 
         self.pack_start(queue_button, False, True, 0)
 
+
 class AppMenu(object):
     """Implements a app menu proxy mirroring some main menu items
     to a new menu and exporting it on the session bus.

--- a/quodlibet/quodlibet/qltk/quodlibetwindow.py
+++ b/quodlibet/quodlibet/qltk/quodlibetwindow.py
@@ -35,7 +35,7 @@ from quodlibet.qltk.info import SongInfo
 from quodlibet.qltk.information import Information
 from quodlibet.qltk.msg import ErrorMessage, WarningMessage
 from quodlibet.qltk.notif import StatusBar, TaskController
-from quodlibet.qltk.playorder import PlayOrderWidget
+from quodlibet.qltk.playorder import PlayOrderWidget, RepeatSongForever
 from quodlibet.qltk.pluginwin import PluginWindow
 from quodlibet.qltk.properties import SongProperties
 from quodlibet.qltk.prefs import PreferencesWindow
@@ -68,7 +68,7 @@ class PlayerOptions(GObject.Object):
     """
 
     __gproperties__ = {
-        'random': (bool, '', '', False,
+        'shuffle': (bool, '', '', False,
                    GObject.ParamFlags.READABLE | GObject.ParamFlags.WRITABLE),
         'repeat': (bool, '', '', False,
                    GObject.ParamFlags.READABLE | GObject.ParamFlags.WRITABLE),
@@ -89,7 +89,7 @@ class PlayerOptions(GObject.Object):
             "toggled", lambda *x: self.notify("stop-after"))
 
         def order_changed(*args):
-            self.notify("random")
+            self.notify("shuffle")
             self.notify("single")
 
         self._order_widget = window.order
@@ -122,16 +122,17 @@ class PlayerOptions(GObject.Object):
         When `repeat` is True the current song will be replayed.
         """
 
-        # FIXME: Add OneSong repeat mode etc
-        return False
+        return (self._order_widget.repeated and
+                self._order_widget.repeater == RepeatSongForever)
 
     @single.setter
     def single(self, value):
         if value and not self.single:
-            # self._order.set_active_by_name("onesong")
+            self.repeat = True
+            self._order_widget.repeater = RepeatSongForever
             pass
         elif not value and self.single:
-            pass
+            self.repeat = False
 
     @property
     def shuffle(self):
@@ -151,6 +152,7 @@ class PlayerOptions(GObject.Object):
 
     @repeat.setter
     def repeat(self, value):
+        print_d("setting repeated to %s" % value)
         self._order_widget.repeated = value
 
     @property

--- a/quodlibet/quodlibet/qltk/songmodel.py
+++ b/quodlibet/quodlibet/qltk/songmodel.py
@@ -7,7 +7,7 @@
 
 from gi.repository import Gtk
 
-from quodlibet.qltk.playorder import ORDERS
+from quodlibet.qltk.playorder import OrderInOrder
 from quodlibet.qltk.models import ObjectStore
 from quodlibet.util import print_d
 from quodlibet.compat import izip
@@ -221,17 +221,14 @@ class PlaylistModel(TrackCurrentModel):
     """A play list model for song lists"""
 
     order = None
-    """The active play order"""
-
-    repeat = False
-    """If the playlist should be repeated after it ended"""
+    """The active `PlayOrder`"""
 
     sourced = False
     """True in case this model is the source of the currently playing song"""
 
-    def __init__(self):
+    def __init__(self, order_cls=OrderInOrder):
         super(PlaylistModel, self).__init__(object)
-        self.order = ORDERS[0](self)
+        self.order = order_cls()
 
         # The playorder plugins use paths atm to remember songs so
         # we need to reset them if the paths change somehow.
@@ -244,12 +241,14 @@ class PlaylistModel(TrackCurrentModel):
         """Switch to the next song"""
 
         iter_ = self.current_iter
+        print_d("Using %s.next_explicit() to get next song" % self.order)
         self.current_iter = self.order.next_explicit(self, iter_)
 
     def next_ended(self):
         """Switch to the next song (action comes from the user)"""
 
         iter_ = self.current_iter
+        print_d("Using %s.next_implicit() to get next song" % self.order)
         self.current_iter = self.order.next_implicit(self, iter_)
 
     def previous(self):

--- a/quodlibet/tests/plugin/test_mpris.py
+++ b/quodlibet/tests/plugin/test_mpris.py
@@ -38,6 +38,7 @@ A2.sanitize()
 
 MAX_TIME = 3
 
+
 @skipUnless(dbus, "no dbus")
 class TMPRIS(PluginTestCase):
 

--- a/quodlibet/tests/plugin/test_mpris.py
+++ b/quodlibet/tests/plugin/test_mpris.py
@@ -4,6 +4,7 @@
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of version 2 of the GNU General Public License as
 # published by the Free Software Foundation.
+import time
 
 try:
     import dbus
@@ -35,6 +36,7 @@ A2 = AudioFile(
          '~filename': fsnative(u'/foo')})
 A2.sanitize()
 
+MAX_TIME = 3
 
 @skipUnless(dbus, "no dbus")
 class TMPRIS(PluginTestCase):
@@ -90,9 +92,12 @@ class TMPRIS(PluginTestCase):
     def _error(self, *args):
         self.failIf(args)
 
-    def _wait(self):
+    def _wait(self, msg=""):
+        start = time.time()
         while not self._replies:
             Gtk.main_iteration_do(False)
+            if time.time() - start > MAX_TIME:
+                self.fail("Timed out waiting for replies (%s)" % msg)
         return self._replies.pop(0)
 
     def test_main(self):
@@ -148,7 +153,7 @@ class TMPRIS(PluginTestCase):
 
         for key, value in props.iteritems():
             self._prop().Get(piface, key, **args)
-            resp = self._wait()[0]
+            resp = self._wait(msg="for key '%s'" % key)[0]
             self.failUnlessEqual(resp, value)
             self.failUnless(isinstance(resp, type(value)))
 

--- a/quodlibet/tests/test_qltk_playorder.py
+++ b/quodlibet/tests/test_qltk_playorder.py
@@ -3,72 +3,105 @@
 # it under the terms of the GNU General Public License version 2 as
 # published by the Free Software Foundation
 
-from tests import TestCase
-
-from quodlibet.qltk.playorder import PlayOrder
 import quodlibet.config
 import quodlibet.plugins
+from quodlibet.qltk import Icons
+from quodlibet.qltk.playorder import OrderShuffle, OrderWeighted, \
+    ToggledPlayOrderMenu, Orders, Order, OrderInOrder
+from quodlibet.qltk.playorder import PlayOrderWidget
+from tests import TestCase
 
 
-class TPlayOrder(TestCase):
+class TPlayOrderWidget(TestCase):
 
     def setUp(self):
-        quodlibet.plugins.init()
+        # quodlibet.plugins.init()
         quodlibet.config.init()
 
         self.order = None
         self.volume = 0
         self.replaygain_profiles = [None, None, None]
         self.reset_replaygain = lambda: None
-        self.po = PlayOrder(self, self)
+        self.po = PlayOrderWidget(self, self)
 
     def tearDown(self):
         self.po.destroy()
-        quodlibet.plugins.quit()
+        # quodlibet.plugins.quit()
         quodlibet.config.quit()
 
     def test_initial(self):
-        self.failUnlessEqual(self.po.get_active_name(), "inorder")
+        self.failIf(self.po.repeated)
+        self.failIf(self.po.shuffled)
+        self.failUnless(isinstance(self.po.order, OrderInOrder))
         self.failUnless(self.replaygain_profiles[2], ["album", "track"])
 
-    def test_unknown_name(self):
-        self.assertRaises(ValueError, self.po.set_active_by_name, "foobar")
-
-    def test_unknown_index(self):
-        self.assertRaises(IndexError, self.po.set_active_by_index, 999)
-
-    def test_set_name(self):
-        self.po.set_active_by_name("weighted")
-        self.failUnlessEqual(self.po.get_active_name(), "weighted")
-
     def test_replay_gain(self):
-        self.po.set_active_by_name("weighted")
+        self.po.shuffler = OrderWeighted
         self.failUnlessEqual(self.replaygain_profiles[2], ["track"])
-        self.po.set_active_by_name("inorder")
+        self.po.shuffler.current = OrderInOrder
         self.failUnlessEqual(self.replaygain_profiles[2], ["album", "track"])
 
-    def test_set_int(self):
-        old = self.po.get_active_name()
-        self.po.set_active_by_index(3)
-        self.failIfEqual(self.po.get_active_name(), old)
-
     def test_get_name(self):
-        orders = ["inorder", "shuffle", "weighted", "onesong"]
-        for i, name in enumerate(orders):
-            self.po.set_active_by_name(name)
-            self.failUnlessEqual(self.po.get_active_name(), name)
+        orders = [OrderShuffle, OrderWeighted]
+        for order in orders:
+            self.po.shuffler = order
+            self.failUnlessEqual(self.po.shuffler, order)
 
     def test_shuffle(self):
-        self.assertEqual(self.po.get_active_name(), "inorder")
-        self.po.set_shuffle(True)
-        self.assertTrue(self.po.get_shuffle())
-        self.assertEqual(self.po.get_active_name(), "shuffle")
+        self.failIf(self.po.repeated)
+        self.po.shuffled = True
+        self.assertTrue(self.po.shuffled)
+        self.assertEqual(self.po.shuffler, OrderShuffle)
+        self.failUnless(isinstance(self.order, OrderShuffle))
 
-    def test_shuffle_weighted(self):
-        self.po.set_active_by_name("weighted")
-        self.assertTrue(self.po.get_shuffle())
-        self.po.set_shuffle(False)
-        self.assertEqual(self.po.get_active_name(), "inorder")
-        self.po.set_shuffle(True)
-        self.assertTrue(self.po.get_shuffle())
-        self.assertEqual(self.po.get_active_name(), "weighted")
+    def test_shuffle_defaults_to_inorder(self):
+        self.po.shuffler = OrderWeighted
+        self.po.shuffled = False
+        self.failUnlessEqual(type(self.po.order), OrderInOrder)
+        self.po.shuffled = True
+        self.assertEqual(self.po.shuffler, OrderWeighted)
+        self.failUnlessEqual(type(self.po.order), OrderWeighted)
+
+
+class FakeOrder(Order):
+    name = "fake"
+
+
+class TToggledPlayOrderMenu(TestCase):
+
+    def setUp(self):
+        self.orders = Orders([OrderShuffle, OrderWeighted, FakeOrder])
+        self.tpom = ToggledPlayOrderMenu(Icons.AUDIO_X_GENERIC,
+                                         orders=self.orders,
+                                         current_order=OrderShuffle,
+                                         enabled=True)
+    def tearDown(self):
+        self.tpom.destroy()
+
+    def test_enabled_initially(self):
+        self.failUnless(self.tpom.enabled)
+
+    def test_setting_enabled(self):
+        self.tpom.enabled = False
+        self.failIf(self.tpom.enabled)
+        self.tpom.enabled = True
+        self.failUnless(self.tpom.enabled)
+
+    def test_initial(self):
+        self.failUnlessEqual(self.tpom.current, OrderShuffle)
+
+    def test_unknown_name(self):
+        self.assertRaises(ValueError, self.tpom.set_active_by_name, "foobar")
+
+    def test_set_by_name(self):
+        self.tpom.set_active_by_name("fake")
+        self.failUnlessEqual(self.tpom.current.name, "fake")
+
+    def test_get_name(self):
+        for order in self.orders:
+            self.tpom.current = order
+            self.failUnlessEqual(self.tpom.current, order)
+
+    def test_set_orders(self):
+        self.tpom.set_orders([])
+        self.failIf(self.tpom.current)

--- a/quodlibet/tests/test_qltk_playorder.py
+++ b/quodlibet/tests/test_qltk_playorder.py
@@ -15,7 +15,6 @@ from tests import TestCase
 class TPlayOrderWidget(TestCase):
 
     def setUp(self):
-        # quodlibet.plugins.init()
         quodlibet.config.init()
 
         self.order = None

--- a/quodlibet/tests/test_qltk_playorder.py
+++ b/quodlibet/tests/test_qltk_playorder.py
@@ -36,9 +36,10 @@ class TPlayOrderWidget(TestCase):
         self.failUnless(self.replaygain_profiles[2], ["album", "track"])
 
     def test_replay_gain(self):
+        self.po.shuffled = True
         self.po.shuffler = OrderWeighted
         self.failUnlessEqual(self.replaygain_profiles[2], ["track"])
-        self.po.shuffler.current = OrderInOrder
+        self.po.shuffled = False
         self.failUnlessEqual(self.replaygain_profiles[2], ["album", "track"])
 
     def test_get_name(self):
@@ -75,6 +76,7 @@ class TToggledPlayOrderMenu(TestCase):
                                          orders=self.orders,
                                          current_order=OrderShuffle,
                                          enabled=True)
+
     def tearDown(self):
         self.tpom.destroy()
 

--- a/quodlibet/tests/test_qltk_songmodel.py
+++ b/quodlibet/tests/test_qltk_songmodel.py
@@ -10,7 +10,8 @@ from gi.repository import Gtk
 from quodlibet.player.nullbe import NullPlayer
 from quodlibet.formats import AudioFile
 from quodlibet.qltk.songmodel import PlaylistModel, PlaylistMux
-from quodlibet.qltk.playorder import ORDERS, Order
+from quodlibet.qltk.playorder import DEFAULT_SHUFFLE_ORDERS, Order, \
+    OrderShuffle, OrderWeighted, OrderInOrder, RepeatSongForever
 
 
 def do_events():
@@ -109,29 +110,23 @@ class TPlaylistModel(TestCase):
         self.pl.next()
         self.failUnlessEqual(self.pl.current, 9)
 
-    def test_next_repeat(self):
-        self.pl.repeat = True
-        self.pl.go_to(3)
-        for i in range(9):
-            self.pl.next()
-        self.assertEqual(self.pl.current, 2)
-        for i in range(12):
-            self.pl.next()
-        self.assertEqual(self.pl.current, 4)
+    def test_next_at_end_finishes(self):
+        self.pl.go_to(9)
+        self.pl.next()
+        self.assertEqual(self.pl.current, None)
 
     def test_shuffle(self):
-        self.pl.order = ORDERS[1](self.pl)
+        self.pl.order = OrderShuffle()
         for i in range(5):
-            numbers = [self.pl.current for i in range(10)
+            history = [self.pl.current for _ in range(10)
                        if self.pl.next() or True]
-            self.assertNotEqual(numbers, list(range(10)))
-            numbers.sort()
-            self.assertEqual(numbers, list(range(10)))
+            self.assertNotEqual(history, list(range(10)))
+            self.assertEqual(sorted(history), list(range(10)))
             self.pl.next()
             self.assertEqual(self.pl.current, None)
 
     def test_weighted(self):
-        self.pl.order = ORDERS[2](self.pl)
+        self.pl.order = OrderWeighted()
         r0 = AudioFile({'~#rating': 0})
         r1 = AudioFile({'~#rating': 1})
         r2 = AudioFile({'~#rating': 2})
@@ -144,9 +139,15 @@ class TPlaylistModel(TestCase):
         self.assert_(songs.count(r2) > songs.count(r1))
         self.assert_(songs.count(r3) > songs.count(r2))
 
+    def test_shuffle_repeat_forever(self):
+        self.pl.order = RepeatSongForever(OrderShuffle())
+        old = self.pl.current
+        for i in range(5):
+            self.pl.next()
+            self.assertEqual(self.pl.current, old)
+
     def test_shuffle_repeat(self):
-        self.pl.order = ORDERS[1](self.pl)
-        self.pl.repeat = True
+        self.pl.order = RepeatSongForever(OrderShuffle())
         numbers = [self.pl.current for i in range(30)
                    if self.pl.next() or True]
         allnums = list(range(10)) * 3
@@ -155,24 +156,24 @@ class TPlaylistModel(TestCase):
         numbers.sort()
         self.assertEqual(numbers, allnums)
 
-    def test_onesong(self):
-        self.pl.go_to(3)
-        self.pl.order = ORDERS[3](self.pl)
-        self.failUnlessEqual(self.pl.current, 3)
-        self.pl.next()
-        self.failUnlessEqual(self.pl.current, 4)
-        self.pl.next_ended()
-        self.failUnlessEqual(self.pl.current, None)
-
-    def test_onesong_repeat(self):
-        self.pl.go_to(3)
-        self.pl.order = ORDERS[3](self.pl)
-        self.pl.repeat = True
-        self.failUnlessEqual(self.pl.current, 3)
-        self.pl.next()
-        self.failUnlessEqual(self.pl.current, 4)
-        self.pl.next_ended()
-        self.failUnlessEqual(self.pl.current, 4)
+    # def test_onesong(self):
+    #     self.pl.go_to(3)
+    #     self.pl.order = ORDERS[3](self.pl)
+    #     self.failUnlessEqual(self.pl.current, 3)
+    #     self.pl.next()
+    #     self.failUnlessEqual(self.pl.current, 4)
+    #     self.pl.next_ended()
+    #     self.failUnlessEqual(self.pl.current, None)
+    #
+    # def test_onesong_repeat(self):
+    #     self.pl.go_to(3)
+    #     self.pl.order = ORDERS[3](self.pl)
+    #     self.pl.repeat = True
+    #     self.failUnlessEqual(self.pl.current, 3)
+    #     self.pl.next()
+    #     self.failUnlessEqual(self.pl.current, 4)
+    #     self.pl.next_ended()
+    #     self.failUnlessEqual(self.pl.current, 4)
 
     def test_previous(self):
         self.pl.go_to(2)
@@ -193,7 +194,7 @@ class TPlaylistModel(TestCase):
         self.failUnlessEqual(self.pl.current, 10)
 
     def test_go_to_order(self):
-        self.pl.order = ORDERS[1](self.pl)
+        self.pl.order = OrderShuffle()
         for i in range(5):
             self.pl.go_to(5)
             self.failUnlessEqual(self.pl.current, 5)
@@ -211,7 +212,7 @@ class TPlaylistModel(TestCase):
             def set_implicit(self, playlist, iter):
                 return playlist.iter_next(playlist.iter_next(iter))
 
-        self.pl.order = SetOrder(self.pl)
+        self.pl.order = SetOrder()
         self.failUnlessEqual(self.pl[self.pl.go_to(5, True)][0], 6)
         self.failUnlessEqual(self.pl[self.pl.go_to(5, False)][0], 7)
 
@@ -229,7 +230,7 @@ class TPlaylistModel(TestCase):
         self.failUnlessEqual(self.pl.current, 0)
 
     def test_reset_order(self):
-        self.pl.order = ORDERS[0](self.pl)
+        self.pl.order = OrderInOrder()
         self.pl.go_to(5)
         self.failUnlessEqual(self.pl.current, 5)
         self.pl.reset()
@@ -244,8 +245,7 @@ class TPlaylistModel(TestCase):
 
     def test_next_nosong_536(self):
         self.pl.go_to(1)
-        self.pl.repeat = True
-        self.pl.order = ORDERS[1](self.pl)
+        self.pl.order = OrderShuffle()
         self.pl.set([])
         Gtk.main_iteration_do(False)
         self.pl.next()
@@ -366,7 +366,7 @@ class TPlaylistMux(TestCase):
             self.pl.set([1])
             do_events()
             self.failUnless(self.mux.current is None)
-            self.q.order = ORDERS[1](self.pl)
+            self.q.order = OrderShuffle()
             self.failUnless(self.next() == 1)
             self.q.set([10, 11])
             do_events()

--- a/quodlibet/tests/test_qltk_songmodel.py
+++ b/quodlibet/tests/test_qltk_songmodel.py
@@ -144,36 +144,40 @@ class TPlaylistModel(TestCase):
         self.pl.order = RepeatSongForever(OrderShuffle())
         old = self.pl.current
         for i in range(5):
-            self.pl.next()
+            self.pl.next_ended()
             self.assertEqual(self.pl.current, old)
 
     def test_shuffle_repeat(self):
         self.pl.order = RepeatListForever(OrderShuffle())
         numbers = [self.pl.current for _ in range(30)
-                   if self.pl.next() or True]
+                   if self.pl.next_ended() or True]
         allnums = sorted(list(range(10)) * 3)
         self.assertNotEqual(numbers, allnums)
         numbers.sort()
         self.assertEqual(numbers, allnums)
 
-    # def test_onesong(self):
-    #     self.pl.go_to(3)
-    #     self.pl.order = ORDERS[3](self.pl)
-    #     self.failUnlessEqual(self.pl.current, 3)
-    #     self.pl.next()
-    #     self.failUnlessEqual(self.pl.current, 4)
-    #     self.pl.next_ended()
-    #     self.failUnlessEqual(self.pl.current, None)
-    #
-    # def test_onesong_repeat(self):
-    #     self.pl.go_to(3)
-    #     self.pl.order = ORDERS[3](self.pl)
-    #     self.pl.repeat = True
-    #     self.failUnlessEqual(self.pl.current, 3)
-    #     self.pl.next()
-    #     self.failUnlessEqual(self.pl.current, 4)
-    #     self.pl.next_ended()
-    #     self.failUnlessEqual(self.pl.current, 4)
+    def test_repeat_song_repeats_on_end(self):
+        self.pl.order = RepeatSongForever(OrderInOrder())
+        self.pl.go_to(3)
+        self.failUnlessEqual(self.pl.current, 3)
+        self.pl.next_ended()
+        self.failUnlessEqual(self.pl.current, 3)
+
+    def test_repeat_song_uses_underlying_on_explicit(self):
+        self.pl.order = RepeatSongForever(OrderInOrder())
+        self.pl.go_to(3)
+        self.pl.next()
+        self.failUnlessEqual(self.pl.current, 4)
+
+    def test_repeat_all_cycles_playlist(self):
+        self.pl.go_to(3)
+        self.pl.order = RepeatListForever(OrderInOrder())
+        self.failUnlessEqual(self.pl.current, 3)
+        self.pl.next()
+        self.failUnlessEqual(self.pl.current, 4)
+        for i in range(9):
+            self.pl.next_ended()
+        self.failUnlessEqual(self.pl.current, 3)
 
     def test_previous(self):
         self.pl.go_to(2)

--- a/quodlibet/tests/test_qltk_songmodel.py
+++ b/quodlibet/tests/test_qltk_songmodel.py
@@ -10,8 +10,8 @@ from gi.repository import Gtk
 from quodlibet.player.nullbe import NullPlayer
 from quodlibet.formats import AudioFile
 from quodlibet.qltk.songmodel import PlaylistModel, PlaylistMux
-from quodlibet.qltk.playorder import DEFAULT_SHUFFLE_ORDERS, Order, \
-    OrderShuffle, OrderWeighted, OrderInOrder, RepeatSongForever
+from quodlibet.qltk.playorder import Order, OrderShuffle, OrderWeighted, \
+    OrderInOrder, RepeatSongForever, RepeatListForever
 
 
 def do_events():
@@ -124,6 +124,7 @@ class TPlaylistModel(TestCase):
             self.assertEqual(sorted(history), list(range(10)))
             self.pl.next()
             self.assertEqual(self.pl.current, None)
+            self.pl.order.reset(self.pl)
 
     def test_weighted(self):
         self.pl.order = OrderWeighted()
@@ -147,11 +148,10 @@ class TPlaylistModel(TestCase):
             self.assertEqual(self.pl.current, old)
 
     def test_shuffle_repeat(self):
-        self.pl.order = RepeatSongForever(OrderShuffle())
-        numbers = [self.pl.current for i in range(30)
+        self.pl.order = RepeatListForever(OrderShuffle())
+        numbers = [self.pl.current for _ in range(30)
                    if self.pl.next() or True]
-        allnums = list(range(10)) * 3
-        allnums.sort()
+        allnums = sorted(list(range(10)) * 3)
         self.assertNotEqual(numbers, allnums)
         numbers.sort()
         self.assertEqual(numbers, allnums)


### PR DESCRIPTION
* Split `PlayOrderPlugin` to `ShufflePlugin` and `RepeatPlugin` marker subclasses
* Add `Repeat` as an explicit (delegating) `Order`, and `Reorder` as the base class for shuffle-style `Order`s (necessary for plugin manager). This then fixes #1111. 
* Add lightweight GObject-based list-like store for `Orders` that signals (but not quite `ListStore`), and a subclass that is also a `PluginManager`
* New generalised class `ToggledPlayOrderMenu`
* `PlayOrder` now `PlayOrderWidget` which tries to do a little less; it's about aggregating the repeat and shuffle controls, and exposing higher level information (notably, the single composed `Order`).
* Remove concept of repeat from Playlist, as repeating is more complex now and handled elsewhere.
* Add  "Repeat All" and "Repeat One" (fixes #1836) type repeaters.
* Config: Finally keep `memory.repeat` and `memory.shuffle` together (removing `settings.repeat`)
* Use more properties everywhere for readability
* Remove mixins that no longer help us
* Fix current plugins to work with new structure (Follow now working fine, fixes #1469).
* Add timeout to mpris test as it was hanging during dev

There _must_ be a few things I've missed / broken... but can't see them right now. 

### TODOs
 * [x] Single
 * [x] Fix / simplify `PlayerOptions`
 * [x] Remoting is broken a bit I think.