### PR TITLE
docs: fix typos

### DIFF
--- a/quodlibet/docs/guide/overview.rst
+++ b/quodlibet/docs/guide/overview.rst
@@ -116,7 +116,7 @@ Besides the active browser in the main window, you can open as many
 different browser windows as you want by selecting one under *Browse* >
 *Open Browser* or in the tray icon plugin context menu.
 
-In an separate browser, double-clicking a song will result in it being
+In a separate browser, double-clicking a song will result in it being
 added to the queue rather than played immediately (as per the main browser).
 
 See the :ref:`Browsers Guide <Browse>` for full details on browsers and the

--- a/quodlibet/docs/guide/playback/replaygain.rst
+++ b/quodlibet/docs/guide/playback/replaygain.rst
@@ -55,7 +55,7 @@ There are two configuration options available:
 
 *Fall-back gain* is the volume adjustment that gets used for songs with no 
 replay gain tags (which have not been analyzed). Most audio files are 
-rather high volume these days and the difference between a 89db song and an 
+rather high volume these days and the difference between an 89db song and an 
 unadjusted song can be quite high (e.g. >9dB). So to avoid a sudden volume 
 jump, try setting this value to the average gain adjustment in your library.
 

--- a/quodlibet/docs/guide/tags/patterns.rst
+++ b/quodlibet/docs/guide/tags/patterns.rst
@@ -68,7 +68,7 @@ In addition to checking if a tag value is empty, the "if" expression can also
 contain a value comparison using the same syntax as the :ref:`search
 <Searching>`:
 
-    ``<sometag=test|the value was test|it was sonething different>``
+    ``<sometag=test|the value was test|it was something different>``
 
 or more complex ones (note the needed escaping):
 

--- a/quodlibet/docs/license.rst
+++ b/quodlibet/docs/license.rst
@@ -19,7 +19,7 @@ Contributors
 
 Email addresses of contributors have been removed; when available they can 
 be found in the source archive. All copyright notices in the archive 
-supercede any here.
+supersede any here.
 
 
 Authors


### PR DESCRIPTION
Found using [mwic](http://jwilk.net/software/mwic) and [anorack](https://github.com/jwilk/anorack).