### PR TITLE
Handle case when arg to cmp is of type songfile and not songwrapper

### DIFF
--- a/quodlibet/quodlibet/util/songwrapper.py
+++ b/quodlibet/quodlibet/util/songwrapper.py
@@ -60,10 +60,14 @@ class SongWrapper(object):
         return hash(self._song)
 
     def __eq__(self, other):
-        return self._song == other._song
+        if hasattr(other, '_song'):
+            other = other._song
+        return self._song == other
 
     def __lt__(self, other):
-        return self._song < other._song
+        if hasattr(other, '_song'):
+            other = other._song
+        return self._song < other
 
     def __getitem__(self, *args):
         return self._song.__getitem__(*args)


### PR DESCRIPTION
Seems to fix #2436 for me

I have no idea why a songfile rather than a songwrapper would be compared somewhere, and why the native bookmarks does not trigger such an issue (and the go-to-bookmark plugin does). Something to do with the plugins fake_player ? I tried finding the cause but it just lead deep into libraries/librarians and changed-signals, though if there is a fixable root cause somewhere due to passing the wrong type then that is probably preferable to these checks. 

The bookmark plugin seems to pass app.library rather than library.librarian as the ctrl+B bookmarks editor does. 

I am not sure what calls the other functions that reference other, and whether those get wrappers or songfiles. 