### PR TITLE
Playlist import DnD: fix import name

### DIFF
--- a/quodlibet/quodlibet/browsers/playlists/main.py
+++ b/quodlibet/quodlibet/browsers/playlists/main.py
@@ -7,7 +7,6 @@
 # published by the Free Software Foundation
 
 import os
-from tempfile import NamedTemporaryFile
 
 from gi.repository import Gtk, GLib, Pango, Gdk
 
@@ -393,18 +392,13 @@ class PlaylistsBrowser(Browser, DisplayPatternMixin):
             uri = uri.encode('utf-8')
             try:
                 sock = urlopen(uri)
-                f = NamedTemporaryFile()
-                f.write(sock.read())
-                f.flush()
                 if uri.lower().endswith('.pls'):
-                    playlist = parse_pls(f.name, library=library)
+                    playlist = parse_pls(sock, name, library=library)
                 elif uri.lower().endswith('.m3u'):
-                    playlist = parse_m3u(f.name, library=library)
+                    playlist = parse_m3u(sock, name, library=library)
                 else:
                     raise IOError
                 library.add(playlist.songs)
-                if name:
-                    playlist.rename(name)
                 self.changed(playlist)
                 Gtk.drag_finish(ctx, True, False, etime)
             except IOError:
@@ -575,13 +569,19 @@ class PlaylistsBrowser(Browser, DisplayPatternMixin):
     def __import(self, activator, library):
         cf = create_chooser_filter(_("Playlists"), ["*.pls", "*.m3u"])
         fns = choose_files(self, _("Import Playlist"), _("_Import"), cf)
+        self._import_playlists(fns, library)
+
+    def _import_playlists(self, fns, library):
         for filename in fns:
-            if filename.endswith(".m3u"):
-                playlist = parse_m3u(filename, library=library)
-            elif filename.endswith(".pls"):
-                playlist = parse_pls(filename, library=library)
-            else:
-                continue
+            name = _name_for(filename)
+            with open(filename, "r") as f:
+                if filename.endswith(".m3u"):
+                    playlist = parse_m3u(f, name, library=library)
+                elif filename.endswith(".pls"):
+                    playlist = parse_pls(f, name, library=library)
+                else:
+                    print_w("Unsupported playlist type for '%s'" % filename)
+                    continue
             self.changed(playlist)
             library.add(playlist)
 

--- a/quodlibet/tests/test_browsers_playlists.py
+++ b/quodlibet/tests/test_browsers_playlists.py
@@ -5,7 +5,7 @@
 # (at your option) any later version.
 
 from gi.repository import Gdk, Gtk
-from senf import fsnative, fsn2uri, fsn2bytes
+from senf import fsnative, fsn2uri, fsn2bytes, text2fsn
 
 from quodlibet import app
 from quodlibet import qltk
@@ -14,10 +14,10 @@ from quodlibet.browsers.playlists.util import PLAYLISTS, parse_m3u, \
     parse_pls, _name_for
 from quodlibet.qltk.songlist import DND_QL
 from quodlibet.util.collection import FileBackedPlaylist
-from tests import TestCase, get_data_path, mkstemp, mkdtemp, _TEMP_DIR, \
+from tests import TestCase, get_data_path, mkdtemp, _TEMP_DIR, \
     init_fake_app, destroy_fake_app
 from tests.gtk_helpers import MockSelData
-from .helper import dummy_path, __
+from .helper import dummy_path, __, temp_filename
 
 import os
 import shutil
@@ -32,7 +32,7 @@ from quodlibet.library.libraries import FileLibrary
 from tests.test_browsers_search import SONGS, TSearchBar
 
 
-class TParsePlaylist(TestCase):
+class ConfigSetupMixin(object):
     def setUp(self):
         quodlibet.config.init()
 
@@ -43,48 +43,44 @@ class TParsePlaylist(TestCase):
 class TParsePlaylistMixin(object):
 
     def test_parse_empty(self):
-        h, name = mkstemp()
-        os.close(h)
-        open(name, "w").close()
-        pl = self.Parse(name)
-        os.unlink(name)
+        with temp_filename() as name:
+            with open(name) as f:
+                pl = self.Parse(f, name)
         self.failUnlessEqual(0, len(pl))
         pl.delete()
 
     def test_parse_onesong(self):
-        h, name = mkstemp()
-        os.close(h)
-        with open(name, "wb") as f:
-            target = self.prefix
-            target += fsn2bytes(get_data_path("silence-44-s.ogg"), "utf-8")
-            f.write(target)
-        list = self.Parse(name)
-        os.unlink(name)
-        self.failUnlessEqual(len(list), 1)
-        self.failUnlessEqual(list[0]("title"), "Silence")
-        list.delete()
+        with temp_filename() as name:
+            with open(name, "wb") as af:
+                target = self.prefix
+                target += fsn2bytes(get_data_path("silence-44-s.ogg"), "utf-8")
+                af.write(target)
+            with open(name) as f:
+                pl = self.Parse(f, name)
+        self.failUnlessEqual(len(pl), 1)
+        self.failUnlessEqual(pl[0]("title"), "Silence")
+        pl.delete()
 
     def test_parse_onesong_uri(self):
-        h, name = mkstemp()
-        os.close(h)
         target = get_data_path("silence-44-s.ogg")
         target = fsn2uri(target).encode("ascii")
         target = self.prefix + target
-        with open(name, "wb") as f:
-            f.write(target)
-        list = self.Parse(name)
-        os.unlink(name)
-        self.failUnlessEqual(len(list), 1)
-        self.failUnlessEqual(list[0]("title"), "Silence")
-        list.delete()
+        with temp_filename() as name:
+            with open(name, "wb") as f:
+                f.write(target)
+            with open(name) as f:
+                pl = self.Parse(f, name)
+        self.failUnlessEqual(len(pl), 1)
+        self.failUnlessEqual(pl[0]("title"), "Silence")
+        pl.delete()
 
 
-class TParseM3U(TParsePlaylist, TParsePlaylistMixin):
+class TParseM3U(TestCase, ConfigSetupMixin, TParsePlaylistMixin):
     Parse = staticmethod(parse_m3u)
     prefix = b""
 
 
-class TParsePLS(TParsePlaylist, TParsePlaylistMixin):
+class TParsePLS(TestCase, ConfigSetupMixin, TParsePlaylistMixin):
     Parse = staticmethod(parse_pls)
     prefix = b"File1="
 
@@ -293,6 +289,22 @@ class TPlaylistsBrowser(TSearchBar):
         ret = b.key_pressed(event)
         self.failUnless(ret, msg="Didn't simulate a delete keypress")
         self.failUnlessEqual(len(first_pl), original_length - 1)
+
+    def test_import(self):
+        pl_name = "_€3 œufs à Noël"
+        pl = FileBackedPlaylist(_TEMP_DIR, pl_name, None)
+        pl.extend(SONGS)
+        pl.write()
+        new_name = os.path.splitext(text2fsn(pl.name))[0] + '.m3u'
+        os.rename(pl.filename, new_name)
+        self.bar._import_playlists([new_name], self.lib)
+        os.unlink(new_name)
+        pls = self.bar.playlists()
+        self.failUnlessEqual(len(pls), 3)
+        # Leading underscore makes it always the last entry
+        imported = pls[-1]
+        self.failUnlessEqual(imported.songs, pl.songs)
+        self.failUnlessEqual(imported.name, pl_name)
 
     @staticmethod
     def _fake_browser_pack(b):

--- a/quodlibet/tests/test_browsers_search.py
+++ b/quodlibet/tests/test_browsers_search.py
@@ -37,11 +37,11 @@ SONGS = [AudioFile({
                 "labelid": "65432-1",
                 "~filename": fsnative(u"/dev/random")}),
          AudioFile({
-                "title": "five",
+                "title": "five € and a £",
                 "artist": "shell",
                 "album": "don't stop",
                 "labelid": "12345-6",
-                "~filename": fsnative(u"/dev/sh")})]
+                "~filename": fsnative(u"/tmp/five € and £!")})]
 
 
 class TSearchBar(TestCase):


### PR DESCRIPTION
 * Ditch the PL temp file on DnD import, and therefore the call
 to `rename` which has no retry logic (unlike `new`)
 * Instead, pass filelike objects.
 * Extract import logic to method too
 * Add tests for this
 * Fix `filter` for PY3 (#2426)
 * Fix tests for new calling
 * Use text not bytes for reading.
 * Make tests use `test_filename()`` - neater.

Fixes #2424,#2426