### PR TITLE
Quick fix for MPRIS notifications

### DIFF
--- a/quodlibet/quodlibet/ext/events/mpris/mpris2.py
+++ b/quodlibet/quodlibet/ext/events/mpris/mpris2.py
@@ -145,8 +145,8 @@ value="false"/>
     def __seeked(self, player, song, ms):
         self.Seeked(ms * 1000)
 
-    def __library_changed(self, library, song):
-        if song and song is not app.player.info:
+    def __library_changed(self, library, songs):
+        if not songs or app.player.info not in songs:
             return
         self.emit_properties_changed(self.PLAYER_IFACE, ["Metadata"])
 


### PR DESCRIPTION
Seems to fix #2358 - `song` is actually a set of songs that were updated and `app.player.info` is the currently playing song, so we skip notifying if no songs were changed or if the playing song is not one of the changed songs

Presumably `song` was once a single song and the check worked