### PR TITLE
Use the locale encoding for locale.format and not utf-8. Fixes #2364

### DIFF
--- a/quodlibet/quodlibet/util/__init__.py
+++ b/quodlibet/quodlibet/util/__init__.py
@@ -6,7 +6,6 @@
 # it under the terms of the GNU General Public License version 2 as
 # published by the Free Software Foundation
 
-import locale
 import os
 import random
 import re
@@ -34,18 +33,18 @@ from quodlibet.util.string.titlecase import title
 
 from quodlibet.const import SUPPORT_EMAIL, COPYRIGHT
 from quodlibet.util.dprint import print_d, print_, print_e, print_w, print_exc
-from .misc import cached_func, get_module_dir, get_ca_file
+from .misc import cached_func, get_module_dir, get_ca_file, get_locale_encoding
 from .environment import is_plasma, is_unity, is_enlightenment, \
     is_linux, is_windows, is_wine, is_osx, is_py2exe, is_py2exe_console, \
     is_py2exe_window
 from .enum import enum
-from .i18n import _, C_
+from .i18n import _, C_, locale_format
 
 
 # pyflakes
 cached_func, enum, print_w, print_exc, is_plasma, is_unity, is_enlightenment,
 is_linux, is_windows, is_wine, is_osx, is_py2exe, is_py2exe_console,
-is_py2exe_window, get_module_dir, get_ca_file
+is_py2exe_window, get_module_dir, get_ca_file, get_locale_encoding
 
 
 if PY2:
@@ -336,14 +335,16 @@ def parse_date(datestr):
 
 def format_int_locale(value):
     """Turn an integer into a grouped, locale-dependent string
-    e.g. 12345 -> "12,345" or "12.345" etc"""
-    return locale.format("%d", value, grouping=True)
+    e.g. 12345 -> "12,345" or "12.345" etc
+    """
+    return locale_format("%d", value, grouping=True)
 
 
-def format_float_locale(value, format=".2f"):
+def format_float_locale(value, format="%.2f"):
     """Turn a float into a grouped, locale-dependent string
-    e.g. 12345.67 -> "12,345.67" or "12.345,67" etc"""
-    return locale.format(format, value, grouping=True)
+    e.g. 12345.67 -> "12,345.67" or "12.345,67" etc
+    """
+    return locale_format(format, value, grouping=True)
 
 
 def format_rating(value, blank=True):
@@ -414,7 +415,7 @@ def format_time_display(time):
 def format_time_seconds(time):
     from quodlibet import ngettext
 
-    time_str = locale.format("%d", time, grouping=True)
+    time_str = format_int_locale(time)
     return ngettext("%s second", "%s seconds", time) % time_str
 
 

--- a/quodlibet/quodlibet/util/i18n.py
+++ b/quodlibet/quodlibet/util/i18n.py
@@ -16,6 +16,17 @@ from quodlibet.util.path import unexpand
 from quodlibet.util.dprint import print_d
 from quodlibet.compat import text_type, PY2, listfilter
 
+from .misc import get_locale_encoding
+
+
+def locale_format(format, val, *args, **kwargs):
+    """Like locale.format but returns text"""
+
+    result = locale.format(format, val, *args, **kwargs)
+    if isinstance(result, bytes):
+        result = result.decode(get_locale_encoding(), "replace")
+    return result
+
 
 def bcp47_to_language(code):
     """Takes a BCP 47 language identifier and returns a value suitable for the

--- a/quodlibet/quodlibet/util/misc.py
+++ b/quodlibet/quodlibet/util/misc.py
@@ -7,6 +7,7 @@
 
 import os
 import sys
+import locale
 from functools import wraps
 
 from senf import environ, argv, path2fsn
@@ -31,6 +32,29 @@ def cached_func(f):
             res.append(f())
         return res[0]
     return wrapper
+
+
+def _verify_encoding(encoding):
+    try:
+        u"".encode(encoding)
+    except LookupError:
+        encoding = "utf-8"
+    return encoding
+
+
+@cached_func
+def get_locale_encoding():
+    """Returns the encoding defined by the locale"""
+
+    try:
+        encoding = locale.getpreferredencoding()
+    except locale.Error:
+        encoding = "utf-8"
+    else:
+        # python on macports can return a bugs result (empty string)
+        encoding = _verify_encoding(encoding)
+
+    return encoding
 
 
 def total_ordering(cls):

--- a/quodlibet/tests/test_util.py
+++ b/quodlibet/tests/test_util.py
@@ -35,7 +35,7 @@ from quodlibet.util.string.splitters import split_people, split_title, \
     split_album
 
 from . import TestCase, skipIf
-from .helper import capture_output
+from .helper import capture_output, locale_numeric_conv
 
 
 is_win = os.name == "nt"
@@ -79,6 +79,28 @@ class Tmtime(TestCase):
     def test_bad(self):
         self.failIf(os.path.exists("/dev/doesnotexist"))
         self.failUnlessEqual(mtime("/dev/doesnotexist"), 0)
+
+
+class Tget_locale_encoding(TestCase):
+
+    def test_main(self):
+        assert isinstance(util.get_locale_encoding(), str)
+
+
+class Tformat_locale(TestCase):
+
+    def test_format_int_locale(self):
+        assert isinstance(util.format_int_locale(1024), text_type)
+
+    def test_format_float_locale(self):
+        assert isinstance(util.format_float_locale(1024.1024), text_type)
+
+    def test_format_time_seconds(self):
+        assert isinstance(util.format_time_seconds(1024), text_type)
+
+        with locale_numeric_conv():
+            assert format_time_seconds(1024) == "1,024 seconds"
+            assert format_time_seconds(1) == "1 second"
 
 
 class Tunexpand(TestCase):


### PR DESCRIPTION
Adds back a wrapper for locale.getpreferredencoding() which was removed
last release and adds some tests.