### PR TITLE
replaygain: save selected replaygain profiles to config

### DIFF
--- a/quodlibet/quodlibet/config.py
+++ b/quodlibet/quodlibet/config.py
@@ -203,6 +203,7 @@ setstringlist = _config.setstringlist
 getlist = _config.getlist
 setlist = _config.setlist
 set = _config.set
+unset = _config.unset
 settext = _config.settext
 write = _config.write
 reset = _config.reset

--- a/quodlibet/quodlibet/player/_base.py
+++ b/quodlibet/quodlibet/player/_base.py
@@ -100,6 +100,7 @@ class BasePlayer(GObject.GObject, Equalizer):
 
     def __init__(self, *args, **kwargs):
         super(BasePlayer, self).__init__()
+        self.reload_replaygain_profiles()
 
     def destroy(self):
         """Free resources"""
@@ -110,6 +111,21 @@ class BasePlayer(GObject.GObject, Equalizer):
         self._source = None
 
         self._destroy()
+
+    def reload_replaygain_profiles(self):
+        for index in range(0, 2, 1):
+            profile_key = "replaygain_profile_" + str(index)
+            self.replaygain_profiles[index] = \
+                config.getstringlist("memory", profile_key, None)
+
+    def update_replaygain_profile(self, index, profile):
+        self.replaygain_profiles[index] = profile
+        profile_key = "replaygain_profile_" + str(index)
+        if profile is not None:
+            config.setstringlist("memory", profile_key, profile)
+        else:
+            config.unset("memory", profile_key)
+        self.reset_replaygain()
 
     def calc_replaygain_volume(self, volume):
         """Returns a new float volume for the given volume.
@@ -133,15 +149,12 @@ class BasePlayer(GObject.GObject, Equalizer):
             scale = 1
         return volume * scale
 
-    def _reset_replaygain(self):
-        self.volume = self.volume
-
     def reset_replaygain(self):
         """Call in case something affecting the replaygain adjustment has
         changed to change the output volume
         """
 
-        self._reset_replaygain()
+        self.volume = self.volume
 
     @property
     def has_external_volume(self):

--- a/quodlibet/quodlibet/qltk/controls.py
+++ b/quodlibet/quodlibet/qltk/controls.py
@@ -138,8 +138,7 @@ class VolumeMenu(Gtk.Menu):
 
     def __changed(self, item, player, profile):
         if item.get_active():
-            player.replaygain_profiles[0] = profile
-            player.reset_replaygain()
+            player.update_replaygain_profile(0, profile)
 
     def popup(self, *args):
         gain = config.getboolean("player", "replaygain")

--- a/quodlibet/quodlibet/qltk/playorder.py
+++ b/quodlibet/quodlibet/qltk/playorder.py
@@ -349,8 +349,8 @@ class PlayOrderWidget(Gtk.HBox):
         print_d("Updating %s order to %s"
                 % (type(self.__playlist).__name__, self.order))
         self.__playlist.order = self.order
-        self.__player.replaygain_profiles[2] = shuffler.replaygain_profiles
-        self.__player.reset_replaygain()
+        self.__player \
+            .update_replaygain_profile(2, shuffler.replaygain_profiles)
         if self.order != old_order:
             self.emit('changed')
 

--- a/quodlibet/quodlibet/qltk/quodlibetwindow.py
+++ b/quodlibet/quodlibet/qltk/quodlibetwindow.py
@@ -1219,8 +1219,7 @@ class QuodLibetWindow(Window, PersistentWindowMixin, AppWindow):
 
         container = self.browser.__container = self.browser.pack(self.songpane)
 
-        player.replaygain_profiles[1] = self.browser.replaygain_profiles
-        player.reset_replaygain()
+        player.update_replaygain_profile(1, self.browser.replaygain_profiles)
         self.__browserbox.add(container)
         container.show()
         self._filter_menu.set_browser(self.browser)

--- a/quodlibet/quodlibet/util/config.py
+++ b/quodlibet/quodlibet/util/config.py
@@ -331,6 +331,15 @@ class Config(object):
             else:
                 raise
 
+    def unset(self, section, option):
+        """Unsets the option.
+        """
+
+        try:
+            self._config.remove_option(section, option)
+        except NoSectionError:
+            pass
+
     def settext(self, section, option, value):
         value = text_type(value)
 

--- a/quodlibet/tests/test_qltk_playorder.py
+++ b/quodlibet/tests/test_qltk_playorder.py
@@ -23,6 +23,9 @@ class TPlayOrderWidget(TestCase):
         self.reset_replaygain = lambda: None
         self.po = PlayOrderWidget(self, self)
 
+    def update_replaygain_profile(self, index, profile):
+        self.replaygain_profiles[index] = profile
+
     def tearDown(self):
         self.po.destroy()
         # quodlibet.plugins.quit()


### PR DESCRIPTION
Fixes #2162.

* Add a method to reload profiles from config
* Add a method to update and save a profile
* Add a utility config.unset(...) method