### PR TITLE
accelerators for "Open Browser" Menu

### DIFF
--- a/quodlibet/quodlibet/qltk/quodlibetwindow.py
+++ b/quodlibet/quodlibet/qltk/quodlibetwindow.py
@@ -1141,7 +1141,8 @@ class QuodLibetWindow(Window, PersistentWindowMixin, AppWindow):
                 LibraryBrowser.open(Kind, library, player)
 
             act.connect('activate', browser_activate, Kind)
-            ag.add_action_with_accel(act, "<Primary><alt>%d" % ((index + 1) % 10,))
+            ag.add_action_with_accel(act,
+                                     "<Primary><alt>%d" % ((index + 1) % 10,))
 
         ui = Gtk.UIManager()
         ui.insert_action_group(ag, -1)

--- a/quodlibet/quodlibet/qltk/quodlibetwindow.py
+++ b/quodlibet/quodlibet/qltk/quodlibetwindow.py
@@ -2,6 +2,7 @@
 # Copyright 2004-2005 Joe Wreschnig, Michael Urman, Iñigo Serna
 #           2012 Christoph Reiter
 #           2012-2016 Nick Boultbee
+#           2017 Uriel Zajaczkovski
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as
@@ -1132,13 +1133,15 @@ class QuodLibetWindow(Window, PersistentWindowMixin, AppWindow):
         for Kind in browsers.browsers:
             action = "Browser" + Kind.__name__
             label = Kind.accelerated_name
+            name = browsers.name(Kind)
+            index = browsers.index(name)
             act = Action(name=action, label=label)
 
             def browser_activate(action, Kind):
                 LibraryBrowser.open(Kind, library, player)
 
             act.connect('activate', browser_activate, Kind)
-            ag.add_action_with_accel(act, None)
+            ag.add_action_with_accel(act, "<Primary><alt>%d" % ((index + 1) % 10,))
 
         ui = Gtk.UIManager()
         ui.insert_action_group(ag, -1)


### PR DESCRIPTION
The ability to open a secondary browser while playing music in the main browser is a nice way browse the library while listening to music. This is a feature that I suspect is frequently used by other users as well, yet it lacks shortcuts. This PR adds shortcuts for all the available browsers. It replicates the main shortcuts with the addition of the _alt_ modifier.