### PR TITLE
Add skip by rating or tag

### DIFF
--- a/quodlibet/po/POTFILES.in
+++ b/quodlibet/po/POTFILES.in
@@ -89,6 +89,7 @@ quodlibet/ext/playorder/follow.py
 quodlibet/ext/playorder/playcounteq.py
 quodlibet/ext/playorder/queue.py
 quodlibet/ext/playorder/reverse.py
+quodlibet/ext/playorder/skip_zeros.py
 quodlibet/ext/playorder/track_repeat.py
 quodlibet/ext/query/conditional.py
 quodlibet/ext/query/pythonexpression.py

--- a/quodlibet/quodlibet/ext/playorder/skip_zeros.py
+++ b/quodlibet/quodlibet/ext/playorder/skip_zeros.py
@@ -53,7 +53,7 @@ class SkipZeros(ShufflePlugin, OrderInOrder, PluginConfigMixin):
     def next(self, playlist, current):
         next = super(SkipZeros, self).next(playlist, current)
 
-        while next is not None and self.shouldSkip(playlist, next):
+        while next is not None and self.should_skip(playlist, next):
             next = super(SkipZeros, self).next(playlist, next)
 
         return next
@@ -61,23 +61,23 @@ class SkipZeros(ShufflePlugin, OrderInOrder, PluginConfigMixin):
     def previous(self, playlist, current):
         previous = super(SkipZeros, self).previous(playlist, current)
 
-        while previous is not None and self.shouldSkip(playlist, previous):
+        while previous is not None and self.should_skip(playlist, previous):
             previous = super(SkipZeros, self).previous(playlist, current)
 
         return previous
 
-    def shouldSkip(self, playlist, song_iter):
-        song_index = playlist.get_path(song_iter).get_indices()[0]
-        song = playlist.get()[song_index]
+    def should_skip(self, playlist, song_iter):
+        song = playlist.get_value(song_iter)
         rating = song("~#rating")
 
-        shouldSkip = False
-        if self.config_get_bool(self._CFG_SKIP_BY_RATING) and rating <= 0:
-            shouldSkip = True
+        should_skip = False
+        if (self.config_get_bool(self._CFG_SKIP_BY_RATING)
+            and song.has_rating and rating <= 0):
+            should_skip = True
             print_d("Rating is %f; skipping..." % (rating))
-        elif self.config_get_bool(self._CFG_SKIP_BY_TAG) and \
-             song("skip") != '':
-            shouldSkip = True
+        elif (self.config_get_bool(self._CFG_SKIP_BY_TAG)
+            and song("skip")):
+            should_skip = True
             print_d("Skip tag present; skipping...")
 
-        return shouldSkip
+        return should_skip

--- a/quodlibet/quodlibet/ext/playorder/skip_zeros.py
+++ b/quodlibet/quodlibet/ext/playorder/skip_zeros.py
@@ -1,24 +1,55 @@
 # -*- coding: utf-8 -*-
-# Copyright 2010 Christoph Reiter
-#           2016 Nick Boultbee
+# Copyright 2016 Nick Boultbee
 #           2017 Jason Heard
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as
 # published by the Free Software Foundation.
 
-from quodlibet import _, print_d
+from gi.repository import Gtk, Pango
+
+from quodlibet import _, print_d, qltk
 from quodlibet.order import OrderInOrder
+from quodlibet.plugins import PluginConfigMixin
 from quodlibet.plugins.playorder import ShufflePlugin
 from quodlibet.qltk import Icons
+from quodlibet.qltk.ccb import ConfigCheckButton
 
 
-class SkipZeros(ShufflePlugin, OrderInOrder):
-    PLUGIN_ID = "skip_zeros"
-    PLUGIN_NAME = _("Skip Zero Rated")
+class SkipZeros(ShufflePlugin, OrderInOrder, PluginConfigMixin):
+    PLUGIN_ID = "skip_songs"
+    PLUGIN_NAME = _("Skip Songs")
     PLUGIN_ICON = Icons.GO_JUMP
-    PLUGIN_DESC = _("Playback skips over songs with a rating of zero unless "
-                    "explicitly played.")
+    PLUGIN_DESC = _("Playback skips over songs with a rating of zero or with "
+                    "a non-empty 'skip' tag unless they are explicitly "
+                    "played.")
+
+
+    _CFG_SKIP_BY_RATING = 'skip_by_rating'
+    _CFG_SKIP_BY_TAG = 'skip_by_tag'
+
+
+    @classmethod
+    def PluginPreferences(self, window):
+        vb = Gtk.VBox(spacing=10)
+        vb.set_border_width(0)
+
+        # Matching Option
+        toggles = [
+            (self._CFG_SKIP_BY_RATING, _("Skip Songs with _Rating of Zero")),
+            (self._CFG_SKIP_BY_TAG, _("Skip Songs with a Non-Empty 'skip' _Tag")),
+        ]
+        vb2 = Gtk.VBox(spacing=6)
+        for key, label in toggles:
+            ccb = ConfigCheckButton(label, 'plugins', self._config_key(key))
+            ccb.set_active(self.config_get_bool(key))
+            vb2.pack_start(ccb, True, True, 0)
+
+        frame = qltk.Frame(label=_("Skipping options"), child=vb2)
+        vb.pack_start(frame, True, True, 0)
+
+        vb.show_all()
+        return vb
 
 
     def next(self, playlist, current):
@@ -45,10 +76,10 @@ class SkipZeros(ShufflePlugin, OrderInOrder):
         rating = song("~#rating")
 
         shouldSkip = False
-        if rating <= 0:
+        if self.config_get_bool(self._CFG_SKIP_BY_RATING) and rating <= 0:
             shouldSkip = True
             print_d("Rating is %f; skipping..." % (rating))
-        elif song("skip") <> '':
+        elif self.config_get_bool(self._CFG_SKIP_BY_TAG) and song("skip") <> '':
             shouldSkip = True
             print_d("Skip tag present; skipping...")
 

--- a/quodlibet/quodlibet/ext/playorder/skip_zeros.py
+++ b/quodlibet/quodlibet/ext/playorder/skip_zeros.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+# Copyright 2010 Christoph Reiter
+#           2016 Nick Boultbee
+#           2017 Jason Heard
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 as
+# published by the Free Software Foundation.
+
+from quodlibet import _, print_d
+from quodlibet.order import OrderInOrder
+from quodlibet.plugins.playorder import ShufflePlugin
+from quodlibet.qltk import Icons
+
+
+class SkipZeros(ShufflePlugin, OrderInOrder):
+    PLUGIN_ID = "skip_zeros"
+    PLUGIN_NAME = _("Skip Zero Rated")
+    PLUGIN_ICON = Icons.GO_JUMP
+    PLUGIN_DESC = _("Playback skips over songs with a rating of zero unless "
+                    "explicitly played.")
+
+
+    def next(self, playlist, current):
+        next = super(SkipZeros, self).next(playlist, current)
+
+        while next is not None and self.shouldSkip(playlist, next):
+            next = super(SkipZeros, self).next(playlist, next)
+
+        return next
+
+
+    def previous(self, playlist, current):
+        previous = super(SkipZeros, self).previous(playlist, current)
+
+        while previous is not None and self.shouldSkip(playlist, previous):
+            previous = super(SkipZeros, self).previous(playlist, current)
+
+        return previous
+
+
+    def shouldSkip(self, playlist, song_iter):
+        song_index = playlist.get_path(song_iter).get_indices()[0]
+        song = playlist.get()[song_index]
+        rating = song("~#rating")
+
+        shouldSkip = False
+        if rating <= 0:
+            shouldSkip = True
+            print_d("Rating is %f; skipping..." % (rating))
+        elif song("skip") <> '':
+            shouldSkip = True
+            print_d("Skip tag present; skipping...")
+
+        return shouldSkip
+

--- a/quodlibet/quodlibet/ext/playorder/skip_zeros.py
+++ b/quodlibet/quodlibet/ext/playorder/skip_zeros.py
@@ -34,14 +34,17 @@ class SkipZeros(ShufflePlugin, OrderInOrder, PluginConfigMixin):
 
         # Matching Option
         toggles = [
-            (self._CFG_SKIP_BY_RATING, _("Skip Songs with _Rating of Zero")),
+            (self._CFG_SKIP_BY_RATING,
+             _("Skip Songs with _Rating of Zero"),
+             True),
             (self._CFG_SKIP_BY_TAG,
-             _("Skip Songs with a Non-Empty 'skip' _Tag")),
+             _("Skip Songs with a Non-Empty 'skip' _Tag"),
+             False),
         ]
         vb2 = Gtk.VBox(spacing=6)
-        for key, label in toggles:
+        for key, label, default in toggles:
             ccb = ConfigCheckButton(label, 'plugins', self._config_key(key))
-            ccb.set_active(self.config_get_bool(key))
+            ccb.set_active(self.config_get_bool(key, default))
             vb2.pack_start(ccb, True, True, 0)
 
         frame = qltk.Frame(label=_("Skipping options"), child=vb2)

--- a/quodlibet/quodlibet/ext/playorder/skip_zeros.py
+++ b/quodlibet/quodlibet/ext/playorder/skip_zeros.py
@@ -6,7 +6,7 @@
 # it under the terms of the GNU General Public License version 2 as
 # published by the Free Software Foundation.
 
-from gi.repository import Gtk, Pango
+from gi.repository import Gtk
 
 from quodlibet import _, print_d, qltk
 from quodlibet.order import OrderInOrder
@@ -24,10 +24,8 @@ class SkipZeros(ShufflePlugin, OrderInOrder, PluginConfigMixin):
                     "a non-empty 'skip' tag unless they are explicitly "
                     "played.")
 
-
     _CFG_SKIP_BY_RATING = 'skip_by_rating'
     _CFG_SKIP_BY_TAG = 'skip_by_tag'
-
 
     @classmethod
     def PluginPreferences(self, window):
@@ -37,7 +35,8 @@ class SkipZeros(ShufflePlugin, OrderInOrder, PluginConfigMixin):
         # Matching Option
         toggles = [
             (self._CFG_SKIP_BY_RATING, _("Skip Songs with _Rating of Zero")),
-            (self._CFG_SKIP_BY_TAG, _("Skip Songs with a Non-Empty 'skip' _Tag")),
+            (self._CFG_SKIP_BY_TAG,
+             _("Skip Songs with a Non-Empty 'skip' _Tag")),
         ]
         vb2 = Gtk.VBox(spacing=6)
         for key, label in toggles:
@@ -51,7 +50,6 @@ class SkipZeros(ShufflePlugin, OrderInOrder, PluginConfigMixin):
         vb.show_all()
         return vb
 
-
     def next(self, playlist, current):
         next = super(SkipZeros, self).next(playlist, current)
 
@@ -60,7 +58,6 @@ class SkipZeros(ShufflePlugin, OrderInOrder, PluginConfigMixin):
 
         return next
 
-
     def previous(self, playlist, current):
         previous = super(SkipZeros, self).previous(playlist, current)
 
@@ -68,7 +65,6 @@ class SkipZeros(ShufflePlugin, OrderInOrder, PluginConfigMixin):
             previous = super(SkipZeros, self).previous(playlist, current)
 
         return previous
-
 
     def shouldSkip(self, playlist, song_iter):
         song_index = playlist.get_path(song_iter).get_indices()[0]
@@ -79,9 +75,9 @@ class SkipZeros(ShufflePlugin, OrderInOrder, PluginConfigMixin):
         if self.config_get_bool(self._CFG_SKIP_BY_RATING) and rating <= 0:
             shouldSkip = True
             print_d("Rating is %f; skipping..." % (rating))
-        elif self.config_get_bool(self._CFG_SKIP_BY_TAG) and song("skip") <> '':
+        elif self.config_get_bool(self._CFG_SKIP_BY_TAG) and \
+             song("skip") != '':
             shouldSkip = True
             print_d("Skip tag present; skipping...")
 
         return shouldSkip
-


### PR DESCRIPTION
This adds a plugin that skips songs automatically if the rating is 0 or they have a non-empty `skip` tag.

I haven't done GTK in Python before, so there are two sections that I wonder if they could be done in a neater way; I'll add line comments for those.

Fixes #2161.