### PR TITLE
Rework parts of the file/folderchooser handling

### DIFF
--- a/quodlibet/quodlibet/browsers/audiofeeds.py
+++ b/quodlibet/quodlibet/browsers/audiofeeds.py
@@ -34,8 +34,8 @@ from quodlibet.qltk.songsmenu import SongsMenu
 from quodlibet.qltk.views import AllTreeView
 from quodlibet.qltk import Icons
 from quodlibet.util import connect_obj, print_w
-from quodlibet.util.path import get_home_dir
 from quodlibet.qltk.x import ScrolledWindow, Align, Button, MenuItem
+from quodlibet.qltk.chooser import choose_target_file, choose_target_folder
 from quodlibet.util.picklehelper import pickle_load, pickle_dump, PickleError
 
 
@@ -267,8 +267,6 @@ class AudioFeeds(Browser):
     priority = 20
     uses_main_library = False
 
-    __last_folder = get_home_dir()
-
     def pack(self, songpane):
         container = qltk.ConfigRHPaned("browsers", "audiofeeds_pos", 0.4)
         self.show()
@@ -357,43 +355,21 @@ class AudioFeeds(Browser):
         return menu
 
     def __download_many(self, activator, sources):
-        chooser = Gtk.FileChooserDialog(
-            title=_("Download Files"), parent=qltk.get_top_parent(self),
-            action=Gtk.FileChooserAction.CREATE_FOLDER)
-        chooser.add_button(_("_Cancel"), Gtk.ResponseType.CANCEL)
-        chooser.add_button(_("_Save"), Gtk.ResponseType.OK)
-        chooser.set_current_folder(self.__last_folder)
-        resp = chooser.run()
-        if resp == Gtk.ResponseType.OK:
-            target = chooser.get_filename()
-            if target:
-                type(self).__last_folder = os.path.dirname(target)
-                for i, source in enumerate(sources):
-                    base = os.path.basename(source)
-                    if not base:
-                        base = ("file%d" % i) + (
-                            os.path.splitext(source)[1] or ".audio")
-                    fulltarget = os.path.join(target, base)
-                    DownloadWindow.download(source, fulltarget, self)
-        chooser.destroy()
+        target = choose_target_folder(self, _("Download Files"), _("_Save"))
+        if target is not None:
+            for i, source in enumerate(sources):
+                base = os.path.basename(source)
+                if not base:
+                    base = ("file%d" % i) + (
+                        os.path.splitext(source)[1] or ".audio")
+                fulltarget = os.path.join(target, base)
+                DownloadWindow.download(source, fulltarget, self)
 
     def __download(self, activator, source):
-        chooser = Gtk.FileChooserDialog(
-            title=_("Download File"), parent=qltk.get_top_parent(self),
-            action=Gtk.FileChooserAction.SAVE)
-        chooser.add_button(_("_Cancel"), Gtk.ResponseType.CANCEL)
-        chooser.add_button(_("_Save"), Gtk.ResponseType.OK)
-        chooser.set_current_folder(self.__last_folder)
         name = os.path.basename(source)
-        if name:
-            chooser.set_current_name(name)
-        resp = chooser.run()
-        if resp == Gtk.ResponseType.OK:
-            target = chooser.get_filename()
-            if target:
-                type(self).__last_folder = os.path.dirname(target)
-                DownloadWindow.download(source, target, self)
-        chooser.destroy()
+        target = choose_target_file(self, _("Download File"), _("_Save"), name)
+        if target is not None:
+            DownloadWindow.download(source, target, self)
 
     def __init__(self, library):
         super(AudioFeeds, self).__init__(spacing=6)

--- a/quodlibet/quodlibet/browsers/playlists/main.py
+++ b/quodlibet/quodlibet/browsers/playlists/main.py
@@ -31,9 +31,9 @@ from quodlibet.qltk.songsmenu import SongsMenu
 from quodlibet.qltk.views import RCMHintedTreeView
 from quodlibet.qltk.x import ScrolledWindow, Align, MenuItem, SymbolicIconImage
 from quodlibet.qltk import Icons
+from quodlibet.qltk.chooser import choose_files, create_chooser_filter
 from quodlibet.query import Query
 from quodlibet.util import connect_obj
-from quodlibet.util.path import get_home_dir
 from quodlibet.util.dprint import print_d, print_w
 from quodlibet.util.collection import FileBackedPlaylist
 from quodlibet.util.urllib import urlopen
@@ -572,23 +572,15 @@ class PlaylistsBrowser(Browser, DisplayPatternMixin):
             self._select_playlist(playlist, scroll=True)
 
     def __import(self, activator, library):
-        filt = lambda fn: fn.endswith(".pls") or fn.endswith(".m3u")
-        from quodlibet.qltk.chooser import FileChooser
-        chooser = FileChooser(self, _("Import Playlist"), filt, get_home_dir())
-        files = chooser.run()
-        chooser.destroy()
-        for filename in files:
+        cf = create_chooser_filter(_("Playlists"), ["*.pls", "*.m3u"])
+        fns = choose_files(self, _("Import Playlist"), _("_Import"), cf)
+        for filename in fns:
             if filename.endswith(".m3u"):
                 playlist = parse_m3u(filename, library=library)
             elif filename.endswith(".pls"):
                 playlist = parse_pls(filename, library=library)
             else:
-                qltk.ErrorMessage(
-                    qltk.get_top_parent(self),
-                    _("Unable to import playlist"),
-                    _("Quod Libet can only import playlists in the M3U "
-                      "and PLS formats.")).run()
-                return
+                continue
             self.changed(playlist)
             library.add(playlist)
 

--- a/quodlibet/quodlibet/ext/songsmenu/html.py
+++ b/quodlibet/quodlibet/ext/songsmenu/html.py
@@ -5,12 +5,11 @@
 # it under the terms of the GNU General Public License version 2 as
 # published by the Free Software Foundation
 
-from gi.repository import Gtk
-
 from quodlibet import _
 from quodlibet.qltk import Icons
 from quodlibet.util import tag, escape
 from quodlibet.qltk.songlist import get_columns
+from quodlibet.qltk.chooser import choose_target_file
 from quodlibet.plugins.songsmenu import SongsMenuPlugin
 from quodlibet.compat import text_type
 
@@ -73,19 +72,8 @@ class ExportToHTML(SongsMenuPlugin):
         if not songs:
             return
 
-        chooser = Gtk.FileChooserDialog(
-            title="Export to HTML",
-            action=Gtk.FileChooserAction.SAVE)
-        chooser.add_button(_("_Cancel"), Gtk.ResponseType.REJECT)
-        chooser.add_button(_("_OK"), Gtk.ResponseType.ACCEPT)
-        chooser.set_default_response(Gtk.ResponseType.ACCEPT)
-        resp = chooser.run()
-        if resp != Gtk.ResponseType.ACCEPT:
-            chooser.destroy()
-            return
-
-        fn = chooser.get_filename()
-        chooser.destroy()
-
-        with open(fn, "wb") as f:
-            f.write(to_html(songs).encode("utf-8"))
+        target = choose_target_file(
+            self.plugin_window, _("Export to HTML"), _("_Save"))
+        if target is not None:
+            with open(target, "wb") as f:
+                f.write(to_html(songs).encode("utf-8"))

--- a/quodlibet/quodlibet/qltk/chooser.py
+++ b/quodlibet/quodlibet/qltk/chooser.py
@@ -1,57 +1,260 @@
 # -*- coding: utf-8 -*-
-# Copyright 2004-2005 Joe Wreschnig, Michael Urman, Iñigo Serna
+# Copyright 2017 Christoph Reiter
 #
 # This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License version 2 as
-# published by the Free Software Foundation
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+
+import os
+import contextlib
 
 from gi.repository import Gtk
+from senf import fsnative, path2fsn, fsn2bytes, bytes2fsn
 
 from quodlibet import _
+from quodlibet import config
 from quodlibet.qltk import get_top_parent
-from quodlibet.qltk import Icons
-from quodlibet.qltk.window import Dialog
+from quodlibet.util.path import fsn2glib, glib2fsn, get_home_dir
 
 
-class FolderChooser(Gtk.FileChooserDialog, Dialog):
-    """Choose folders and return them when run.
-
-    Note: works with glib paths
+def _get_chooser(accept_label, cancel_label):
+    """
+    Args:
+        accept_label (text_type)
+        cancel_label (text_type)
+    Returns:
+        Gtk.FileChooser
     """
 
-    def __init__(self, parent, title, initial_dir=None,
-                 action=Gtk.FileChooserAction.SELECT_FOLDER):
-        super(FolderChooser, self).__init__(
-            title=title, transient_for=get_top_parent(parent), action=action)
+    if hasattr(Gtk, "FileChooserNative"):
+        FileChooser = Gtk.FileChooserNative
+    else:
+        FileChooser = Gtk.FileChooserDialog
 
-        self.add_button(_("_Cancel"), Gtk.ResponseType.CANCEL)
-        self.add_icon_button(_("_Open"), Icons.DOCUMENT_OPEN,
-                             Gtk.ResponseType.OK)
+    chooser = FileChooser()
 
-        if initial_dir:
-            self.set_current_folder(initial_dir)
-        self.set_local_only(True)
-        self.set_select_multiple(True)
+    if hasattr(chooser, "set_accept_label"):
+        chooser.set_accept_label(accept_label)
+    else:
+        chooser.add_button(accept_label, Gtk.ResponseType.ACCEPT)
+        chooser.set_default_response(Gtk.ResponseType.ACCEPT)
 
-    def run(self):
-        resp = super(FolderChooser, self).run()
-        fns = self.get_filenames()
-        if resp == Gtk.ResponseType.OK:
-            return fns
-        else:
-            return []
+    if hasattr(chooser, "set_cancel_label"):
+        chooser.set_cancel_label(cancel_label)
+    else:
+        chooser.add_button(cancel_label, Gtk.ResponseType.CANCEL)
+
+    return chooser
 
 
-class FileChooser(FolderChooser):
-    """Choose files and return them when run."""
+_response = None
 
-    def __init__(self, parent, title, filter=None, initial_dir=None):
-        super(FileChooser, self).__init__(
-            parent, title, initial_dir, Gtk.FileChooserAction.OPEN)
-        if filter:
-            def new_filter(args, realfilter):
-                return realfilter(args.filename)
-            f = Gtk.FileFilter()
-            f.set_name(_("Songs"))
-            f.add_custom(Gtk.FileFilterFlags.FILENAME, new_filter, filter)
-            self.add_filter(f)
+
+@contextlib.contextmanager
+def with_response(resp):
+    # for testing
+    global _response
+
+    _response = resp
+    yield
+    _response = None
+
+
+def _run_chooser(parent, chooser):
+    """Run the chooser ("blocking") and return a list of paths.
+
+    Args:
+        parent (Gtk.Widget)
+        chooser (Gtk.FileChooser)
+    Returns:
+        List[fsnative]
+    """
+
+    chooser.set_current_folder(fsn2glib(get_current_dir()))
+    chooser.set_transient_for(get_top_parent(parent))
+
+    if _response is not None:
+        response = _response
+    else:
+        response = chooser.run()
+
+    if response == Gtk.ResponseType.ACCEPT:
+        result = [glib2fsn(fn) for fn in chooser.get_filenames()]
+
+        current_dir = chooser.get_current_folder()
+        if current_dir:
+            set_current_dir(glib2fsn(current_dir))
+    else:
+        result = []
+    chooser.destroy()
+    return result
+
+
+def find_nearest_dir(path):
+    """Given a path return the closes existing directory. Either itself
+    or a parent. In case it can't find one it returns None.
+
+    Returns:
+        fsnative or None
+    """
+
+    path = os.path.abspath(path)
+
+    def is_ok(p):
+        return os.path.exists(p) and os.path.isdir(p)
+
+    while not is_ok(path):
+        dirname = os.path.dirname(path)
+        if dirname == path:
+            return None
+        path = dirname
+
+    return path
+
+
+def get_current_dir():
+    """Returns the currently active chooser directory path.
+    The path might not actually exist.
+
+    Returns:
+        fsnative
+    """
+
+    data = config.getbytes("memory", "chooser_dir", b"")
+    try:
+        path = bytes2fsn(data, "utf-8") or None
+    except ValueError:
+        path = None
+
+    # the last user dir might not be there any more, try showing a parent
+    # instead
+    if path is not None:
+        path = find_nearest_dir(path)
+
+    if path is None:
+        path = get_home_dir()
+
+    return path
+
+
+def set_current_dir(path):
+    """Set the current chooser directory.
+
+    Args:
+        path (fsnative)
+    """
+
+    assert isinstance(path, fsnative)
+    data = fsn2bytes(path, "utf-8")
+    config.setbytes("memory", "chooser_dir", data)
+
+
+def create_chooser_filter(name, patterns):
+    """Create a Gtk.FileFilter that also works on Windows
+
+    Args:
+        name (text_type): The name of the filter
+        patterns (List[pathlike]): A list of glob patterns
+    Returns:
+        Gtk.FileFilter
+    """
+
+    # The Windows FileChooserNative implementation only supports patterns
+    filter_ = Gtk.FileFilter()
+    filter_.set_name(name)
+    for pattern in sorted(set(patterns)):
+        filter_.add_pattern(fsn2glib(path2fsn(pattern)))
+    return filter_
+
+
+def choose_folders(parent, title, action_title):
+    """Opens a folder chooser widget and returns a list of folders selected.
+
+    Args:
+        parent (Gtk.Widget)
+        title (text_type): The window title
+        action_title (text_type): The button title
+    Returns:
+        List[fsnative]
+    """
+
+    chooser = _get_chooser(action_title, _("_Cancel"))
+    chooser.set_title(title)
+    chooser.set_action(Gtk.FileChooserAction.SELECT_FOLDER)
+    chooser.set_local_only(True)
+    chooser.set_select_multiple(True)
+
+    return _run_chooser(parent, chooser)
+
+
+def choose_files(parent, title, action_title, filter_=None):
+    """Opens a folder chooser widget and returns a list of folders selected.
+
+    Args:
+        parent (Gtk.Widget)
+        title (text_type): The window title
+        action_title (text_type): The button title
+        filter_ (Gtk.FileFilter or None)
+    Returns:
+        List[fsnative]
+    """
+
+    chooser = _get_chooser(action_title, _("_Cancel"))
+    chooser.set_title(title)
+    chooser.set_action(Gtk.FileChooserAction.OPEN)
+    chooser.set_local_only(True)
+    chooser.set_select_multiple(True)
+
+    if filter_ is not None:
+        chooser.add_filter(filter_)
+
+    return _run_chooser(parent, chooser)
+
+
+def choose_target_file(parent, title, action_title, name_suggestion=None):
+    """Opens a file chooser for saving a file.
+
+    Args:
+        parent (Gtk.Widget)
+        title (text_type): The window title
+        action_title (text_type): The button title
+        name_suggestion (text_type): The suggested file name (not fsnative)
+    Returns:
+        fsnative or None
+    """
+
+    chooser = _get_chooser(action_title, _("_Cancel"))
+    chooser.set_title(title)
+    chooser.set_action(Gtk.FileChooserAction.SAVE)
+    chooser.set_local_only(True)
+    if name_suggestion is not None:
+        chooser.set_current_name(name_suggestion)
+
+    result = _run_chooser(parent, chooser)
+    if result:
+        return result[0]
+
+
+def choose_target_folder(parent, title, action_title, name_suggestion=None):
+    """Opens a file chooser for saving a file.
+
+    Args:
+        parent (Gtk.Widget)
+        title (text_type): The window title
+        action_title (text_type): The button title
+        name_suggestion (text_type): The suggested folder name (not fsnative)
+    Returns:
+        fsnative or None
+    """
+
+    chooser = _get_chooser(action_title, _("_Cancel"))
+    chooser.set_title(title)
+    chooser.set_action(Gtk.FileChooserAction.CREATE_FOLDER)
+    chooser.set_local_only(True)
+    if name_suggestion is not None:
+        chooser.set_current_name(name_suggestion)
+
+    result = _run_chooser(parent, chooser)
+    if result:
+        return result[0]

--- a/quodlibet/quodlibet/qltk/chooser.py
+++ b/quodlibet/quodlibet/qltk/chooser.py
@@ -76,6 +76,8 @@ def _run_chooser(parent, chooser):
 
     if _response is not None:
         response = _response
+        while Gtk.events_pending():
+            Gtk.main_iteration()
     else:
         response = chooser.run()
 

--- a/quodlibet/quodlibet/qltk/scanbox.py
+++ b/quodlibet/quodlibet/qltk/scanbox.py
@@ -6,37 +6,19 @@
 # it under the terms of the GNU General Public License version 2 as
 # published by the Free Software Foundation
 
-import os
-
 from gi.repository import Gtk
 from gi.repository import Pango
 from senf import fsn2text
 
 from quodlibet import _
-from quodlibet.qltk.chooser import FolderChooser
+from quodlibet.qltk.chooser import choose_folders
 from quodlibet.qltk.views import RCMHintedTreeView
 from quodlibet.qltk.models import ObjectStore
 from quodlibet.qltk.x import MenuItem, Button
 from quodlibet.qltk import Icons
-from quodlibet.util.path import unexpand, get_home_dir, glib2fsn, fsn2glib
+from quodlibet.util.path import unexpand
 from quodlibet.util.library import get_scan_dirs, set_scan_dirs
 from quodlibet.util import connect_obj
-
-
-def get_init_select_dir():
-    """Returns a path which might be a good starting point when browsing
-    for a path for library scanning.
-
-    Returns:
-        fsnative
-    """
-
-    scandirs = get_scan_dirs()
-    if scandirs and os.path.isdir(scandirs[-1]):
-        # start with last added directory
-        return scandirs[-1]
-    else:
-        return get_home_dir()
 
 
 class ScanBox(Gtk.HBox):
@@ -114,11 +96,7 @@ class ScanBox(Gtk.HBox):
         self.__save()
 
     def __add(self, *args):
-        initial = get_init_select_dir()
-        chooser = FolderChooser(
-            self, _("Select Directories"), fsn2glib(initial))
-        fns = chooser.run()
-        chooser.destroy()
+        fns = choose_folders(self, _("Select Directories"), _("_Add Folders"))
         for fn in fns:
-            self.model.append(row=[glib2fsn(fn)])
+            self.model.append(row=[fn])
         self.__save()

--- a/quodlibet/tests/test_qltk_chooser.py
+++ b/quodlibet/tests/test_qltk_chooser.py
@@ -1,44 +1,62 @@
 # -*- coding: utf-8 -*-
+# Copyright 2017 Christoph Reiter
+#
 # This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License version 2 as
-# published by the Free Software Foundation
-
-from tests import TestCase
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
 
 from gi.repository import Gtk
+from senf import fsnative, getcwd
 
-from quodlibet.qltk.chooser import FolderChooser, FileChooser
-import quodlibet.config
+from quodlibet.qltk.chooser import choose_files, get_current_dir, \
+    set_current_dir, choose_folders, create_chooser_filter, \
+    choose_target_file, choose_target_folder, with_response
 
-
-class TFolderChooser(TestCase):
-    Kind = FolderChooser
-
-    def setUp(self):
-        quodlibet.config.init()
-
-    def tearDown(self):
-        quodlibet.config.quit()
-
-    def test_init_nodir(self):
-        f = self.Kind(None, "A file chooser")
-        while Gtk.events_pending():
-            Gtk.main_iteration()
-        f.destroy()
-
-    def test_init_dir(self):
-        f = self.Kind(None, "A file chooser", initial_dir="/home")
-        while Gtk.events_pending():
-            Gtk.main_iteration()
-        f.destroy()
+from . import TestCase
 
 
-class TFileChooser(TFolderChooser):
-    Kind = FileChooser
+class Tchooser(TestCase):
 
-    def test_filter(self):
-        f = lambda *x: None
-        x = FileChooser(None, "foo", filter=f)
-        while Gtk.events_pending():
-            Gtk.main_iteration()
-        x.destroy()
+    def test_choose_files(self):
+        w = Gtk.Window()
+        with with_response(Gtk.ResponseType.CANCEL):
+            assert choose_files(w, u"title", u"action") == []
+
+    def test_choose_folders(self):
+        w = Gtk.Window()
+        with with_response(Gtk.ResponseType.CANCEL):
+            assert choose_folders(w, u"title", u"action") == []
+
+    def test_choose_filter(self):
+        cf = create_chooser_filter(u"filter", ["*.txt"])
+        assert isinstance(cf, Gtk.FileFilter)
+        assert cf.get_name() == u"filter"
+
+        w = Gtk.Window()
+        with with_response(Gtk.ResponseType.CANCEL):
+            assert choose_files(w, u"title", u"action", cf) == []
+
+    def test_choose_target_file(self):
+        w = Gtk.Window()
+        with with_response(Gtk.ResponseType.CANCEL):
+            assert choose_target_file(w, u"title", u"action") is None
+        with with_response(Gtk.ResponseType.CANCEL):
+            assert choose_target_file(
+                w, u"title", u"action", u"example") is None
+
+    def test_choose_target_folder(self):
+        w = Gtk.Window()
+        with with_response(Gtk.ResponseType.CANCEL):
+            assert choose_target_folder(w, u"title", u"action") is None
+        with with_response(Gtk.ResponseType.CANCEL):
+            assert choose_target_folder(
+                w, u"title", u"action", u"example") is None
+
+    def test_get_current_dir(self):
+        path = get_current_dir()
+        assert isinstance(path, fsnative)
+
+    def test_set_current_dir(self):
+        set_current_dir(fsnative(u"."))
+        assert get_current_dir() == getcwd()

--- a/quodlibet/tests/test_qltk_scanbox.py
+++ b/quodlibet/tests/test_qltk_scanbox.py
@@ -3,9 +3,7 @@
 # it under the terms of the GNU General Public License version 2 as
 # published by the Free Software Foundation
 
-from senf import fsnative
-
-from quodlibet.qltk.scanbox import ScanBox, get_init_select_dir
+from quodlibet.qltk.scanbox import ScanBox
 
 from . import TestCase
 
@@ -14,6 +12,3 @@ class TScanBox(TestCase):
 
     def test_main(self):
         ScanBox().destroy()
-
-    def test_get_init_select_dir(self):
-        assert isinstance(get_init_select_dir(), fsnative)


### PR DESCRIPTION
Newer GTK+ added an interface for opening the native file chooser on
Windows so add a simple interface using the new/old interface depending
on the gtk+ version.

Replaces some simple filechooser usage which didn't need API not available
on Windows. One thing removed was the "watch for new files" checkbox, which
was a bit confusing anyway imo.

Some places saved/restored the last visible directory for the file chooser.
This replaces it with a global path saved in the config.

TODO: The remaining, less simple file chooser cases need to be replaced with
the chooser and an addition dialog for further actions.