### PR TITLE
Added '~dirname'-tag to album_key of AudioFile

### DIFF
--- a/quodlibet/quodlibet/formats/_audio.py
+++ b/quodlibet/quodlibet/formats/_audio.py
@@ -146,7 +146,7 @@ class AudioFile(dict, ImageContainer):
                 human(self("albumartistsort", "")),
                 self.get("album_grouping_key") or self.get("labelid") or
                 self.get("musicbrainz_albumid") or "",
-                self.__call__("~dirname"))
+                os.path.dirname(self.get("~filename") or ""))
 
     @util.cached_property
     def sort_key(self):

--- a/quodlibet/quodlibet/formats/_audio.py
+++ b/quodlibet/quodlibet/formats/_audio.py
@@ -145,7 +145,8 @@ class AudioFile(dict, ImageContainer):
         return (human(self("albumsort", "")),
                 human(self("albumartistsort", "")),
                 self.get("album_grouping_key") or self.get("labelid") or
-                self.get("musicbrainz_albumid") or "")
+                self.get("musicbrainz_albumid") or "",
+                self.__call__("~dirname"))
 
     @util.cached_property
     def sort_key(self):

--- a/quodlibet/tests/test_formats__audio.py
+++ b/quodlibet/tests/test_formats__audio.py
@@ -626,14 +626,14 @@ class TAudioFile(TestCase):
 
     def test_album_key(self):
         album_key_tests = [
-            ({}, ((), (), '')),
-            ({'album': 'foo'}, (('foo',), (), '')),
-            ({'labelid': 'foo'}, ((), (), 'foo')),
-            ({'musicbrainz_albumid': 'foo'}, ((), (), 'foo')),
-            ({'album': 'foo', 'labelid': 'bar'}, (('foo',), (), 'bar')),
+            ({}, ((), (), '','/dir')),
+            ({'album': 'foo'}, (('foo',), (), '','/dir')),
+            ({'labelid': 'foo'}, ((), (), 'foo','/dir')),
+            ({'musicbrainz_albumid': 'foo'}, ((), (), 'foo','/dir')),
+            ({'album': 'foo', 'labelid': 'bar'}, (('foo',), (), 'bar','/dir')),
             ({'album': 'foo', 'labelid': 'bar', 'musicbrainz_albumid': 'quux'},
-                (('foo',), (), 'bar')),
-            ({'albumartist': 'a'}, ((), ('a',), '')),
+                (('foo',), (), 'bar','/dir')),
+            ({'albumartist': 'a'}, ((), ('a',), '','/dir')),
             ]
         for tags, expected in album_key_tests:
             afile = AudioFile(**tags)


### PR DESCRIPTION
The album_key of AudioFiles has been expanded by adding the directory name. This is useful if one has multiple copies of the same album in the library. Without this patch these two copies are merged together in one album in albumlist-view; with this patch they are splitted in two albums.