### PR TITLE
Change "vertical split" to "wide mode" in covergrid browser

### DIFF
--- a/quodlibet/quodlibet/browsers/covergrid/main.py
+++ b/quodlibet/quodlibet/browsers/covergrid/main.py
@@ -154,12 +154,12 @@ class CoverGrid(Browser, util.InstanceTracker, VisibleUpdate,
             covergrid.view.queue_resize()
 
     @classmethod
-    def toggle_vert(klass):
-        vert = config.getboolean("browsers", "covergrid_vertical", True)
+    def toggle_wide(klass):
+        wide = config.getboolean("browsers", "covergrid_wide", False)
         for covergrid in klass.instances():
             covergrid.songcontainer.set_orientation(
-                Gtk.Orientation.VERTICAL if vert
-                else Gtk.Orientation.HORIZONTAL)
+                Gtk.Orientation.HORIZONTAL if wide
+                else Gtk.Orientation.VERTICAL)
 
     @classmethod
     def update_mag(klass):
@@ -208,7 +208,7 @@ class CoverGrid(Browser, util.InstanceTracker, VisibleUpdate,
         self.set_orientation(Gtk.Orientation.VERTICAL)
         self.songcontainer = qltk.paned.ConfigRVPaned(
             "browsers", "covergrid_pos", 0.4)
-        if not config.getboolean("browsers", "covergrid_vertical", True):
+        if config.getboolean("browsers", "covergrid_wide", False):
             self.songcontainer.set_orientation(Gtk.Orientation.HORIZONTAL)
 
         self._register_instance()

--- a/quodlibet/quodlibet/browsers/covergrid/prefs.py
+++ b/quodlibet/quodlibet/browsers/covergrid/prefs.py
@@ -75,11 +75,11 @@ class Preferences(qltk.UniqueWindow, EditDisplayPatternMixin):
         vbox.pack_start(cb2, False, True, 0)
 
         cb3 = ConfigCheckButton(
-            _("Vertical Split"), "browsers", "covergrid_vertical")
+            _("Wide Mode"), "browsers", "covergrid_wide")
         cb3.set_active(config.getboolean("browsers",
-            "covergrid_vertical", True))
+            "covergrid_wide", False))
         cb3.connect('toggled',
-                   lambda s: browser.toggle_vert())
+                   lambda s: browser.toggle_wide())
         vbox.pack_start(cb3, False, True, 0)
 
         # Redraws the covers only when the user releases the slider


### PR DESCRIPTION
As mentioned in #2322, the current naming and mapping was confusing. This commit changes the checkbox label from "vertical split" to "wide mode" (to be consistent with the paned browser) and "inverts" the checkbox mapping from what it was before. 

Codewise, to make the name of the config variable associated with the checkbox consistent with the checkbox label, it was changed from covergrid_vertical to covergrid_wide. This will result in people having to re-enable wide mode again when updating if the old "vertical split" checkbox was explicitly unchecked. I don't consider this an issue, but I guess it can be changed back to covergrid_vertical if this "breaks" backwards compatibility.