### PR TITLE
Attempt at fixing various playlist-updating issues

### DIFF
--- a/quodlibet/quodlibet/browsers/playlists/main.py
+++ b/quodlibet/quodlibet/browsers/playlists/main.py
@@ -258,9 +258,6 @@ class PlaylistsBrowser(Browser, DisplayPatternMixin):
         view.connect('row-activated', lambda *x: self.songs_activated())
         view.connect('popup-menu', self.__popup_menu, library)
         view.get_selection().connect('changed', self.activate)
-        #model = view.get_model()
-        #s = model.connect('row-changed', self.__check_current)
-        #connect_obj(self, 'destroy', model.disconnect, s)
         self.connect('key-press-event', self.__key_pressed)
 
     def __create_cell_renderer(self):
@@ -300,19 +297,6 @@ class PlaylistsBrowser(Browser, DisplayPatternMixin):
                 self._start_rename(model.get_path(iter))
             return True
         return False
-
-    # Does not seem to be used for anything but row-changes to
-    # playlists? Breaks a lot of stuff in current implementation
-    # (on track change, clears selection, causes the playlist to
-    # scroll despite jump config being off, if a playlist contains
-    # duplicate tracks it skips to the last instance, ... )
-    """
-    def __check_current(self, model, path, iter):
-        model, citer = self.__selected_playlists()
-        if citer and model.get_path(citer) == path:
-            songlist = qltk.get_top_parent(self).songlist
-            self.activate(resort=not songlist.is_sorted())
-    """
 
     def __drag_motion(self, view, ctx, x, y, time):
         targets = [t.name() for t in ctx.list_targets()]

--- a/quodlibet/quodlibet/browsers/playlists/main.py
+++ b/quodlibet/quodlibet/browsers/playlists/main.py
@@ -258,7 +258,7 @@ class PlaylistsBrowser(Browser, DisplayPatternMixin):
         view.connect('row-activated', lambda *x: self.songs_activated())
         view.connect('popup-menu', self.__popup_menu, library)
         view.get_selection().connect('changed', self.activate)
-        model = view.get_model()
+        #model = view.get_model()
         #s = model.connect('row-changed', self.__check_current)
         #connect_obj(self, 'destroy', model.disconnect, s)
         self.connect('key-press-event', self.__key_pressed)
@@ -365,7 +365,7 @@ class PlaylistsBrowser(Browser, DisplayPatternMixin):
         playlist.inhibit = False
 
     def __get_name_of_current_selected_playlist(self):
-        model,iter = self.__selected_playlists()
+        model, iter = self.__selected_playlists()
         path = model.get_path(iter)
         playlist = model[path][0]
         return playlist


### PR DESCRIPTION
related to issues #2446 #2253

This appears to fix (in the playlist browser):
* A track change causing the current selection to be cleared
* A track change causing the playlist to scroll to the new track regardless of whether Jump on track change in config is set or not
* At least for me, when a playlist had duplicate tracks and one started playing, the last one would start playing, potentially skipping far into the playlist. 

now I have no idea if anything breaks so I suppose this pull request would serve better as some discussion of some sort (or if any of these changes are horribly messy).

I would like to add that I have no idea what I am doing and I worry something fairly unobvious breaks as a result of this.

as a sidenote I have not been able to run tests locally, the tests stop after a short while at 
```
tests/test_browsers_paned.py .Trace/breakpoint trap
#(with this in my /var/log/messages, which I could not make sense of:)
#Jun 25 10:22:40 Meowth kernel: traps: python[17475] trap int3 ip:7fb763cb5101 sp:7fffc9ecb140 error:0
```
