### PR TITLE
Remove cover loading/caching code from Album

### DIFF
--- a/quodlibet/quodlibet.py
+++ b/quodlibet/quodlibet.py
@@ -78,15 +78,6 @@ def main(argv):
 
     from quodlibet.qltk.songlist import SongList, get_columns
 
-    from quodlibet.util.collection import Album
-    try:
-        cover_size = config.getint("browsers", "cover_size")
-    except config.Error:
-        pass
-    else:
-        if cover_size > 0:
-            Album.COVER_SIZE = cover_size
-
     headers = get_columns()
     SongList.set_all_column_headers(headers)
 

--- a/quodlibet/quodlibet/browsers/albums/main.py
+++ b/quodlibet/quodlibet/browsers/albums/main.py
@@ -77,6 +77,7 @@ def cmpa(a, b):
 
 
 def compare_title(a1, a2):
+    a1, a2 = a1.album, a2.album
     # All albums should stay at the top
     if a1 is None:
         return -1
@@ -92,6 +93,7 @@ def compare_title(a1, a2):
 
 
 def compare_artist(a1, a2):
+    a1, a2 = a1.album, a2.album
     if a1 is None:
         return -1
     if a2 is None:
@@ -107,6 +109,7 @@ def compare_artist(a1, a2):
 
 
 def compare_date(a1, a2):
+    a1, a2 = a1.album, a2.album
     if a1 is None:
         return -1
     if a2 is None:
@@ -121,6 +124,7 @@ def compare_date(a1, a2):
 
 
 def compare_genre(a1, a2):
+    a1, a2 = a1.album, a2.album
     if a1 is None:
         return -1
     if a2 is None:
@@ -137,6 +141,7 @@ def compare_genre(a1, a2):
 
 
 def compare_rating(a1, a2):
+    a1, a2 = a1.album, a2.album
     if a1 is None:
         return -1
     if a2 is None:
@@ -711,12 +716,13 @@ class AlbumList(Browser, util.InstanceTracker, VisibleUpdate,
 
     def list_albums(self):
         model = self.view.get_model()
-        return [row[0].key for row in model if row[0]]
+        return [row[0].album.key for row in model if row[0].album]
 
     def filter_albums(self, values):
         view = self.view
         self.__inhibit()
-        changed = view.select_by_func(lambda r: r[0] and r[0].key in values)
+        changed = view.select_by_func(
+            lambda r: r[0].album and r[0].album.key in values)
         self.__uninhibit()
         if changed:
             self.activate()
@@ -754,7 +760,7 @@ class AlbumList(Browser, util.InstanceTracker, VisibleUpdate,
         else:
 
             def select_fun(row):
-                album = row[0]
+                album = row[0].album
                 if not album:  # all
                     return False
                 return album.str_key in keys
@@ -763,7 +769,7 @@ class AlbumList(Browser, util.InstanceTracker, VisibleUpdate,
 
     def scroll(self, song):
         album_key = song.album_key
-        select = lambda r: r[0] and r[0].key == album_key
+        select = lambda r: r[0].album and r[0].album.key == album_key
         self.view.select_by_func(select, one=True)
 
     def __get_config_string(self):

--- a/quodlibet/quodlibet/browsers/albums/models.py
+++ b/quodlibet/quodlibet/browsers/albums/models.py
@@ -9,19 +9,28 @@ from quodlibet.qltk.models import ObjectStore, ObjectModelFilter
 from quodlibet.qltk.models import ObjectModelSort
 
 
+class AlbumItem(object):
+
+    def __init__(self, album):
+        self.album = album
+
+    def __repr__(self):
+        return repr(self.album)
+
+
 class AlbumModelMixin(object):
 
     def get_albums(self, paths):
-        values = [self.get_value(self.get_iter(p), 0) for p in paths]
+        values = [self.get_value(self.get_iter(p), 0).album for p in paths]
         try:
             values.remove(None)
         except ValueError:
             return values
         else:
-            return [v for v in self.itervalues() if v]
+            return [v.album for v in self.itervalues() if v.album]
 
     def get_album(self, iter_):
-        return self.get_value(iter_, 0)
+        return self.get_value(iter_, 0).album
 
 
 class AlbumModel(ObjectStore, AlbumModelMixin):
@@ -37,8 +46,8 @@ class AlbumModel(ObjectStore, AlbumModelMixin):
             albums.connect("changed", self._change_albums)
         ]
 
-        self.append(row=[None])
-        self.append_many(albums.itervalues())
+        self.append(row=[AlbumItem(None)])
+        self.append_many((AlbumItem(a) for a in albums.itervalues()))
 
     def refresh_all(self):
         """Trigger redraws for all rows"""
@@ -59,15 +68,16 @@ class AlbumModel(ObjectStore, AlbumModelMixin):
             self.row_changed(row.path, row.iter)
 
     def _add_albums(self, library, added):
-        self.append_many(added)
+        self.append_many((AlbumItem(a) for a in added))
         self._update_all()
 
     def _remove_albums(self, library, removed):
         removed_albums = removed.copy()
         iters_remove = []
-        for iter_, value in self.iterrows():
-            if value is not None and value in removed_albums:
-                removed_albums.remove(value)
+        for iter_, item in self.iterrows():
+            album = item.album
+            if album is not None and album in removed_albums:
+                removed_albums.remove(album)
                 iters_remove.append(iter_)
                 if not removed_albums:
                     break
@@ -81,9 +91,10 @@ class AlbumModel(ObjectStore, AlbumModelMixin):
         """Trigger a row redraw for each album that changed"""
 
         changed_albums = changed.copy()
-        for iter_, value in self.iterrows():
-            if value is not None and value in changed_albums:
-                changed_albums.remove(value)
+        for iter_, item in self.iterrows():
+            album = item.album
+            if album is not None and album in changed_albums:
+                changed_albums.remove(album)
                 self.row_changed(self.get_path(iter_), iter_)
                 if not changed_albums:
                     break
@@ -92,7 +103,7 @@ class AlbumModel(ObjectStore, AlbumModelMixin):
 class AlbumFilterModel(ObjectModelFilter, AlbumModelMixin):
 
     def contains_all(self, paths):
-        values = (self.get_value(self.get_iter(p), 0) for p in paths)
+        values = (self.get_value(self.get_iter(p), 0).album for p in paths)
         return None in values
 
 

--- a/quodlibet/quodlibet/browsers/albums/models.py
+++ b/quodlibet/quodlibet/browsers/albums/models.py
@@ -6,7 +6,7 @@
 # published by the Free Software Foundation
 
 from quodlibet import app
-from quodlibet.util.collection import Album
+from quodlibet import config
 from quodlibet.qltk.models import ObjectStore, ObjectModelFilter
 from quodlibet.qltk.models import ObjectModelSort
 
@@ -21,7 +21,10 @@ class AlbumItem(object):
 
     @property
     def COVER_SIZE(self):
-        return Album.COVER_SIZE
+        size = config.getint("browsers", "cover_size")
+        if size <= 0:
+            size = 48
+        return size
 
     def scan_cover(self, force=False, scale_factor=1,
             callback=None, cancel=None):

--- a/quodlibet/quodlibet/browsers/collection/main.py
+++ b/quodlibet/quodlibet/browsers/collection/main.py
@@ -23,12 +23,11 @@ from quodlibet.qltk import Icons
 from quodlibet.qltk.image import scale, add_border_widget, \
     get_surface_for_pixbuf
 from quodlibet.qltk.x import ScrolledWindow, Align, SymbolicIconImage
-from quodlibet.util.collection import Album
 from quodlibet.util import connect_obj
 from quodlibet.util.library import background_filter
 
 from .models import (CollectionTreeStore, CollectionSortModel,
-    CollectionFilterModel, MultiNode, UnknownNode)
+    CollectionFilterModel, MultiNode, UnknownNode, AlbumNode)
 from .prefs import get_headers, Preferences
 
 
@@ -166,10 +165,10 @@ class CollectionBrowser(Browser, util.InstanceTracker):
                     t2 is MultiNode or t2 is UnknownNode:
                 return -cmp(t1, t2)
 
-            if not isinstance(t1, Album):
+            if not isinstance(t1, AlbumNode):
                 return cmp(util.human_sort_key(t1), util.human_sort_key(t2))
 
-            a1, a2 = t1, t2
+            a1, a2 = t1.album, t2.album
             return (cmp(a1.peoplesort and a1.peoplesort[0],
                         a2.peoplesort and a2.peoplesort[0]) or
                         cmp(a1.date or "ZZZZ", a2.date or "ZZZZ") or
@@ -280,8 +279,8 @@ class CollectionBrowser(Browser, util.InstanceTracker):
             return f(obj) and b(obj)
 
         obj = model.get_value(iter_)
-        if isinstance(obj, Album):
-            return check_album(obj)
+        if isinstance(obj, AlbumNode):
+            return check_album(obj.album)
         else:
             for album in model.iter_albums(iter_):
                 if check_album(album):
@@ -317,7 +316,7 @@ class CollectionBrowser(Browser, util.InstanceTracker):
 
     def __play(self, view, path, col):
         model = view.get_model()
-        if isinstance(model[path][0], Album):
+        if isinstance(model[path][0], AlbumNode):
             self.songs_activated()
         else:
             if view.row_expanded(path):

--- a/quodlibet/quodlibet/browsers/collection/main.py
+++ b/quodlibet/quodlibet/browsers/collection/main.py
@@ -20,8 +20,7 @@ from quodlibet.qltk.searchbar import SearchBarBox
 from quodlibet.qltk.songsmenu import SongsMenu
 from quodlibet.qltk.views import AllTreeView
 from quodlibet.qltk import Icons
-from quodlibet.qltk.image import scale, add_border_widget, \
-    get_surface_for_pixbuf
+from quodlibet.qltk.image import add_border_widget, get_surface_for_pixbuf
 from quodlibet.qltk.x import ScrolledWindow, Align, SymbolicIconImage
 from quodlibet.util import connect_obj
 from quodlibet.util.library import background_filter
@@ -184,26 +183,21 @@ class CollectionBrowser(Browser, util.InstanceTracker):
             cell.markup = markup
             cell.set_property('markup', markup)
 
-        def get_scaled_cover(album):
-            # XXX: Cache this somewhere else
-            cover = None
-            if not hasattr(album, "_scaled_cover"):
-                scale_factor = self.get_scale_factor()
-                album.scan_cover(scale_factor=scale_factor)
-                if album.cover:
-                    s = 25 * scale_factor
-                    cover = scale(album.cover, (s, s))
-                    album._scaled_cover = cover
-            else:
-                cover = album._scaled_cover
-            return cover
+        def get_scaled_cover(item):
+            if item.scanned:
+                return item.cover
+
+            scale_factor = self.get_scale_factor()
+            item.scan_cover(scale_factor=scale_factor)
+            return item.cover
 
         def cell_data_pb(column, cell, model, iter_, data):
             album = model.get_album(iter_)
             if album is None:
                 cell.set_property('icon-name', Icons.FOLDER)
             else:
-                cover = get_scaled_cover(album)
+                item = model.get_value(iter_)
+                cover = get_scaled_cover(item)
                 if cover:
                     cover = add_border_widget(cover, view)
                     surface = get_surface_for_pixbuf(self, cover)

--- a/quodlibet/quodlibet/browsers/collection/models.py
+++ b/quodlibet/quodlibet/browsers/collection/models.py
@@ -6,11 +6,11 @@
 # published by the Free Software Foundation
 
 from quodlibet import util
+from quodlibet import config
 from quodlibet import _
 from quodlibet.pattern import XMLFromPattern
 from quodlibet.qltk.models import ObjectTreeStore, ObjectModelFilter
 from quodlibet.qltk.models import ObjectModelSort
-from quodlibet.util.collection import Album
 from quodlibet.compat import iteritems
 
 
@@ -34,7 +34,10 @@ class AlbumNode(object):
 
     @property
     def COVER_SIZE(self):
-        return Album.COVER_SIZE
+        size = config.getint("browsers", "cover_size")
+        if size <= 0:
+            size = 48
+        return size
 
     def scan_cover(self, scale_factor=1):
         if self.scanned or not self.album.songs:

--- a/quodlibet/quodlibet/browsers/collection/models.py
+++ b/quodlibet/quodlibet/browsers/collection/models.py
@@ -10,6 +10,7 @@ from quodlibet import _
 from quodlibet.pattern import XMLFromPattern
 from quodlibet.qltk.models import ObjectTreeStore, ObjectModelFilter
 from quodlibet.qltk.models import ObjectModelSort
+from quodlibet.util.collection import Album
 from quodlibet.compat import iteritems
 
 
@@ -29,6 +30,21 @@ class AlbumNode(object):
 
     def __init__(self, album):
         self.album = album
+        self.scanned = False
+
+    @property
+    def COVER_SIZE(self):
+        return Album.COVER_SIZE
+
+    def scan_cover(self, scale_factor=1):
+        if self.scanned or not self.album.songs:
+            return
+        self.scanned = True
+
+        from quodlibet import app
+        s = self.COVER_SIZE * scale_factor * 0.5
+        self.cover = app.cover_manager.get_pixbuf_many(self.album.songs, s, s)
+
 
 UnknownNode = object()
 MultiNode = object()

--- a/quodlibet/quodlibet/browsers/collection/models.py
+++ b/quodlibet/quodlibet/browsers/collection/models.py
@@ -8,7 +8,6 @@
 from quodlibet import util
 from quodlibet import _
 from quodlibet.pattern import XMLFromPattern
-from quodlibet.util.collection import Album
 from quodlibet.qltk.models import ObjectTreeStore, ObjectModelFilter
 from quodlibet.qltk.models import ObjectModelSort
 from quodlibet.compat import iteritems
@@ -25,6 +24,11 @@ UNKNOWN_PATTERN = "<b><i>%s</i></b>" % _("Unknown %s")
 MULTI_PATTERN = "<b><i>%s</i></b>" % _("Multiple %s Values")
 COUNT_PATTERN = " <span size='small' color='#777'>(%s)</span>"
 
+
+class AlbumNode(object):
+
+    def __init__(self, album):
+        self.album = album
 
 UnknownNode = object()
 MultiNode = object()
@@ -56,7 +60,8 @@ class CollectionModelMixin(object):
         """Returns the path for an album or None"""
 
         def func(model, path, iter_, result):
-            if model[iter_][0] is album:
+            item = model.get_value(iter_)
+            if getattr(item, "album", None) is album:
                 # pygobject bug: treepath only valid in callback,
                 # so make a copy
                 result[0] = path.copy()
@@ -73,13 +78,13 @@ class CollectionModelMixin(object):
     def get_albums_for_iter(self, iter_):
         obj = self.get_value(iter_)
 
-        if isinstance(obj, Album):
-            return {obj}
+        if isinstance(obj, AlbumNode):
+            return {obj.album}
 
         albums = set()
         for child_iter, value in self.iterrows(iter_):
-            if isinstance(value, Album):
-                albums.add(value)
+            if isinstance(value, AlbumNode):
+                albums.add(value.album)
             else:
                 albums.update(self.get_albums_for_iter(child_iter))
         return albums
@@ -88,16 +93,16 @@ class CollectionModelMixin(object):
         """Yields all albums below iter_"""
 
         for child_iter, value in self.iterrows(iter_):
-            if isinstance(value, Album):
-                yield value
+            if isinstance(value, AlbumNode):
+                yield value.album
             else:
                 for album in self.iter_albums(child_iter):
                     yield album
 
     def get_markup(self, tags, iter_):
         obj = self.get_value(iter_, 0)
-        if isinstance(obj, Album):
-            return PAT % obj
+        if isinstance(obj, AlbumNode):
+            return PAT % obj.album
 
         if isinstance(obj, basestring):
             markup = util.escape(obj)
@@ -113,8 +118,8 @@ class CollectionModelMixin(object):
 
     def get_album(self, iter_):
         obj = self.get_value(iter_, 0)
-        if isinstance(obj, Album):
-            return obj
+        if isinstance(obj, AlbumNode):
+            return obj.album
 
 
 class CollectionFilterModel(ObjectModelFilter, CollectionModelMixin):
@@ -144,7 +149,7 @@ class CollectionTreeStore(ObjectTreeStore, CollectionModelMixin):
             # lowest level, add albums
             if isinstance(tree, list):
                 for album in tree:
-                    self.append(parent=iter_, row=[album])
+                    self.append(parent=iter_, row=[AlbumNode(album)])
                 return
 
             # move into existing nodes and remove them from tree
@@ -171,9 +176,9 @@ class CollectionTreeStore(ObjectTreeStore, CollectionModelMixin):
             while child:
                 _remove_albums(albums, child)
                 obj = self[child][0]
-                if isinstance(obj, Album):
+                if isinstance(obj, AlbumNode):
                     # remove albums
-                    if obj in albums:
+                    if obj.album in albums:
                         if not self.remove(child):
                             child = None
                         continue
@@ -201,7 +206,7 @@ class CollectionTreeStore(ObjectTreeStore, CollectionModelMixin):
                 while child:
                     row = self[child]
                     try:
-                        tree.remove(row[0])
+                        tree.remove(row[0].album)
                     except ValueError:
                         pass
                     else:

--- a/quodlibet/quodlibet/ext/songsmenu/albumart.py
+++ b/quodlibet/quodlibet/ext/songsmenu/albumart.py
@@ -364,7 +364,7 @@ class CoverArea(Gtk.VBox, PluginConfigMixin):
                 except:
                     pass
 
-            app.cover_manager.cover_changed([self.song])
+            app.cover_manager.cover_changed([self.song._song])
 
         self.main_win.destroy()
 

--- a/quodlibet/quodlibet/library/libraries.py
+++ b/quodlibet/quodlibet/library/libraries.py
@@ -361,10 +361,6 @@ class AlbumLibrary(Library):
         self._csig = library.connect('changed', self.__changed)
         self.__added(library, library.values(), signal=False)
 
-    def refresh(self, items):
-        """Refresh albums after a manual change."""
-        self._changed(set(items))
-
     def load(self):
         # deprectated
         pass

--- a/quodlibet/quodlibet/qltk/quodlibetwindow.py
+++ b/quodlibet/quodlibet/qltk/quodlibetwindow.py
@@ -367,15 +367,6 @@ class TopBar(Gtk.Toolbar):
 
     def __song_art_changed(self, player, songs, library):
         self.image.refresh()
-        refresh_albums = []
-        for song in songs:
-            # Album browser only (currently):
-            album = library.albums.get(song.album_key, None)
-            if album:
-                album.scan_cover(force=True)
-                refresh_albums.append(album)
-        if refresh_albums:
-            library.albums.refresh(refresh_albums)
 
 
 class QueueButton(Gtk.ToggleButton):

--- a/quodlibet/quodlibet/util/collection.py
+++ b/quodlibet/quodlibet/util/collection.py
@@ -313,23 +313,14 @@ class Album(Collection):
         self.__dict__.pop("peoplesort", None)
         self.__dict__.pop("genre", None)
 
-    def scan_cover(self, force=False, scale_factor=1,
-            callback=None, cancel=None):
+    def scan_cover(self, force=False, scale_factor=1):
         if (self.scanned and not force) or not self.songs:
             return
         self.scanned = True
 
-        def set_cover_cb(pixbuf):
-            self.cover = pixbuf
-            callback()
-
         from quodlibet import app
         s = self.COVER_SIZE * scale_factor
-        if callback is not None:
-            app.cover_manager.get_pixbuf_many_async(
-                self.songs, s, s, cancel, set_cover_cb)
-        else:
-            self.cover = app.cover_manager.get_pixbuf_many(self.songs, s, s)
+        self.cover = app.cover_manager.get_pixbuf_many(self.songs, s, s)
 
     def __repr__(self):
         return "Album(%s)" % repr(self.key)

--- a/quodlibet/quodlibet/util/collection.py
+++ b/quodlibet/quodlibet/util/collection.py
@@ -252,8 +252,6 @@ class Collection(object):
                 if rating is None:
                     return None
                 return util.format_rating(rating)
-            elif key == "cover":
-                return ((self.cover != type(self).cover) and "y") or None
             elif numkey == "filesize":
                 size = self.__get_value("~#" + key)
                 return None if size is None else util.format_size(size)
@@ -274,11 +272,6 @@ class Collection(object):
 class Album(Collection):
     """Like a `Collection` but adds cover scanning, some attributes for sorting
     and uses a set for the songs."""
-
-    COVER_SIZE = 48
-
-    cover = None
-    scanned = False
 
     @util.cached_property
     def peoplesort(self):
@@ -312,15 +305,6 @@ class Album(Collection):
         super(Album, self).finalize()
         self.__dict__.pop("peoplesort", None)
         self.__dict__.pop("genre", None)
-
-    def scan_cover(self, force=False, scale_factor=1):
-        if (self.scanned and not force) or not self.songs:
-            return
-        self.scanned = True
-
-        from quodlibet import app
-        s = self.COVER_SIZE * scale_factor
-        self.cover = app.cover_manager.get_pixbuf_many(self.songs, s, s)
 
     def __repr__(self):
         return "Album(%s)" % repr(self.key)

--- a/quodlibet/tests/test_browsers_albums.py
+++ b/quodlibet/tests/test_browsers_albums.py
@@ -18,6 +18,7 @@ from .helper import realized
 from quodlibet import config
 
 from quodlibet.browsers.albums import AlbumList
+from quodlibet.browsers.albums.models import AlbumItem
 from quodlibet.browsers.albums.prefs import Preferences, DEFAULT_PATTERN_TEXT
 from quodlibet.browsers.albums.main import (compare_title, compare_artist,
     compare_genre, compare_rating, compare_date)
@@ -74,7 +75,7 @@ class TAlbumSort(TestCase):
         song = AudioFile(dict_)
         album = Album(song)
         album.songs.add(song)
-        return album
+        return AlbumItem(album)
 
     def assertOrder(self, func, list_):
         key = cmp_to_key(func)
@@ -89,7 +90,7 @@ class TAlbumSort(TestCase):
         b = self._get_album({"album": "b"})
         n = self._get_album({"album": ""})
 
-        self.assertOrder(compare_title, [None, a, b, n])
+        self.assertOrder(compare_title, [AlbumItem(None), a, b, n])
 
     def test_sort_artist(self):
         a = self._get_album({"album": "b", "artist": "x"})
@@ -97,7 +98,7 @@ class TAlbumSort(TestCase):
         c = self._get_album({"album": "a", "artist": ""})
         n = self._get_album({"album": ""})
 
-        self.assertOrder(compare_artist, [None, a, b, c, n])
+        self.assertOrder(compare_artist, [AlbumItem(None), a, b, c, n])
 
     def test_sort_genre(self):
         a = self._get_album({"album": "b", "genre": "x"})
@@ -105,7 +106,7 @@ class TAlbumSort(TestCase):
         c = self._get_album({"album": "a", "genre": ""})
         n = self._get_album({"album": ""})
 
-        self.assertOrder(compare_genre, [None, a, b, c, n])
+        self.assertOrder(compare_genre, [AlbumItem(None), a, b, c, n])
 
     def test_sort_date(self):
         a = self._get_album({"album": "b", "date": "1970"})
@@ -113,7 +114,7 @@ class TAlbumSort(TestCase):
         c = self._get_album({"album": "a", "date": ""})
         n = self._get_album({"album": ""})
 
-        self.assertOrder(compare_date, [None, a, b, c, n])
+        self.assertOrder(compare_date, [AlbumItem(None), a, b, c, n])
 
     def test_sort_rating(self):
         a = self._get_album({"album": "b", "~#rating": 0.5})
@@ -121,7 +122,7 @@ class TAlbumSort(TestCase):
         c = self._get_album({"album": "x", "~#rating": 0.0})
         n = self._get_album({"album": "", "~#rating": 0.25})
 
-        self.assertOrder(compare_rating, [None, a, b, c, n])
+        self.assertOrder(compare_rating, [AlbumItem(None), a, b, c, n])
 
 
 class TAlbumBrowser(TestCase):

--- a/quodlibet/tests/test_util_collection.py
+++ b/quodlibet/tests/test_util_collection.py
@@ -233,7 +233,6 @@ class TAlbum(TestCase):
         failUnlessEq(album("~performer", "x"), song("~performer", "x"))
         failUnlessEq(album("~performersort", "x"), song("~performersort", "x"))
 
-        failUnlessEq(album("~cover", "x"), song("~cover", "x"))
         failUnlessEq(album("~rating", "x"), song("~rating", "x"))
 
         for p in PEOPLE:


### PR DESCRIPTION
Instead move it into the browsers. This should make it easier to implement changing the cover size at runtime.