### PR TITLE
Wording fixes

### DIFF
--- a/quodlibet/quodlibet/browsers/covergrid/prefs.py
+++ b/quodlibet/quodlibet/browsers/covergrid/prefs.py
@@ -51,7 +51,7 @@ class Preferences(qltk.UniqueWindow, EditDisplayPatternMixin):
             return
         super(Preferences, self).__init__()
         self.set_border_width(12)
-        self.set_title(_("Cover Grid Preferences") + " - Quod Libet")
+        self.set_title(_("Cover Grid Preferences"))
         self.set_default_size(420, 380)
         self.set_transient_for(qltk.get_top_parent(browser))
         # Do this config-driven setup at instance-time

--- a/quodlibet/quodlibet/qltk/shortcuts.py
+++ b/quodlibet/quodlibet/qltk/shortcuts.py
@@ -38,7 +38,7 @@ SHORTCUTS = [
     ]),
     (_("Text Entries"), [
         ("<Primary>Z",
-         _("Collapses the element or select the parent element")),
+         _("Undo the last change")),
         ("<Primary><Shift>Z", _("Redo the last undone change")),
     ]),
     (_("Paned Browser"), [


### PR DESCRIPTION
The description of the undo operation in the shortcuts window was erroneously _Collapses the element or select the parent element_.

The second fix regarding the covergrid preference window wasn’t meant to be included in this pull request … but at least it is somewhat related.