### PR TITLE
Show all songs when clearing playlist search

### DIFF
--- a/quodlibet/quodlibet/browsers/playlists/main.py
+++ b/quodlibet/quodlibet/browsers/playlists/main.py
@@ -167,6 +167,7 @@ class PlaylistsBrowser(Browser, DisplayPatternMixin):
     def __init__(self, library):
         super(PlaylistsBrowser, self).__init__(spacing=6)
         self.set_orientation(Gtk.Orientation.VERTICAL)
+        self._library = library
         self.__render = self.__create_cell_renderer()
         self.__view = view = self.__create_playlists_view(self.__render)
         self.__embed_in_scrolledwin(view)
@@ -478,7 +479,12 @@ class PlaylistsBrowser(Browser, DisplayPatternMixin):
 
         text = self.get_filter_text()
         # TODO: remove static dependency on Query
-        if Query.is_parsable(text):
+        selection = self.__view.get_selection()
+        model, paths = selection.get_selected_rows()
+        playlist_selected = paths and paths[0]
+        if not playlist_selected and not text:
+            songs = filter(lambda s: isinstance(s, AudioFile), self._library)
+        elif Query.is_parsable(text):
             self._query = Query(text, SongList.star)
             songs = self._query.filter(songs)
         GLib.idle_add(self.songs_selected, songs, resort)


### PR DESCRIPTION
In the Playlists view, show all songs when no search term is
present and no playlist is selected.
This fixes #1761.