### PR TITLE
Wikipedia plugin - search instead of direct URL

### DIFF
--- a/quodlibet/quodlibet/ext/songsmenu/wikipedia.py
+++ b/quodlibet/quodlibet/ext/songsmenu/wikipedia.py
@@ -16,7 +16,7 @@ from quodlibet.qltk.entry import Entry
 from quodlibet.qltk import Icons
 from quodlibet.plugins.songsmenu import SongsMenuPlugin
 
-WIKI_URL = "https://%s.wikipedia.org/wiki/"
+WIKI_URL = "https://%s.wikipedia.org/wiki/Special:Search/"
 
 
 def get_lang():


### PR DESCRIPTION
The wikipedia plugin tries to convert artist/album metadata to a URL by changing spaces into underscores. This sometimes results in non-valid URLs, specially when accents or special characters are part of the metadata. A way to reduce non-valid URL is by using the search functionality of wikipedia.