### PR TITLE
Add checkbox to stop player after queue is empty

### DIFF
--- a/quodlibet/quodlibet/config.py
+++ b/quodlibet/quodlibet/config.py
@@ -58,7 +58,7 @@ INITIAL = {
         "queue": "false", # on or off
         "queue_expanded": "false", # on or off
         "shufflequeue": "false", # on or off
-        "queue_stop_after_empty": "false", # on or off
+        "queue_stop_once_empty": "false", # on or off
         "sortby": "0album", # <reversed?>tagname, song list sort
 
         # Repeat on or off

--- a/quodlibet/quodlibet/config.py
+++ b/quodlibet/quodlibet/config.py
@@ -58,6 +58,7 @@ INITIAL = {
         "queue": "false", # on or off
         "queue_expanded": "false", # on or off
         "shufflequeue": "false", # on or off
+        "queue_stop_after_empty": "false", # on or off
         "sortby": "0album", # <reversed?>tagname, song list sort
 
         # Repeat on or off

--- a/quodlibet/quodlibet/qltk/queue.py
+++ b/quodlibet/quodlibet/qltk/queue.py
@@ -133,9 +133,9 @@ class QueueExpander(Gtk.Expander):
         left.pack_start(rand_checkbox, False, True, 0)
 
         stop_checkbox = ConfigCheckButton(
-            _("Stop After Empty"), "memory", "queue_stop_after_empty")
+            _("Stop Once Empty"), "memory", "queue_stop_once_empty")
         stop_checkbox.set_active(config.getboolean("memory",
-                                                   "queue_stop_after_empty",
+                                                   "queue_stop_once_empty",
                                                    False))
         stop_checkbox.set_no_show_all(True)
         left.pack_start(stop_checkbox, False, True, 0)
@@ -216,7 +216,7 @@ class QueueExpander(Gtk.Expander):
     def __clear_queue(self, activator):
         self.model.clear()
         stop_queue = config.getboolean("memory",
-                                       "queue_stop_after_empty",
+                                       "queue_stop_once_empty",
                                        False)
         if stop_queue:
             app.player_options.stop_after = True
@@ -247,7 +247,7 @@ class QueueExpander(Gtk.Expander):
         model.order = OrderShuffle() if button.get_active() else OrderInOrder()
 
     def __update_queue_stop(self, player, song, model):
-        enabled = config.getboolean("memory", "queue_stop_after_empty", False)
+        enabled = config.getboolean("memory", "queue_stop_once_empty", False)
         songs_left = len(model.get())
         if enabled and songs_left == 1:
             # Enable stop_after if this is the last song

--- a/quodlibet/quodlibet/qltk/queue.py
+++ b/quodlibet/quodlibet/qltk/queue.py
@@ -215,6 +215,10 @@ class QueueExpander(Gtk.Expander):
 
     def __clear_queue(self, activator):
         self.model.clear()
+        stop_queue = config.getboolean("memory",
+                                       "queue_stop_after_empty",
+                                       False)
+        app.player_options.stop_after = stop_queue
 
     def __motion(self, wid, context, x, y, time):
         Gdk.drag_status(context, Gdk.DragAction.COPY, time)

--- a/quodlibet/quodlibet/qltk/queue.py
+++ b/quodlibet/quodlibet/qltk/queue.py
@@ -218,7 +218,8 @@ class QueueExpander(Gtk.Expander):
         stop_queue = config.getboolean("memory",
                                        "queue_stop_after_empty",
                                        False)
-        app.player_options.stop_after = stop_queue
+        if stop_queue:
+            app.player_options.stop_after = True
 
     def __motion(self, wid, context, x, y, time):
         Gdk.drag_status(context, Gdk.DragAction.COPY, time)
@@ -247,10 +248,10 @@ class QueueExpander(Gtk.Expander):
 
     def __update_queue_stop(self, player, song, model):
         enabled = config.getboolean("memory", "queue_stop_after_empty", False)
-        if enabled:
-            songs_left = len(model.get())
+        songs_left = len(model.get())
+        if enabled and songs_left == 1:
             # Enable stop_after if this is the last song
-            app.player_options.stop_after = (songs_left == 1)
+            app.player_options.stop_after = True
 
     def __expand(self, cb, prop, clear):
         expanded = self.get_expanded()


### PR DESCRIPTION
Fixes #43

Although the "Queue Only" plugin has this as a side effect, the effect of always adding songs to the queue may not be desired. This addition instead adds a checkbox - "Stop After Empty" - next to the "Random" checkbox that has no other side effects than stopping the player after the queue is empty, instead of continuing to play a song from the song pane.