### PR TITLE
fix for #2072 - The "random album" plugin thinks it can function in the playlist browser

### DIFF
--- a/quodlibet/quodlibet/ext/events/randomalbum.py
+++ b/quodlibet/quodlibet/ext/events/randomalbum.py
@@ -235,8 +235,4 @@ class RandomAlbum(EventPlugin):
             app.player.paused = True
 
     def disabled_for_browser(self, browser):
-        if not browser.can_filter_albums():
-            return True
-        if browser == "Playlists":
-            return True
-        return False
+        return not browser.can_filter_albums() or browser == "Playlists"

--- a/quodlibet/quodlibet/ext/events/randomalbum.py
+++ b/quodlibet/quodlibet/ext/events/randomalbum.py
@@ -165,7 +165,7 @@ class RandomAlbum(EventPlugin):
         if song is None and not one_song and not app.player.paused:
             browser = app.window.browser
 
-            if not browser.can_filter('album'):
+            if self.disabled_for_browser(browser):
                 return
 
             albumlib = app.library.albums
@@ -215,7 +215,7 @@ class RandomAlbum(EventPlugin):
 
     def change_album(self, album):
         browser = app.window.browser
-        if not browser.can_filter('album'):
+        if self.disabled_for_browser(browser):
             return
 
         if browser.can_filter_albums():
@@ -233,3 +233,10 @@ class RandomAlbum(EventPlugin):
             app.player.next()
         except AttributeError:
             app.player.paused = True
+
+    def disabled_for_browser(self, browser):
+        if not browser.can_filter_albums():
+            return True
+        if browser == "Playlists":
+            return True
+        return False


### PR DESCRIPTION
Fix for #2072 - The "ugly" fix mentioned in that issue that should stop the random album plugin causing annoying effects within the playlists browser until the architecture is ready to enact one of the other fixes mentioned in that issue. 