### PR TITLE
RPaned: ensure get_relative always returns a value between 0 and 1

### DIFF
--- a/quodlibet/quodlibet/qltk/paned.py
+++ b/quodlibet/quodlibet/qltk/paned.py
@@ -77,6 +77,9 @@ class RPaned(Paned):
     def set_relative(self, v):
         """Set the relative position of the separator, [0..1]."""
 
+        if v < 0 or v > 1:
+            raise ValueError("v must be in [0..1]")
+
         if self.__alloced:
             max_pos = self._get_max()
             self.set_position(int(round(v * max_pos)))
@@ -87,13 +90,15 @@ class RPaned(Paned):
         """Return the relative position of the separator, [0..1]."""
 
         if self.__alloced:
-            max_pos = self._get_max()
-            return (float(self.get_position()) / max_pos)
-        elif self.__relative is not None:
+            rel = float(self.get_position()) / self._get_max()
+            if 0 <= rel <= 1:
+                return rel
+
+        if self.__relative is not None:
             return self.__relative
-        else:
-            # before first alloc and set_relative not called
-            return 0.5
+
+        # before first alloc and set_relative not called
+        return 0.5
 
     def do_size_allocate(self, *args):
         ret = Gtk.HPaned.do_size_allocate(self, *args)

--- a/quodlibet/tests/test_qltk_paned.py
+++ b/quodlibet/tests/test_qltk_paned.py
@@ -23,6 +23,8 @@ class TRPaned(object):
         p = self.Kind()
         p.set_relative(0.25)
         self.failUnlessEqual(p.get_relative(), 0.25)
+        self.assertRaises(ValueError, p.set_relative, 2.0)
+        self.assertRaises(ValueError, p.set_relative, -2.0)
 
     def test_visible_no_setup(self):
         p = self.Kind()


### PR DESCRIPTION
Fixes #2321 

The cause of the issue was that RPaned's get_relative() occasionally returned a value greater than 1, because get_max() returned a value of 1 while get_position() returned a value >1. The solution was to not solely trust the _alloced flag, and instead return __relative in cases where the function otherwise would return invalid values.

To make the relative position consistently between 0 and 1, I also added a check for this in set_relative().