### PR TITLE
Update OSX modules

### DIFF
--- a/osx_bundle/modulesets/quodlibet.modules
+++ b/osx_bundle/modulesets/quodlibet.modules
@@ -481,6 +481,7 @@
       <dep package="libxml2"/>
       <dep package="libxslt"/>
       <dep package="itstool"/>
+      <dep package="intltool"/>
     </dependencies>
   </autotools>
 


### PR DESCRIPTION
yelp-xsl fails to build if intltool isn't present

```
...
checking for intltool >= 0.40.0...  found
configure: error: Your intltool is too old.  You need intltool 0.40.0 or later.
```