### PR TITLE
Added support for custom DateColumn timestamp formats

### DIFF
--- a/quodlibet/quodlibet/config.py
+++ b/quodlibet/quodlibet/config.py
@@ -150,6 +150,9 @@ INITIAL = {
 
         # the pattern for the main window title
         "window_title_pattern": "~title~version~~people",
+
+        # the format of the timestamps in DateColumn
+        "datecolumn_timestamp_format": "",
     },
     "rename": {
         "spaces": "false",

--- a/quodlibet/quodlibet/ext/events/advanced_preferences.py
+++ b/quodlibet/quodlibet/ext/events/advanced_preferences.py
@@ -146,6 +146,12 @@ class AdvancedPreferences(EventPlugin):
                 ("A (tied) tag for the main window title, e.g. ~title~~people "
                  "(restart required)")))
 
+        rows.append(
+            text_config(
+                "settings", "datecolumn_timestamp_format",
+                "DateColumn timestamp format",
+                "A timestamp format, e.g. %Y%m%d %X "))
+
         for (row, (label, entry, button)) in enumerate(rows):
             label.set_alignment(1.0, 0.5)
             table.attach(label, 0, 1, row, row + 1,

--- a/quodlibet/quodlibet/qltk/songlistcolumns.py
+++ b/quodlibet/quodlibet/qltk/songlistcolumns.py
@@ -279,14 +279,23 @@ class DateColumn(WideTextColumn):
             except (OverflowError, ValueError, OSError):
                 text = u""
             else:
-                today = datetime.datetime.now().date()
-                days = (today - date).days
-                if days == 0:
-                    format_ = "%X"
-                elif days < 7:
-                    format_ = "%A"
+                format_setting = config.gettext("settings",
+                                      "datecolumn_timestamp_format")
+
+                # use default behaviour-format
+                if not format_setting:
+                    today = datetime.datetime.now().date()
+                    days = (today - date).days
+                    if days == 0:
+                        format_ = "%X"
+                    elif days < 7:
+                        format_ = "%A"
+                    else:
+                        format_ = "%x"
+                # use format from Advanced Preferences
                 else:
-                    format_ = "%x"
+                    format_ = format_setting
+
                 stamp = time.localtime(stamp)
                 text = time.strftime(format_, stamp)
             cell.set_property('text', text)

--- a/quodlibet/quodlibet/qltk/songlistcolumns.py
+++ b/quodlibet/quodlibet/qltk/songlistcolumns.py
@@ -282,8 +282,11 @@ class DateColumn(WideTextColumn):
                 format_setting = config.gettext("settings",
                                       "datecolumn_timestamp_format")
 
+                # use format configured in Advanced Preferences
+                if format_setting:
+                    format_ = format_setting
                 # use default behaviour-format
-                if not format_setting:
+                else:
                     today = datetime.datetime.now().date()
                     days = (today - date).days
                     if days == 0:
@@ -292,9 +295,6 @@ class DateColumn(WideTextColumn):
                         format_ = "%A"
                     else:
                         format_ = "%x"
-                # use format from Advanced Preferences
-                else:
-                    format_ = format_setting
 
                 stamp = time.localtime(stamp)
                 text = time.strftime(format_, stamp)

--- a/quodlibet/tests/test_qltk_songlistcolumns.py
+++ b/quodlibet/tests/test_qltk_songlistcolumns.py
@@ -115,4 +115,3 @@ class TSongListColumns(TestCase):
         column = create_songlist_column("~#added")
         text = self._render_column(column, **{"~#added": stamp})
         self.assertNotEqual(text, "19990501 23:11:59 PLAINTEXT")
-

--- a/quodlibet/tests/test_qltk_songlistcolumns.py
+++ b/quodlibet/tests/test_qltk_songlistcolumns.py
@@ -102,6 +102,17 @@ class TSongListColumns(TestCase):
         self.assertEqual(text, "19990501 23:11:59 PLAINTEXT")
 
     def test_nonconfigured_datecol_format(self):
+        # make sure config option is unset by default
         text = quodlibet.config.gettext("settings",
                                         "datecolumn_timestamp_format")
         self.assertEqual(text, "")
+
+        # make sure unset config option does not result in the
+        # behaviour for testcase for set option above
+        d = datetime.datetime(year=1999, month=5, day=1,
+                              hour=23, minute=11, second=59)
+        stamp = int(time.mktime(d.timetuple()))
+        column = create_songlist_column("~#added")
+        text = self._render_column(column, **{"~#added": stamp})
+        self.assertNotEqual(text, "19990501 23:11:59 PLAINTEXT")
+

--- a/quodlibet/tests/test_qltk_songlistcolumns.py
+++ b/quodlibet/tests/test_qltk_songlistcolumns.py
@@ -16,6 +16,7 @@ from quodlibet.formats import AudioFile
 import quodlibet.config
 
 import datetime
+import time
 
 
 class TSongListColumns(TestCase):
@@ -95,9 +96,9 @@ class TSongListColumns(TestCase):
 
         d = datetime.datetime(year=1999, month=5, day=1,
                               hour=23, minute=11, second=59)
-
+        stamp = int(time.mktime(d.timetuple()))
         column = create_songlist_column("~#added")
-        text = self._render_column(column, **{"~#added": int(d.timestamp())})
+        text = self._render_column(column, **{"~#added": stamp})
         self.assertEqual(text, "19990501 23:11:59 PLAINTEXT")
 
     def test_nonconfigured_datecol_format(self):

--- a/quodlibet/tests/test_qltk_songlistcolumns.py
+++ b/quodlibet/tests/test_qltk_songlistcolumns.py
@@ -15,6 +15,8 @@ from quodlibet.qltk.songmodel import PlaylistModel
 from quodlibet.formats import AudioFile
 import quodlibet.config
 
+import datetime
+
 
 class TSongListColumns(TestCase):
     def setUp(self):
@@ -85,3 +87,20 @@ class TSongListColumns(TestCase):
     def test_people(self):
         column = create_songlist_column("~people")
         self._render_column(column)
+
+    def test_custom_datecol_format(self):
+        format = "%Y%m%d %H:%M:%S PLAINTEXT"
+        quodlibet.config.settext("settings", "datecolumn_timestamp_format",
+                                 format)
+
+        d = datetime.datetime(year=1999, month=5, day=1,
+                              hour=23, minute=11, second=59)
+
+        column = create_songlist_column("~#added")
+        text = self._render_column(column, **{"~#added": int(d.timestamp())})
+        self.assertEqual(text, "19990501 23:11:59 PLAINTEXT")
+
+    def test_nonconfigured_datecol_format(self):
+        text = quodlibet.config.gettext("settings",
+                                        "datecolumn_timestamp_format")
+        self.assertEqual(text, "")


### PR DESCRIPTION
Personally I dislike the random "Yesterday",  "23:55:12",  "30/01/2015", and so on timestamps scattered through the datecolumn

This adds an option in advanced preferences to specify the format string to be used. 