### PR TITLE
headerbar: layout player controls in headerbar when running on Gnome

### DIFF
--- a/quodlibet/quodlibet/qltk/controls.py
+++ b/quodlibet/quodlibet/qltk/controls.py
@@ -236,6 +236,30 @@ class PlayPauseButton(Gtk.Button):
             player.paused = not self.get_active()
 
 
+class PreviousSongButton(Gtk.Button):
+
+    def __init__(self, player, relief=Gtk.ReliefStyle.NONE):
+        super(PreviousSongButton, self).__init__(relief=relief)
+        self.add(SymbolicIconImage("media-skip-backward",
+                                   Gtk.IconSize.LARGE_TOOLBAR))
+        self.connect('clicked', self.__clicked, player)
+
+    def __clicked(self, button, player):
+        player.previous()
+
+
+class NextSongButton(Gtk.Button):
+
+    def __init__(self, player, relief=Gtk.ReliefStyle.NONE):
+        super(NextSongButton, self).__init__(relief=relief)
+        self.add(SymbolicIconImage("media-skip-forward",
+                                   Gtk.IconSize.LARGE_TOOLBAR))
+        self.connect('clicked', self.__clicked, player)
+
+    def __clicked(self, button, player):
+        player.next()
+
+
 class PlayControls(Gtk.VBox):
 
     def __init__(self, player, library):
@@ -245,17 +269,13 @@ class PlayControls(Gtk.VBox):
         upper.set_row_spacings(3)
         upper.set_col_spacings(3)
 
-        prev = Gtk.Button(relief=Gtk.ReliefStyle.NONE)
-        prev.add(SymbolicIconImage("media-skip-backward",
-                                   Gtk.IconSize.LARGE_TOOLBAR))
+        prev = PreviousSongButton(player)
         upper.attach(prev, 0, 1, 0, 1)
 
         play = PlayPauseButton(player)
         upper.attach(play, 1, 2, 0, 1)
 
-        next_ = Gtk.Button(relief=Gtk.ReliefStyle.NONE)
-        next_.add(SymbolicIconImage("media-skip-forward",
-                                    Gtk.IconSize.LARGE_TOOLBAR))
+        next_ = NextSongButton(player)
         upper.attach(next_, 2, 3, 0, 1)
 
         lower = Gtk.Table(n_rows=1, n_columns=3, homogeneous=True)
@@ -281,12 +301,3 @@ class PlayControls(Gtk.VBox):
 
         self.pack_start(upper, False, True, 0)
         self.pack_start(lower, False, True, 0)
-
-        connect_obj(prev, 'clicked', self.__previous, player)
-        connect_obj(next_, 'clicked', self.__next, player)
-
-    def __previous(self, player):
-        player.previous()
-
-    def __next(self, player):
-        player.next()

--- a/quodlibet/quodlibet/qltk/quodlibetwindow.py
+++ b/quodlibet/quodlibet/qltk/quodlibetwindow.py
@@ -302,16 +302,7 @@ class TopBar(Gtk.Toolbar):
         # play controls
         control_item = Gtk.ToolItem()
         self.insert(control_item, 0)
-        t = PlayControls(player, library.librarian)
-        self.volume = t.volume
-
-        # only restore the volume in case it is managed locally, otherwise
-        # this could affect the system volume
-        if not player.has_external_volume:
-            player.volume = config.getfloat("memory", "volume")
-
-        connect_destroy(player, "notify::volume", self._on_volume_changed)
-        control_item.add(t)
+        control_item.add(PlayControls(player, library.librarian))
 
         self.insert(Gtk.SeparatorToolItem(), 1)
 
@@ -361,9 +352,6 @@ class TopBar(Gtk.Toolbar):
 
         if widget:
             self._pattern_box.pack_start(widget, False, True, 0)
-
-    def _on_volume_changed(self, player, *args):
-        config.set("memory", "volume", str(player.volume))
 
     def __new_song(self, player, song):
         self.image.set_song(song)

--- a/quodlibet/quodlibet/qltk/quodlibetwindow.py
+++ b/quodlibet/quodlibet/qltk/quodlibetwindow.py
@@ -297,10 +297,10 @@ class MainSongList(SongList):
 
 
 class TopBar(Gtk.Toolbar):
-    def __init__(self, parent, player, library):
+    def __init__(self, parent, player, library, player_controls):
         super(TopBar, self).__init__()
 
-        if not util.is_linux() or not util.is_gnome():
+        if player_controls:
             # play controls
             control_item = Gtk.ToolItem()
             self.insert(control_item, 0)
@@ -673,22 +673,23 @@ class QuodLibetWindow(Window, PersistentWindowMixin, AppWindow):
         self.__player = player
         self.__library = library
 
-        if util.is_linux() and util.is_gnome():
-            self._header_bar = header_bar = self.use_header_bar()
+        self._header_bar = self.use_header_bar() \
+            if util.is_linux() and util.is_gnome() else None
 
+        if self._header_bar:
             # Previous, Play/Pause, Next
             box = Gtk.HBox()
             box.get_style_context().add_class(Gtk.STYLE_CLASS_LINKED)
             box.add(PreviousSongButton(player, relief=Gtk.ReliefStyle.NORMAL))
             box.add(PlayPauseButton(player, relief=Gtk.ReliefStyle.NORMAL))
             box.add(NextSongButton(player, relief=Gtk.ReliefStyle.NORMAL))
-            header_bar.pack_start(box)
+            self._header_bar.pack_start(box)
 
             # Volume
             volume = Volume(player, relief=Gtk.ReliefStyle.NORMAL)
-            header_bar.pack_end(volume)
+            self._header_bar.pack_end(volume)
 
-            header_bar.show_all()
+            self._header_bar.show_all()
 
         # create main menubar, load/restore accelerator groups
         ui = self.__create_menu(player, library)
@@ -749,7 +750,7 @@ class QuodLibetWindow(Window, PersistentWindowMixin, AppWindow):
         self.playlist = PlaylistMux(
             player, self.qexpander.model, self.songlist.model)
 
-        top_bar = TopBar(self, player, library)
+        top_bar = TopBar(self, player, library, not self._header_bar)
         main_box.pack_start(top_bar, False, True, 0)
         self.top_bar = top_bar
 
@@ -1273,7 +1274,7 @@ class QuodLibetWindow(Window, PersistentWindowMixin, AppWindow):
         if song:
             tag = config.gettext("settings", "window_title_pattern")
             subtitle = song.comma(tag)
-            if util.is_linux() and util.is_gnome():
+            if self._header_bar:
                 self._header_bar.set_subtitle(subtitle)
             else:
                 title = subtitle + " - " + title

--- a/quodlibet/quodlibet/util/__init__.py
+++ b/quodlibet/quodlibet/util/__init__.py
@@ -35,7 +35,7 @@ from quodlibet.util.string.titlecase import title
 from quodlibet.const import SUPPORT_EMAIL, COPYRIGHT
 from quodlibet.util.dprint import print_d, print_, print_e, print_w, print_exc
 from .misc import cached_func, get_module_dir, get_ca_file
-from .environment import is_plasma, is_unity, is_enlightenment, \
+from .environment import is_gnome, is_plasma, is_unity, is_enlightenment, \
     is_linux, is_windows, is_wine, is_osx, is_py2exe, is_py2exe_console, \
     is_py2exe_window
 from .enum import enum
@@ -43,9 +43,9 @@ from .i18n import _, C_
 
 
 # pyflakes
-cached_func, enum, print_w, print_exc, is_plasma, is_unity, is_enlightenment,
-is_linux, is_windows, is_wine, is_osx, is_py2exe, is_py2exe_console,
-is_py2exe_window, get_module_dir, get_ca_file
+cached_func, enum, print_w, print_exc, is_gnome, is_plasma, is_unity,
+is_enlightenment, is_linux, is_windows, is_wine, is_osx, is_py2exe,
+is_py2exe_console, is_py2exe_window, get_module_dir, get_ca_file
 
 
 if PY2:

--- a/quodlibet/quodlibet/util/environment.py
+++ b/quodlibet/quodlibet/util/environment.py
@@ -32,6 +32,12 @@ def _dbus_name_owned(name):
         return False
 
 
+def is_gnome():
+    """If we are running under Gnome"""
+
+    return not is_plasma() and not is_unity() and not is_enlightenment()
+
+
 def is_plasma():
     """If we are running under plasma"""
 


### PR DESCRIPTION
Fixes #2297.

* cleaned and encapsulate player controls' behavior
* introduced an `is_gnome()` helper
* use the header bar to layout player controls when running on Gnome

I was not very sure for the implementation of `is_gnome()`. I guess that a Gnome-specific dbus service to test would be more correct and more efficient, but I was dry on that.