### PR TITLE
waveformseekbar: Enhance the redraw performance and frequence

### DIFF
--- a/quodlibet/quodlibet/ext/events/waveformseekbar.py
+++ b/quodlibet/quodlibet/ext/events/waveformseekbar.py
@@ -207,6 +207,7 @@ class WaveformScale(Gtk.EventBox):
         self._player = player
         self.set_size_request(40, 40)
         self.position = 0
+        self._last_drawn_position = 0
         self.override_background_color(
             Gtk.StateFlags.NORMAL, Gdk.RGBA(alpha=0))
 
@@ -242,8 +243,9 @@ class WaveformScale(Gtk.EventBox):
         line_width = 1.0 / pixel_ratio
 
         # Compute the thinnest rectangle to redraw
+        last_position_x = self._last_drawn_position * width
         position_x = self.position * width
-        return max(0.0, position_x - line_width), 0.0, \
+        return max(0.0, last_position_x), 0.0, \
                min(width, position_x + line_width), height
 
     def draw_waveform(self, cr, width, height, elapsed_color, remaining_color):
@@ -295,6 +297,8 @@ class WaveformScale(Gtk.EventBox):
             cr.move_to(hx, half_height - val)
             cr.line_to(hx, half_height + val)
             cr.stroke()
+
+        self._last_drawn_position = self.position
 
     def draw_placeholder(self, cr, width, height, color):
         scale_factor = self.get_scale_factor()

--- a/quodlibet/quodlibet/ext/events/waveformseekbar.py
+++ b/quodlibet/quodlibet/ext/events/waveformseekbar.py
@@ -133,14 +133,7 @@ class WaveformSeekBar(Gtk.Box):
         self._update_waveform(player)
 
     def _on_seekable_changed(self, player, *args):
-        if player.info:
-            self._elapsed_label.set_disabled(not player.seekable)
-            self._remaining_label.set_disabled(not player.seekable)
-            self.set_sensitive(player.seekable)
-        else:
-            self._remaining_label.set_disabled(True)
-            self._elapsed_label.set_disabled(True)
-            self.set_sensitive(False)
+        self._update_label(player)
 
     def _on_player_seek(self, player, song, ms):
         self._update(player, True)
@@ -171,6 +164,10 @@ class WaveformSeekBar(Gtk.Box):
 
             self._elapsed_label.set_time(position)
             self._remaining_label.set_time(remaining)
+
+            self._elapsed_label.set_disabled(not player.seekable)
+            self._remaining_label.set_disabled(not player.seekable)
+            self.set_sensitive(player.seekable)
         else:
             self._remaining_label.set_disabled(True)
             self._elapsed_label.set_disabled(True)

--- a/quodlibet/quodlibet/ext/events/waveformseekbar.py
+++ b/quodlibet/quodlibet/ext/events/waveformseekbar.py
@@ -136,7 +136,7 @@ class WaveformSeekBar(Gtk.Box):
         self._update_label(player)
 
     def _on_player_seek(self, player, song, ms):
-        self._update(player, True)
+        self._update(player)
 
     def _on_song_changed(self, library, songs, player):
         if player.info:
@@ -245,8 +245,8 @@ class WaveformScale(Gtk.EventBox):
         # Compute the thinnest rectangle to redraw
         last_position_x = self._last_drawn_position * width
         position_x = self.position * width
-        x = max(0.0, last_position_x)
-        w = max(line_width * 10, min(width, position_x - last_position_x))
+        x = max(0.0, min(last_position_x, position_x) - line_width * 5)
+        w = min(width, abs(position_x - last_position_x) + line_width * 10)
         return x, 0.0, w, height
 
     def draw_waveform(self, cr, width, height, elapsed_color, remaining_color):

--- a/quodlibet/quodlibet/ext/events/waveformseekbar.py
+++ b/quodlibet/quodlibet/ext/events/waveformseekbar.py
@@ -245,8 +245,9 @@ class WaveformScale(Gtk.EventBox):
         # Compute the thinnest rectangle to redraw
         last_position_x = self._last_drawn_position * width
         position_x = self.position * width
-        return max(0.0, last_position_x), 0.0, \
-               min(width, position_x + line_width), height
+        x = max(0.0, last_position_x)
+        w = max(line_width * 10, min(width, position_x - last_position_x))
+        return x, 0.0, w, height
 
     def draw_waveform(self, cr, width, height, elapsed_color, remaining_color):
         scale_factor = self.get_scale_factor()

--- a/quodlibet/quodlibet/qltk/tracker.py
+++ b/quodlibet/quodlibet/qltk/tracker.py
@@ -29,14 +29,22 @@ class TimeTracker(GObject.GObject):
     def __init__(self, player):
         super(TimeTracker, self).__init__()
 
+        self.__interval = 1000
         self.__player = player
         self.__id = None
         self.__stop = False
+        self.__reset = False
         self.__sigs = [
             player.connect("paused", self.__paused, True),
             player.connect("unpaused", self.__paused, False),
         ]
         self.__paused(player, player.paused)
+
+    def set_interval(self, interval):
+        """Update the resolution in milliseconds"""
+
+        self.__interval = interval
+        self.__reset = True
 
     def tick(self):
         """Emit a tick event"""
@@ -58,6 +66,11 @@ class TimeTracker(GObject.GObject):
             self.__source_remove()
             return False
 
+        if self.__reset:
+            self.__reset = False
+            self.__source_remove()
+            self.__paused(self.__player, self.__player.paused)
+
         self.tick()
         return True
 
@@ -69,7 +82,7 @@ class TimeTracker(GObject.GObject):
         else:
             self.__stop = False
             if self.__id is None:
-                self.__id = GLib.timeout_add_seconds(1, self.__update)
+                self.__id = GLib.timeout_add(self.__interval, self.__update)
 
 
 class SongTracker(object):

--- a/quodlibet/quodlibet/qltk/tracker.py
+++ b/quodlibet/quodlibet/qltk/tracker.py
@@ -85,10 +85,9 @@ class TimeTracker(GObject.GObject):
                 # The application is already woke up every seconds
                 # so synchronize to it by calling timeout_add_seconds(...)
                 # if the requested tracker interval is exactly 1 second.
-                if self.__interval == 1000:
-                    self.__id = GLib.timeout_add_seconds(1, self.__update)
-                else:
-                    self.__id = GLib.timeout_add(self.__interval, self.__update)
+                self.__id = GLib.timeout_add_seconds(1, self.__update) \
+                    if self.__interval == 1000 \
+                    else GLib.timeout_add(self.__interval, self.__update)
 
 
 class SongTracker(object):

--- a/quodlibet/quodlibet/qltk/tracker.py
+++ b/quodlibet/quodlibet/qltk/tracker.py
@@ -82,7 +82,13 @@ class TimeTracker(GObject.GObject):
         else:
             self.__stop = False
             if self.__id is None:
-                self.__id = GLib.timeout_add(self.__interval, self.__update)
+                # The application is already woke up every seconds
+                # so synchronize to it by calling timeout_add_seconds(...)
+                # if the requested tracker interval is exactly 1 second.
+                if self.__interval == 1000:
+                    self.__id = GLib.timeout_add_seconds(1, self.__update)
+                else:
+                    self.__id = GLib.timeout_add(self.__interval, self.__update)
 
 
 class SongTracker(object):


### PR DESCRIPTION
I carefully enhanced the performance by using Cairo's clipping mechanism. Now, only the minimum required region of the waveform is queued for redraw.

Then the interval time between the redraws is computed depending on the width of the waveform and the length of the song. With a 2'50 song rendered on half of a MacBookPro 13", the redraw happens every ~250 milliseconds (4 times more than currently). On a full screen MacBookPro 13" it happens every ~90 milliseconds. Due to the careful handling of the clip rectangle, the occupation of the CPU shows no real difference.