### PR TITLE
Allow resizing of panes in PanedBrowser

### DIFF
--- a/quodlibet/quodlibet/browsers/paned/main.py
+++ b/quodlibet/quodlibet/browsers/paned/main.py
@@ -24,6 +24,7 @@ from quodlibet.qltk.searchbar import SearchBarBox
 from quodlibet.qltk.x import ScrolledWindow, Align
 from quodlibet.util.library import background_filter
 from quodlibet.util import connect_destroy
+from quodlibet.qltk.paned import ConfigMultiRHPaned
 
 from .prefs import PreferencesButton
 from .util import get_headers
@@ -103,6 +104,8 @@ class PanedBrowser(Browser, util.InstanceTracker):
         self.main_box = qltk.ConfigRPaned("browsers", "panedbrowser_pos", 0.4)
         self.pack_start(self.main_box, True, True, 0)
 
+        self.multi_paned = ConfigMultiRHPaned("browsers",
+                                              "panedbrowser_pane_widths")
         self.refresh_panes()
 
         for child in self.get_children():
@@ -114,14 +117,13 @@ class PanedBrowser(Browser, util.InstanceTracker):
     def set_wide_mode(self, do_wide):
         hor = Gtk.Orientation.HORIZONTAL
         ver = Gtk.Orientation.VERTICAL
-        panes = self.main_box.get_child1()
 
         if do_wide:
             self.main_box.props.orientation = hor
-            panes.props.orientation = ver
+            self.multi_paned.change_orientation(horizontal=False)
         else:
             self.main_box.props.orientation = ver
-            panes.props.orientation = hor
+            self.multi_paned.change_orientation(horizontal=True)
 
     def _get_text(self):
         return self._sb_box.get_text()
@@ -194,51 +196,29 @@ class PanedBrowser(Browser, util.InstanceTracker):
             pane.scroll(song)
 
     def refresh_panes(self):
-        paned = self.main_box.get_child1()
-        if paned:
-            paned.destroy()
+        self.multi_paned.destroy()
 
         # Fill in the pane list. The last pane reports back to us.
         self._panes = [self]
         for header in reversed(get_headers()):
             pane = Pane(self._library, header, self._panes[0])
+            pane.connect('row-activated',
+                         lambda *x: self.songs_activated())
             self._panes.insert(0, pane)
         self._panes.pop()  # remove self
 
-        # remove saved widths of old paneds to avoid new paneds (having
-        # the same id) getting old lengths
-        options = config.options("browser_paned_widths")
-        for option in options[len(self._panes) - 1:]:
-            config.remove_option("browser_paned_widths", option)
-
-        # root_paned will be the root of a nested paned structure.
-        # if we have three panes - p1, p2 and p3 - root_paned will
-        # eventually look like this: Paned(p1, Paned(p2, p3))
-        root_paned = qltk.ConfigRHPaned("browser_paned_widths", "0", 0.5)
-
-        curr_paned = root_paned
+        # Put the panes in scrollable windows
+        sws = []
         for pane in self._panes:
-            pane.connect('row-activated',
-                         lambda *x: self.songs_activated())
             sw = ScrolledWindow()
             sw.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
             sw.set_shadow_type(Gtk.ShadowType.IN)
             sw.add(pane)
+            sws.append(sw)
 
-            # the last pane should not be nested
-            if pane is self._panes[-1]:
-                curr_paned.pack2(sw, True, False)
-                break
-
-            curr_paned.pack1(sw, True, False)
-            tmp_paned = qltk.ConfigRHPaned("browser_paned_widths",
-                                           str(self._panes.index(pane) + 1),
-                                           0.5)
-            curr_paned.pack2(tmp_paned, True, False)
-            curr_paned = tmp_paned
-
-        root_paned.show_all()
-        self.main_box.pack1(root_paned, True, False)
+        self.multi_paned.set_widgets(sws)
+        self.multi_paned.show_all()
+        self.main_box.pack1(self.multi_paned.get_paned(), True, False)
 
         self.__star = {}
         for p in self._panes:
@@ -253,33 +233,7 @@ class PanedBrowser(Browser, util.InstanceTracker):
         self._panes[-1].uninhibit()
 
     def make_pane_widths_equal(self):
-        paneds = self.get_paneds()
-
-        # the relative paned widths must be equal to the reciprocal (1/i) of
-        # their respective indices (i) in reverse order (from right to left)
-        # to make the pane widths equal.
-        for i, paned in enumerate(reversed(paneds)):
-            width = min(1.0 / (i + 1), 0.5)
-            paned.set_relative(width)
-
-    def get_paneds(self):
-        """Get all paneds in a flat, ordered list.
-
-        Does not include the outermost paned with the song pane.
-        """
-        root_paned = self.main_box.get_child1()
-        paneds = [root_paned]
-
-        # gather all the paneds in the nested structure
-        curr_paned = root_paned
-        while True:
-            child = curr_paned.get_child2()
-            if type(child) is qltk.ConfigRHPaned:
-                paneds.append(child)
-                curr_paned = child
-            else:
-                break
-        return paneds
+        self.multi_paned.make_pane_widths_equal()
 
     def __get_filter_pane(self, key):
         """Get the best pane for filtering etc."""

--- a/quodlibet/quodlibet/browsers/paned/prefs.py
+++ b/quodlibet/quodlibet/browsers/paned/prefs.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # Copyright 2013 Christoph Reiter
 #           2015 Nick Boultbee
+#           2017 Fredrik Strupe
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as
@@ -16,7 +17,7 @@ from quodlibet.qltk.tagscombobox import TagsComboBoxEntry
 from quodlibet.qltk.x import SymbolicIconImage, MenuItem, Button
 from quodlibet.qltk import Icons
 from quodlibet.qltk.menubutton import MenuButton
-from quodlibet.qltk.ccb import ConfigCheckMenuItem
+from quodlibet.qltk.ccb import ConfigCheckMenuItem, ConfigCheckButton
 from quodlibet.util import connect_obj, escape
 from quodlibet.compat import iteritems, iterkeys
 from .util import get_headers, save_headers
@@ -200,16 +201,23 @@ class Preferences(qltk.UniqueWindow):
         editor = PatternEditor()
         editor.headers = get_headers()
 
+        equal_width = ConfigCheckButton(_("Equal pane width"),
+                                        "browsers",
+                                        "equal_pane_width",
+                                        populate=True)
+
         apply_ = Button(_("_Apply"))
-        connect_obj(apply_, "clicked", self.__apply, editor, browser, False)
+        connect_obj(apply_, "clicked", self.__apply, editor,
+                    browser, False, equal_width)
 
         cancel = Button(_("_Cancel"))
         cancel.connect("clicked", lambda x: self.destroy())
 
         box = Gtk.HButtonBox()
         box.set_spacing(6)
-        box.set_layout(Gtk.ButtonBoxStyle.END)
-        box.pack_start(apply_, True, True, 0)
+        box.set_layout(Gtk.ButtonBoxStyle.EDGE)
+        box.pack_start(equal_width, True, True, 0)
+        box.pack_start(apply_, False, False, 0)
         self.use_header_bar()
         if not self.has_close_button():
             box.pack_start(cancel, True, True, 0)
@@ -222,10 +230,13 @@ class Preferences(qltk.UniqueWindow):
         cancel.grab_focus()
         self.get_child().show_all()
 
-    def __apply(self, editor, browser, close):
+    def __apply(self, editor, browser, close, equal_width):
         if editor.headers != get_headers():
             save_headers(editor.headers)
             browser.set_all_panes()
+
+        if equal_width.get_active():
+            browser.make_pane_widths_equal()
 
         if close:
             self.destroy()

--- a/quodlibet/quodlibet/config.py
+++ b/quodlibet/quodlibet/config.py
@@ -96,9 +96,6 @@ INITIAL = {
         "covergrid_magnification": "3.0", # show text in covergrid view
         "covergrid_all": "0", # show "all albums" in covergrid view
     },
-    # width of paneds in the paned browser
-    "browser_paned_widths": {
-    },
     # Kind of a dumping ground right now, should probably be
     # cleaned out later.
     "settings": {

--- a/quodlibet/quodlibet/config.py
+++ b/quodlibet/quodlibet/config.py
@@ -80,6 +80,7 @@ INITIAL = {
             "~people\t<~year|[b][i]<~year>[/i][/b] - ><album>",
         "pane_selection": "", # selected pane values
         "pane_wide_mode": "0", # browser orientation
+        "equal_pane_width": "true", # equal pane width in paned browser
         "background": "", # "global" filter for SearchBar
         "albums": "", # album list
         "album_sort": "0", # album sorting mode, default is title
@@ -94,6 +95,9 @@ INITIAL = {
         "album_text": "1", # show text in covergrid view
         "covergrid_magnification": "3.0", # show text in covergrid view
         "covergrid_all": "0", # show "all albums" in covergrid view
+    },
+    # width of paneds in the paned browser
+    "browser_paned_widths": {
     },
     # Kind of a dumping ground right now, should probably be
     # cleaned out later.

--- a/quodlibet/quodlibet/qltk/paned.py
+++ b/quodlibet/quodlibet/qltk/paned.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 # Copyright 2005 Joe Wreschnig, Michael Urman
+#           2017 Fredrik Strupe
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as

--- a/quodlibet/quodlibet/qltk/paned.py
+++ b/quodlibet/quodlibet/qltk/paned.py
@@ -130,3 +130,169 @@ class ConfigRHPaned(ConfigRPaned):
 
 class ConfigRVPaned(ConfigRPaned):
     ORIENTATION = Gtk.Orientation.VERTICAL
+
+
+class MultiRPaned(object):
+    """A Paned that supports an unlimited number of panes."""
+
+    # The Paned type (horizontal or vertical)
+    PANED = None
+
+    def __init__(self):
+        self._root_paned = None
+
+        if self.PANED is None:
+            explanation = ("PANED is None. Do not directly"
+                           "instantiate MultiRPaned, use"
+                           "one of its subclasses.")
+            raise AttributeError(explanation)
+
+    def set_widgets(self, widgets):
+        """Put a list of widgets in separate panes."""
+
+        # root_paned will be the root of a nested paned structure.
+        # if we have three panes - p1, p2 and p3 - root_paned will
+        # eventually look like this: Paned(p1, Paned(p2, p3))
+        self._root_paned = self.PANED()
+
+        curr_paned = self._root_paned
+        for widget in widgets:
+            # the last widget completes the last paned
+            if widget is widgets[-1]:
+                curr_paned.pack2(widget, True, False)
+                break
+            curr_paned.pack1(widget, True, False)
+
+            # the second last widget ends the nesting
+            if widget is widgets[-2]:
+                continue
+
+            tmp_paned = self.PANED()
+            curr_paned.pack2(tmp_paned, True, False)
+            curr_paned = tmp_paned
+
+    def get_paned(self):
+        """Get the GTK Paned used for displaying."""
+
+        return self._root_paned
+
+    def make_pane_widths_equal(self):
+        paneds = self._get_paneds()
+
+        # the relative paned widths must be equal to the reciprocal (1/i) of
+        # their respective indices (i) in reverse order (from right to left)
+        # to make the pane widths equal. (i + 2) because +1 from changing
+        # from zero- to one-indexed, and +1 for compensating that the last
+        # paned contains two panes
+        for i, paned in enumerate(reversed(paneds)):
+            width = min(1.0 / (i + 2), 0.5)
+            paned.set_relative(width)
+
+    def change_orientation(self, horizontal):
+        """Change the orientation of the paned."""
+
+        hor = Gtk.Orientation.HORIZONTAL
+        ver = Gtk.Orientation.VERTICAL
+
+        for paned in self._get_paneds():
+            paned.props.orientation = hor if horizontal else ver
+
+    def destroy(self):
+        if self._root_paned:
+            self._root_paned.destroy()
+
+    def show_all(self):
+        self._root_paned.show_all()
+
+    def _get_paneds(self):
+        """Get all internal paneds in a flat, ordered list."""
+
+        paneds = [self._root_paned]
+
+        # gather all the paneds in the nested structure
+        curr_paned = self._root_paned
+        while True:
+            child = curr_paned.get_child2()
+            if type(child) is self.PANED:
+                paneds.append(child)
+                curr_paned = child
+            else:
+                break
+
+        return paneds
+
+
+class MultiRHPaned(MultiRPaned):
+    PANED = RHPaned
+
+
+class MultiRVPaned(MultiRPaned):
+    PANED = RVPaned
+
+
+class ConfigMultiRPaned(MultiRPaned):
+
+    def __init__(self, section, option):
+        super(ConfigMultiRPaned, self).__init__()
+        self.section = section
+        self.option = option
+
+    def set_widgets(self, widgets):
+        super(ConfigMultiRPaned, self).set_widgets(widgets)
+        paneds = self._get_paneds()
+
+        # Connect all paneds
+        for paned in paneds:
+            paned.connect('notify::position', self.__changed)
+
+        self._restore_widths()
+
+    def save_widths(self):
+        """Save all current paned widths."""
+
+        paneds = self._get_paneds()
+        if len(paneds) == 1 and not paneds[0].get_child1():
+            # If there's only one pane (i.e. the only paned has just one
+            # child), do not save the paned width, as this will cause
+            # a later added second pane to get the width of the previous
+            # second pane
+            widths = []
+        else:
+            widths = [str(p.get_relative()) for p in paneds]
+
+        config.setstringlist(self.section, self.option, widths)
+
+    def _restore_widths(self):
+        """Restore pane widths from the config."""
+
+        widths = config.getstringlist(self.section, self.option, [])
+        paneds = self._get_paneds()
+
+        if not widths:
+            # If no widths are saved, save the current widths
+            self.__changed()
+        else:
+            # Restore as many widths as we have saved
+            # (and convert them from str to float)
+            for i, width in enumerate(map(float, widths)):
+                if i >= len(paneds):
+                    break
+                paneds[i].set_relative(width)
+            self.__changed()
+
+    def __changed(self, widget=None, event=None):
+        """Callback function for individual paneds. Saves all current paned widths.
+
+        Widget and event default to None, as they aren't really used. They
+        are just required for GTK.
+        """
+
+        self.save_widths()
+
+
+class ConfigMultiRHPaned(ConfigMultiRPaned):
+    PANED = RHPaned
+
+
+class ConfigMultiRVPaned(ConfigMultiRPaned):
+    PANED = RVPaned

--- a/quodlibet/tests/test_browsers_paned.py
+++ b/quodlibet/tests/test_browsers_paned.py
@@ -155,7 +155,7 @@ class TPanedBrowser(TestCase):
         config.set("browsers", "panes", "artist\talbum")
         self.bar.set_all_panes()
 
-        paned = self.bar.get_paneds()[0]
+        paned = self.bar.multi_paned.get_paned()
         paned.set_relative(0.8)
         self.bar.set_all_panes()
         self.failUnlessAlmostEqual(paned.get_relative(), 0.8)
@@ -164,12 +164,11 @@ class TPanedBrowser(TestCase):
         config.set("browsers", "panes", "artist\talbum\t~year\t~#track")
         self.bar.set_all_panes()
         self.bar.make_pane_widths_equal()
-        paneds = self.bar.get_paneds()
+        paneds = self.bar.multi_paned._get_paneds()
 
         self.failUnlessAlmostEqual(paneds[0].get_relative(), 1.0 / 4.0)
         self.failUnlessAlmostEqual(paneds[1].get_relative(), 1.0 / 3.0)
         self.failUnlessAlmostEqual(paneds[2].get_relative(), 1.0 / 2.0)
-        self.failUnlessAlmostEqual(paneds[3].get_relative(), 1.0 / 2.0)
 
     def test_wide_mode(self):
         self.bar.set_all_wide_mode(True)

--- a/quodlibet/tests/test_browsers_paned.py
+++ b/quodlibet/tests/test_browsers_paned.py
@@ -151,6 +151,26 @@ class TPanedBrowser(TestCase):
         self.bar.finalize(False)
         self.bar.set_all_panes()
 
+    def test_restore_pane_width(self):
+        config.set("browsers", "panes", "artist\talbum")
+        self.bar.set_all_panes()
+
+        paned = self.bar.get_paneds()[0]
+        paned.set_relative(0.8)
+        self.bar.set_all_panes()
+        self.failUnlessAlmostEqual(paned.get_relative(), 0.8)
+
+    def test_make_pane_widths_equal(self):
+        config.set("browsers", "panes", "artist\talbum\t~year\t~#track")
+        self.bar.set_all_panes()
+        self.bar.make_pane_widths_equal()
+        paneds = self.bar.get_paneds()
+
+        self.failUnlessAlmostEqual(paneds[0].get_relative(), 1.0 / 4.0)
+        self.failUnlessAlmostEqual(paneds[1].get_relative(), 1.0 / 3.0)
+        self.failUnlessAlmostEqual(paneds[2].get_relative(), 1.0 / 2.0)
+        self.failUnlessAlmostEqual(paneds[3].get_relative(), 1.0 / 2.0)
+
     def test_wide_mode(self):
         self.bar.set_all_wide_mode(True)
         self.bar.set_all_wide_mode(False)

--- a/quodlibet/tests/test_qltk_paned.py
+++ b/quodlibet/tests/test_qltk_paned.py
@@ -5,7 +5,8 @@
 
 from gi.repository import Gtk
 
-from quodlibet.qltk.paned import RVPaned, RHPaned, ConfigRVPaned
+from quodlibet.qltk.paned import RVPaned, RHPaned, ConfigRVPaned, \
+        MultiRVPaned, MultiRHPaned, ConfigMultiRVPaned, ConfigMultiRHPaned
 from quodlibet import config
 
 from . import TestCase
@@ -86,3 +87,114 @@ class TConfigRPaned(TestCase):
 
         config_value = config.getfloat("memory", "foobar")
         self.failUnlessAlmostEqual(config_value, 0.10, 2)
+
+
+class TMultiRPaned(object):
+    Kind = None
+
+    def test_set_widgets(self):
+        """Test if widgets are properly set and in the correct order."""
+        p = self.Kind()
+
+        # 0 widgets
+        p.set_widgets([])
+        paned = p.get_paned()
+        self.assertIsNotNone(paned)
+        self.assertIsNone(paned.get_child1())
+        self.assertIsNone(paned.get_child2())
+
+        # 1 widget
+        sw = Gtk.ScrolledWindow()
+        p.set_widgets([sw])
+        paned = p.get_paned()
+        children = [paned.get_child1(), paned.get_child2()]
+        self.assertIn(sw, children)
+
+        # 2 widgets
+        sws = [Gtk.ScrolledWindow() for _ in range(2)]
+        p.set_widgets(sws)
+        paned = p.get_paned()
+        self.assertIs(sws[0], paned.get_child1())
+        self.assertIs(sws[1], paned.get_child2())
+
+        # 3 wigets
+        sws = [Gtk.ScrolledWindow() for _ in range(3)]
+        p.set_widgets(sws)
+
+        root_paned = p.get_paned()
+        self.assertIs(sws[0], root_paned.get_child1())
+
+        sub_paned = root_paned.get_child2()
+        self.assertIs(sws[1], sub_paned.get_child1())
+        self.assertIs(sws[2], sub_paned.get_child2())
+
+    def test_make_pane_widths_equal(self):
+        p = self.Kind()
+        sws = [Gtk.ScrolledWindow() for _ in range(4)]
+        p.set_widgets(sws)
+        p.make_pane_widths_equal()
+
+        paneds = p._get_paneds()
+        self.failUnlessAlmostEqual(paneds[0].get_relative(), 1.0 / 4.0)
+        self.failUnlessAlmostEqual(paneds[1].get_relative(), 1.0 / 3.0)
+        self.failUnlessAlmostEqual(paneds[2].get_relative(), 1.0 / 2.0)
+
+    def test_change_orientation(self):
+        p = self.Kind()
+        p.set_widgets([Gtk.ScrolledWindow()])
+
+        opposite = Gtk.Orientation.HORIZONTAL
+        horizontal_opposite = True
+        if p.get_paned().props.orientation is Gtk.Orientation.HORIZONTAL:
+            opposite = Gtk.Orientation.VERTICAL
+            horizontal_opposite = False
+
+        p.change_orientation(horizontal=horizontal_opposite)
+        for paned in p._get_paneds():
+            self.assertIs(paned.props.orientation, opposite)
+
+    def test_destroy(self):
+        self.Kind().destroy()
+
+
+class TMultiRHPaned(TestCase, TMultiRPaned):
+    Kind = MultiRHPaned
+
+
+class TMultiRVPaned(TestCase, TMultiRPaned):
+    Kind = MultiRVPaned
+
+
+class TConfigMultiRPaned(object):
+
+    def setUp(self):
+        config.init()
+
+    def tearDown(self):
+        config.quit()
+
+    def test_basic(self):
+        self.assertTrue(config.get("memory", "pane_widths", None) is None)
+
+        p = self.Kind("memory", "pane_widths")
+        sws = [Gtk.ScrolledWindow() for _ in range(3)]
+        p.set_widgets(sws)
+
+        paneds = p._get_paneds()
+        paneds[0].set_relative(0.4)
+        paneds[1].set_relative(0.6)
+        p.save_widths()
+
+        widths = config.getstringlist("memory", "pane_widths")
+        self.assertAlmostEqual(float(widths[0]), 0.4)
+        self.assertAlmostEqual(float(widths[1]), 0.6)
+
+        config.remove_option("memory", "pane_widths")
+
+
+class TConfigMultiRHPaned(TestCase, TConfigMultiRPaned):
+    Kind = ConfigMultiRHPaned
+
+
+class TConfigMultiRVPaned(TestCase, TConfigMultiRPaned):
+    Kind = ConfigMultiRVPaned


### PR DESCRIPTION
Implements #1118 

The way it is implemented is to use a nested paned structure instead of the existing vbox. For example, for three panes - p1, p2 and p3 - the structure will look like Paned(p1, Paned(p2, p3)). Gtk doesn't seem to have paneds with more than two panes, so I'm not sure if this can be solved in any other way.

The pane widths are made persistant by extension of the paneds being instances of ConfigRHPaned. ConfigRHPaned only supports writing its width to a single option variable in the config though, so to enable an arbitrary number of paned widths to be saved, each width is saved in the config under the "browser_paned_widths" section, under options "0", "1" etc.

I'm not sure if this is the preferred way to do it, as I couldn't find anything similar already in the code. But as I see it, the alternative will be to either have an arbitrary number of widths saved under the "browsers" section (not good imo), or to save them as a single list option. The disadvantage with the latter will be that ConfigRHPaned needs to be changed, and I also don't think the paneds can constantly write their widths like they do now if they have to all write to the same option (so it may need to be changed to only write widths on shutdown / browser change). Any input on this?

There's also a checkbox in the paned browser preferences - "Equal pane width" - which is checked by default. When checked, all panes will be set to have equal width when the apply button is clicked, so basically like it has been up until now. The reason for having that checkbox is in case people don't want their pane widths to be changed after adding a new pane.