### PR TITLE
deps: require python-feedparser

### DIFF
--- a/quodlibet/NEWS
+++ b/quodlibet/NEWS
@@ -3,6 +3,7 @@
 
 Packaging Changes:
   * **python-zeitgeist** no longer used
+  * **python-feedparser** required (no longer optional)
 
 
 .. _release-3.8.1:

--- a/quodlibet/docs/packaging.rst
+++ b/quodlibet/docs/packaging.rst
@@ -35,6 +35,7 @@ The following software is needed to start Ex Falso or Quod Libet.
 * **GTK+** (>= 3.10)
 * **libsoup** (>= 2.44)
 * On OS X only: **PyObjC**
+* **feedparser**
 
 For icons a complete **icon theme** is needed, preferably with symbolic icons. 
 For example **adwaita-icon-theme** or the older **gnome-icon-theme** + 
@@ -79,9 +80,6 @@ Optional Runtime Dependencies
 
 **udisks2**:
     * For detection of DAPs
-
-**python-feedparser**:
-    * For the feed browser
 
 **libmodplug1**:
     * For MOD support

--- a/quodlibet/quodlibet/browsers/audiofeeds.py
+++ b/quodlibet/quodlibet/browsers/audiofeeds.py
@@ -12,6 +12,7 @@ import threading
 import time
 
 from gi.repository import Gtk, GLib, Pango, Gdk
+import feedparser
 
 import quodlibet
 from quodlibet import _
@@ -20,6 +21,7 @@ from quodlibet import formats
 from quodlibet import print_d
 from quodlibet import qltk
 from quodlibet import util
+from quodlibet import app
 
 from quodlibet.browsers import Browser
 from quodlibet.compat import listfilter, text_type, build_opener, PY2
@@ -545,15 +547,8 @@ class AudioFeeds(Browser):
             self.__view.select_by_func(lambda r: r[0].name in names)
 
 browsers = []
-try:
-    import feedparser
-except ImportError:
-    print_w(_("Could not import %s. Audio Feeds browser disabled.")
-            % "python-feedparser")
+if not app.player or app.player.can_play_uri("http://"):
+    browsers = [AudioFeeds]
 else:
-    from quodlibet import app
-    if not app.player or app.player.can_play_uri("http://"):
-        browsers = [AudioFeeds]
-    else:
-        print_w(_("The current audio backend does not support URLs, "
-                  "Audio Feeds browser disabled."))
+    print_w(_("The current audio backend does not support URLs, "
+              "Audio Feeds browser disabled."))

--- a/quodlibet/quodlibet/update.py
+++ b/quodlibet/quodlibet/update.py
@@ -17,6 +17,7 @@ is used and not the release version.
 """
 
 from gi.repository import Gtk
+import feedparser
 
 import quodlibet
 from quodlibet import _
@@ -55,12 +56,6 @@ def fetch_versions(build_type, timeout=5.0):
 
     Raises UpdateError
     """
-
-    # TODO: we currently don't depend on feedparser.. maybe we should?
-    try:
-        import feedparser
-    except ImportError as error:
-        raise UpdateError(error)
 
     try:
         content = urlopen(


### PR DESCRIPTION
It's quite common, so why not.