### PR TITLE
fix title if main window title in advanced preferences is empty

### DIFF
--- a/quodlibet/quodlibet/qltk/quodlibetwindow.py
+++ b/quodlibet/quodlibet/qltk/quodlibetwindow.py
@@ -1264,7 +1264,8 @@ class QuodLibetWindow(Window, PersistentWindowMixin, AppWindow):
         title = "Quod Libet"
         if song:
             tag = config.gettext("settings", "window_title_pattern")
-            title = song.comma(tag) + " - " + title
+            if tag:
+                title = song.comma(tag) + " - " + title
         self.set_title(title)
 
     def __song_started(self, player, song):


### PR DESCRIPTION
This is a (very) silly edge case. If "Main Window Title" in "Advanced Preferences" plugin is empty the the main window title is " - Quod Libet" which looks a bit weird. This PR fixes that by replacing the title with "Quod Libet"