### PR TITLE
Created new confirmation dialog; cleared some redundancy in dialog usage

### DIFF
--- a/quodlibet/quodlibet/ext/songsmenu/custom_commands.py
+++ b/quodlibet/quodlibet/ext/songsmenu/custom_commands.py
@@ -11,7 +11,7 @@ import os
 
 from quodlibet.util.songwrapper import SongWrapper
 
-from quodlibet.qltk.songsmenu import ConfirmMultiSongInvoke
+from quodlibet.qltk.songsmenu import confirm_multi_song_invoke
 
 import quodlibet
 from quodlibet import _
@@ -267,7 +267,7 @@ class CustomCommands(PlaylistPlugin, SongsMenuPlugin, PluginConfigMixin):
         if self.com_index:
             com = self.get_data(self.com_index)
             if len(songs) > com.warn_threshold:
-                if not ConfirmMultiSongInvoke.confirm(
+                if not confirm_multi_song_invoke(
                         self, com.name, len(songs)):
                     print_d("User decided not to run on %d songs" % len(songs))
                     return

--- a/quodlibet/quodlibet/plugins/playlist.py
+++ b/quodlibet/quodlibet/plugins/playlist.py
@@ -5,48 +5,28 @@
 # it under the terms of the GNU General Public License version 2 as
 # published by the Free Software Foundation
 
-from gi.repository import Gtk
-
 from quodlibet import ngettext, _
 from quodlibet.qltk import get_top_parent, get_menu_item_top_parent
-from quodlibet.qltk.msg import WarningMessage
+from quodlibet.qltk.msg import ConfirmationPrompt
 from quodlibet.qltk.x import SeparatorMenuItem
-from quodlibet.qltk import Icons
 from quodlibet.util import print_exc, format_int_locale
 from quodlibet.util.dprint import print_d, print_e
 from quodlibet.plugins import PluginHandler, PluginManager
 from quodlibet.plugins.gui import MenuItemPlugin
 
 
-class ConfirmMultiPlaylistInvoke(WarningMessage):
+def confirm_multi_playlist_invoke(parent, plugin_name, count):
     """Dialog to confirm invoking a plugin with X playlists
     in case X is high
     """
-
-    RESPONSE_INVOKE = 1
-
-    def __init__(self, parent, plugin_name, count):
-        params = {"name": plugin_name, "count": format_int_locale(count)}
-        title = ngettext("Run the plugin \"%(name)s\" on %(count)s playlist?",
-                         "Run the plugin \"%(name)s\" on %(count)s playlists?",
-                         count) % params
-
-        super(ConfirmMultiPlaylistInvoke, self).__init__(
-            get_top_parent(parent),
-            title, "",
-            buttons=Gtk.ButtonsType.NONE)
-
-        self.add_button(_("_Cancel"), Gtk.ResponseType.CANCEL)
-        self.add_icon_button(
-            _("_Run Plugin"), Icons.SYSTEM_RUN, self.RESPONSE_INVOKE)
-        self.set_default_response(Gtk.ResponseType.CANCEL)
-
-    @classmethod
-    def confirm(cls, parent, plugin_name, count):
-        """Returns if the action was confirmed"""
-
-        resp = cls(parent, plugin_name, count).run()
-        return resp == cls.RESPONSE_INVOKE
+    params = {"name": plugin_name, "count": format_int_locale(count)}
+    title = ngettext("Run the plugin \"%(name)s\" on %(count)s playlist?",
+                     "Run the plugin \"%(name)s\" on %(count)s playlists?",
+                     count) % params
+    description = ""
+    ok_text = _("_Run Plugin")
+    prompt = ConfirmationPrompt(parent, title, description, ok_text).run()
+    return prompt == ConfirmationPrompt.RESPONSE_INVOKE
 
 
 class PlaylistPlugin(MenuItemPlugin):
@@ -108,7 +88,7 @@ class PlaylistPluginHandler(PluginHandler):
 
         self.__plugins = []
         self._confirm_multiple = (confirmer or
-                                  ConfirmMultiPlaylistInvoke.confirm)
+                                  confirm_multi_playlist_invoke)
 
     def populate_menu(self, menu, library, browser, playlists):
         """Appends items onto `menu` for each enabled playlist plugin,

--- a/quodlibet/quodlibet/qltk/msg.py
+++ b/quodlibet/quodlibet/qltk/msg.py
@@ -78,6 +78,31 @@ class WarningMessage(Message):
             Gtk.MessageType.WARNING, *args, **kwargs)
 
 
+class ConfirmationPrompt(WarningMessage):
+    """Dialog to confirm actions, given a parent, title, description, and
+       OK-button text"""
+
+    RESPONSE_INVOKE = 1
+
+    def __init__(self, parent, title, description, ok_button_text):
+        super(ConfirmationPrompt, self).__init__(
+            get_top_parent(parent),
+            title, description,
+            buttons=Gtk.ButtonsType.NONE)
+
+        self.add_button(_("_Cancel"), Gtk.ResponseType.CANCEL)
+        self.add_icon_button(ok_button_text, Icons.SYSTEM_RUN,
+                             self.RESPONSE_INVOKE)
+        self.set_default_response(Gtk.ResponseType.CANCEL)
+
+    @classmethod
+    def confirm(cls, parent, plugin_name, count):
+        """Returns if the action was confirmed"""
+
+        resp = cls(parent, plugin_name, count).run()
+        return resp == cls.RESPONSE_INVOKE
+
+
 class ConfirmFileReplace(WarningMessage):
 
     RESPONSE_REPLACE = 1

--- a/quodlibet/quodlibet/qltk/msg.py
+++ b/quodlibet/quodlibet/qltk/msg.py
@@ -95,13 +95,6 @@ class ConfirmationPrompt(WarningMessage):
                              self.RESPONSE_INVOKE)
         self.set_default_response(Gtk.ResponseType.CANCEL)
 
-    @classmethod
-    def confirm(cls, parent, plugin_name, count):
-        """Returns if the action was confirmed"""
-
-        resp = cls(parent, plugin_name, count).run()
-        return resp == cls.RESPONSE_INVOKE
-
 
 class ConfirmFileReplace(WarningMessage):
 

--- a/quodlibet/quodlibet/qltk/songsmenu.py
+++ b/quodlibet/quodlibet/qltk/songsmenu.py
@@ -15,7 +15,7 @@ from quodlibet import ngettext, _
 from quodlibet import qltk
 
 from quodlibet.util import print_exc, print_e, print_w
-from quodlibet.qltk.msg import WarningMessage
+from quodlibet.qltk.msg import ConfirmationPrompt
 from quodlibet.qltk.delete import TrashMenuItem, trash_songs
 from quodlibet.qltk.information import Information
 from quodlibet.qltk.properties import SongProperties
@@ -27,60 +27,26 @@ from quodlibet.plugins.songsmenu import SongsMenuPlugin
 from quodlibet.util.songwrapper import ListWrapper, check_wrapper_changed
 
 
-class ConfirmMultiSongInvoke(WarningMessage):
+def confirm_multi_song_invoke(parent, plugin_name, count):
     """Dialog to confirm invoking a plugin with X songs in case X is high"""
-
-    RESPONSE_INVOKE = 1
-
-    def __init__(self, parent, plugin_name, count):
-        title = ngettext("Run the plugin \"%(name)s\" on %(count)d song?",
-                         "Run the plugin \"%(name)s\" on %(count)d songs?",
-                         count) % {"name": plugin_name, "count": count}
-
-        super(ConfirmMultiSongInvoke, self).__init__(
-            get_top_parent(parent),
-            title, "",
-            buttons=Gtk.ButtonsType.NONE)
-
-        self.add_button(_("_Cancel"), Gtk.ResponseType.CANCEL)
-        self.add_icon_button(_("_Run Plugin"), Icons.SYSTEM_RUN,
-                             self.RESPONSE_INVOKE)
-        self.set_default_response(Gtk.ResponseType.CANCEL)
-
-    @classmethod
-    def confirm(cls, parent, plugin_name, count):
-        """Returns if the action was confirmed"""
-
-        resp = cls(parent, plugin_name, count).run()
-        return resp == cls.RESPONSE_INVOKE
+    title = ngettext("Run the plugin \"%(name)s\" on %(count)d song?",
+                     "Run the plugin \"%(name)s\" on %(count)d songs?",
+                     count) % {"name": plugin_name, "count": count}
+    description = ""
+    ok_text = _("_Run Plugin")
+    prompt = ConfirmationPrompt(parent, title, description, ok_text).run()
+    return prompt == ConfirmationPrompt.RESPONSE_INVOKE
 
 
-class ConfirmMultiAlbumInvoke(WarningMessage):
+def confirm_multi_album_invoke(parent, plugin_name, count):
     """Dialog to confirm invoking a plugin with X albums in case X is high"""
-
-    RESPONSE_INVOKE = 1
-
-    def __init__(self, parent, plugin_name, count):
-        title = ngettext("Run the plugin \"%(name)s\" on %(count)d album?",
-                         "Run the plugin \"%(name)s\" on %(count)d albums?",
-                         count) % {'name': plugin_name, 'count': count}
-
-        super(ConfirmMultiAlbumInvoke, self).__init__(
-            get_top_parent(parent),
-            title, "",
-            buttons=Gtk.ButtonsType.NONE)
-
-        self.add_button(_("_Cancel"), Gtk.ResponseType.CANCEL)
-        self.add_icon_button(_("_Run Plugin"), Icons.SYSTEM_RUN,
-                             self.RESPONSE_INVOKE)
-        self.set_default_response(Gtk.ResponseType.CANCEL)
-
-    @classmethod
-    def confirm(cls, parent, plugin_name, count):
-        """Returns if the action was confirmed"""
-
-        resp = cls(parent, plugin_name, count).run()
-        return resp == cls.RESPONSE_INVOKE
+    title = ngettext("Run the plugin \"%(name)s\" on %(count)d album?",
+                     "Run the plugin \"%(name)s\" on %(count)d albums?",
+                     count) % {"name": plugin_name, "count": count}
+    description = ""
+    ok_text = _("_Run Plugin")
+    prompt = ConfirmationPrompt(parent, title, description, ok_text).run()
+    return prompt == ConfirmationPrompt.RESPONSE_INVOKE
 
 
 class SongsMenuPluginHandler(PluginHandler):
@@ -90,11 +56,11 @@ class SongsMenuPluginHandler(PluginHandler):
 
         self.__plugins = []
 
-        self._confirm_multiple_songs = ConfirmMultiSongInvoke.confirm
+        self._confirm_multiple_songs = confirm_multi_song_invoke
         if song_confirmer is not None:
             self._confirm_multiple_songs = song_confirmer
 
-        self._confirm_multiple_albums = ConfirmMultiAlbumInvoke.confirm
+        self._confirm_multiple_albums = confirm_multi_album_invoke
         if album_confirmer is not None:
             self._confirm_multiple_albums = album_confirmer
 
@@ -280,7 +246,6 @@ class SongsMenu(Gtk.Menu):
                  queue=True, remove=True, delete=False,
                  edit=True, ratings=True, items=None, accels=True):
         super(SongsMenu, self).__init__()
-
         # The library may actually be a librarian; if it is, use it,
         # otherwise find the real librarian.
         librarian = getattr(library, 'librarian', library)


### PR DESCRIPTION
New confirmation dialog in qltk/msg.py for cancel/accept-dialogs that takes title, description, and button label. 
This also changes the plugin prompts (for activating plugins on X many items) in songsmenu to use this for a tiny cleanup in code reuse. 

I have a second branch that adds a confirmation prompt using this new dialog for removing tracks from the library that I could include in this request if that is desirable, or maybe in a second request (though it depends on this). 

I noticed tests/test_qltk_chooser.py which I think could be used to put together some tests too