### PR TITLE
travis: another take on enabling faulthandler with pytest

### DIFF
--- a/quodlibet/tests/__init__.py
+++ b/quodlibet/tests/__init__.py
@@ -4,6 +4,7 @@
 # published by the Free Software Foundation
 
 import os
+import sys
 import unittest
 import tempfile
 import shutil
@@ -23,6 +24,7 @@ try:
 except ImportError:
     xvfbwrapper = None
 
+import faulthandler
 from senf import fsnative, path2fsn, environ
 
 import quodlibet
@@ -161,7 +163,7 @@ def init_test_environ():
     any resources created.
     """
 
-    global _TEMP_DIR, _BUS_INFO, _VDISPLAY
+    global _TEMP_DIR, _BUS_INFO, _VDISPLAY, _faulthandler_fobj
 
     # create a user dir in /tmp and set env vars
     _TEMP_DIR = tempfile.mkdtemp(prefix=fsnative(u"QL-TEST-"))
@@ -198,6 +200,10 @@ def init_test_environ():
 
     quodlibet.init(no_translations=True, no_excepthook=True)
     quodlibet.app.name = "QL Tests"
+
+    # to get around pytest silencing
+    _faulthandler_fobj = os.fdopen(os.dup(sys.__stderr__.fileno()), "w")
+    faulthandler.enable(_faulthandler_fobj)
 
     # try to make things the same in case a different locale is active.
     # LANG for gettext, setlocale for number formatting etc.


### PR DESCRIPTION
reopen stderr.. while this doesn't work through the py.test
command it works with setup.py test, and we use that on travis.