### PR TITLE
waveformseekbar: update waveform data at the end of computation

### DIFF
--- a/quodlibet/quodlibet/ext/events/waveformseekbar.py
+++ b/quodlibet/quodlibet/ext/events/waveformseekbar.py
@@ -114,14 +114,14 @@ class WaveformSeekBar(Gtk.Box):
             self._pipeline.set_state(Gst.State.NULL)
             self._clean_pipeline()
 
-            # Only update the waveform if it has changed
-            if self._player.info and self._rms_vals != self._new_rms_vals:
-                self._rms_vals = self._new_rms_vals
-                self._waveform_scale.reset(self._rms_vals)
-                self._waveform_scale.set_placeholder(False)
-                self._update_redraw_interval()
-            else:
-                del self._new_rms_vals
+            # Update the waveform with the new data
+            self._rms_vals = self._new_rms_vals
+            self._waveform_scale.reset(self._rms_vals)
+            self._waveform_scale.set_placeholder(False)
+            self._update_redraw_interval()
+
+            # Clear temporary reference to the waveform data
+            del self._new_rms_vals
 
     def _clean_pipeline(self):
         if self._bus_id:


### PR DESCRIPTION
Fixes #2357.

The previous code was trying to be smart where that was not necessary.
We now update the waveform data even if it is the same data.