### PR TITLE
Fix results for queries with time tags and aggregate functions

### DIFF
--- a/quodlibet/quodlibet/query/_match.py
+++ b/quodlibet/quodlibet/query/_match.py
@@ -269,7 +269,10 @@ class NumexprTag(Numexpr):
         else:
             num = data(self._ftag, None)
         if num is not None:
-            if self._ftag in TIME_TAGS:
+            # Strip aggregate function from tag
+            func_start = self._ftag.find(":")
+            tag = self._ftag[:func_start] if func_start >= 0 else self._ftag
+            if tag in TIME_TAGS:
                 num = time - num
             return round(num, 2)
         return None

--- a/quodlibet/tests/test_query__match.py
+++ b/quodlibet/tests/test_query__match.py
@@ -10,6 +10,7 @@ from quodlibet.query._match import NumexprNow, numexprTagOrSpecial, Inter,\
     True_, Neg
 from quodlibet.util import parse_date
 from quodlibet.formats import AudioFile
+from quodlibet.util.collection import Collection
 
 
 class TQueryInter(TestCase):
@@ -65,6 +66,16 @@ class TQueryMatch(TestCase):
                         > parse_date('2012-11-08'))
         self.failUnless(NumexprTag('date').evaluate(song, 0, True)
                         < parse_date('2012-11-10'))
+
+    def test_numexpr_func(self):
+        time = 424242
+        col = Collection()
+        col.songs = (AudioFile({'~#added': 400000, '~#length': 315}),
+                     AudioFile({'~#added': 405000, '~#length': 225}))
+        self.failUnless(NumexprTag('length:avg').evaluate(col, time, True)
+                        == 270)
+        self.failUnless(NumexprTag('added:max').evaluate(col, time, True)
+                        == 19242)
 
     def test_numexpr_now(self):
         time = 424242


### PR DESCRIPTION
This fixes issues as reported in #2200. 

Tags related to times weren't correctly identified when combined with an aggregate function which produced wrong query results. 