### PR TITLE
Fix covergrid preferences: slider release

### DIFF
--- a/quodlibet/quodlibet/browsers/covergrid/prefs.py
+++ b/quodlibet/quodlibet/browsers/covergrid/prefs.py
@@ -3,6 +3,7 @@
 #           2009-2010 Steven Robertson
 #      2012,2013,2016 Nick Boultbee
 #           2009-2013 Christoph Reiter
+#                2016 Mice Pápai
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as
@@ -20,6 +21,7 @@ from quodlibet.qltk import Button, Icons
 from quodlibet.qltk.ccb import ConfigCheckButton
 from quodlibet.util import format_rating
 from quodlibet.util.i18n import numeric_phrase
+from quodlibet.util.dprint import print_d
 
 PEOPLE
 _SOME_PEOPLE = "\n".join([util.tag("artist"), util.tag("performer"),
@@ -79,11 +81,17 @@ class Preferences(qltk.UniqueWindow, EditDisplayPatternMixin):
                    lambda s: browser.toggle_vert())
         vbox.pack_start(cb3, False, True, 0)
 
-        def mag_changed(mag):
+        # Redraws the covers only when the user releases the slider
+        def mag_button_release(mag, _):
+            newmag = mag.get_value()
+            oldmag = config.getfloat("browsers", "covergrid_magnification", 3.)
+            if newmag == oldmag:
+                print_d("Covergrid magnification haven't changed: {0}"
+                        .format(newmag))
+                return
+            print_d('Covergrid magnification update from {0} to {1}'
+                    .format(oldmag, newmag))
             config.set("browsers", "covergrid_magnification", mag.get_value())
-
-        # Only redraws the covers when the user releases the slider
-        def mag_button_release(*_):
             browser.update_mag()
 
         mag_scale = Gtk.HScale(
@@ -92,7 +100,6 @@ class Preferences(qltk.UniqueWindow, EditDisplayPatternMixin):
         mag_scale.set_tooltip_text(_("Cover Magnification"))
         l = Gtk.Label(label=_("Cover Magnification"))
         mag_scale.set_value_pos(Gtk.PositionType.RIGHT)
-        mag_scale.connect('value-changed', mag_changed)
         mag_scale.connect('button-release-event', mag_button_release)
 
         vbox.pack_start(l, False, True, 0)

--- a/quodlibet/quodlibet/browsers/covergrid/prefs.py
+++ b/quodlibet/quodlibet/browsers/covergrid/prefs.py
@@ -81,6 +81,9 @@ class Preferences(qltk.UniqueWindow, EditDisplayPatternMixin):
 
         def mag_changed(mag):
             config.set("browsers", "covergrid_magnification", mag.get_value())
+
+        # Only redraws the covers when the user releases the slider
+        def mag_button_release(*_):
             browser.update_mag()
 
         mag_scale = Gtk.HScale(
@@ -90,6 +93,7 @@ class Preferences(qltk.UniqueWindow, EditDisplayPatternMixin):
         l = Gtk.Label(label=_("Cover Magnification"))
         mag_scale.set_value_pos(Gtk.PositionType.RIGHT)
         mag_scale.connect('value-changed', mag_changed)
+        mag_scale.connect('button-release-event', mag_button_release)
 
         vbox.pack_start(l, False, True, 0)
         vbox.pack_start(mag_scale, False, True, 0)

--- a/quodlibet/quodlibet/browsers/covergrid/prefs.py
+++ b/quodlibet/quodlibet/browsers/covergrid/prefs.py
@@ -56,6 +56,7 @@ class Preferences(qltk.UniqueWindow, EditDisplayPatternMixin):
         self.set_transient_for(qltk.get_top_parent(browser))
         # Do this config-driven setup at instance-time
         self._PREVIEW_ITEM["~rating"] = format_rating(0.75)
+        self.mag_lock = False
 
         box = Gtk.VBox(spacing=6)
         vbox = Gtk.VBox(spacing=6)
@@ -82,7 +83,16 @@ class Preferences(qltk.UniqueWindow, EditDisplayPatternMixin):
         vbox.pack_start(cb3, False, True, 0)
 
         # Redraws the covers only when the user releases the slider
+        def mag_button_press(*_):
+            self.mag_lock = True
+
         def mag_button_release(mag, _):
+            self.mag_lock = False
+            mag_changed(mag)
+
+        def mag_changed(mag):
+            if self.mag_lock:
+                return
             newmag = mag.get_value()
             oldmag = config.getfloat("browsers", "covergrid_magnification", 3.)
             if newmag == oldmag:
@@ -96,11 +106,13 @@ class Preferences(qltk.UniqueWindow, EditDisplayPatternMixin):
 
         mag_scale = Gtk.HScale(
             adjustment=Gtk.Adjustment.new(config.getfloat("browsers",
-                "covergrid_magnification", 3), 0., 10., .5, 5, 0))
+                "covergrid_magnification", 3), 0., 10., .5, .5, 0))
         mag_scale.set_tooltip_text(_("Cover Magnification"))
         l = Gtk.Label(label=_("Cover Magnification"))
         mag_scale.set_value_pos(Gtk.PositionType.RIGHT)
+        mag_scale.connect('button-press-event', mag_button_press)
         mag_scale.connect('button-release-event', mag_button_release)
+        mag_scale.connect('value-changed', mag_changed)
 
         vbox.pack_start(l, False, True, 0)
         vbox.pack_start(mag_scale, False, True, 0)


### PR DESCRIPTION
The UI lagged as hell when I tried to change the cover magnification with the slider. Now it only updates the settings / redraws the covers when:
- The user releases the slider
- The new setting is different from the old one