### PR TITLE
Fixed broken random album plugin

### DIFF
--- a/quodlibet/quodlibet/ext/events/randomalbum.py
+++ b/quodlibet/quodlibet/ext/events/randomalbum.py
@@ -162,7 +162,7 @@ class RandomAlbum(EventPlugin):
 
     def plugin_on_song_started(self, song):
         one_song = app.player_options.single
-        if song is None and one_song and not app.player.paused:
+        if song is None and not one_song and not app.player.paused:
             browser = app.window.browser
 
             if not browser.can_filter('album'):


### PR DESCRIPTION
The logic got inverted in commit dcfb0471f666a6a1fc8eed2b08be97f2ac442a6d, fairly innocently I think due to confusing wording.

Replaces my previous pull request which was cluttered up with another change.