### PR TITLE
Soundcloud: my tracks and more

### DIFF
--- a/quodlibet/quodlibet/browsers/soundcloud/api.py
+++ b/quodlibet/quodlibet/browsers/soundcloud/api.py
@@ -13,7 +13,7 @@ from quodlibet import util, config
 from quodlibet.util import website
 from quodlibet.util.dprint import print_w, print_d
 from quodlibet.util.http import download_json, download
-from quodlibet.compat import urlencode, iteritems
+from quodlibet.compat import urlencode, iteritems, text_type
 
 from .library import SoundcloudFile
 from .util import json_callback, Wrapper, sanitise_tag, DEFAULT_BITRATE, EPOCH
@@ -96,12 +96,15 @@ class SoundcloudApiClient(RestApi):
         'authenticated': (GObject.SignalFlags.RUN_LAST, None, (object,)),
     }
 
-    def __init__(self, token=None):
+    def __init__(self):
         print_d("Starting Soundcloud API...")
         super(SoundcloudApiClient, self).__init__(self.API_ROOT)
-        self.online = bool(token)
+        self.access_token = config.get("browsers", "soundcloud_token", None)
+        self.online = bool(self.access_token)
+        self.user_id = config.get("browsers", "soundcloud_user_id", None)
+        if not self.user_id:
+            self._get_me()
         self.username = None
-        self.access_token = token
 
     def _default_params(self):
         params = {'client_id': self.__CLIENT_ID}
@@ -119,7 +122,7 @@ class SoundcloudApiClient(RestApi):
     def log_out(self):
         print_d("Destroying access token...")
         self.access_token = None
-        self.save_token()
+        self.save_auth()
         self.online = False
 
     def get_token(self, code):
@@ -137,13 +140,17 @@ class SoundcloudApiClient(RestApi):
     def _receive_token(self, json):
         self.access_token = json['access_token']
         print_d("Got an access token: %s" % self.access_token)
-        self.save_token()
+        self.save_auth()
         self.online = True
+        self._get_me()
+
+    def _get_me(self):
         self._get('/me', self._receive_me)
 
     @json_callback
     def _receive_me(self, json):
         self.username = json['username']
+        self.user_id = json['id']
         self.emit('authenticated', Wrapper(json))
 
     def get_tracks(self, params):
@@ -166,6 +173,9 @@ class SoundcloudApiClient(RestApi):
     def get_favorites(self):
         self._get('/me/favorites', self._on_track_data, limit=self.PAGE_SIZE)
 
+    def get_my_tracks(self):
+        self._get('/me/tracks', self._on_track_data, limit=self.PAGE_SIZE)
+
     def get_comments(self, track_id):
         self._get('/tracks/%s/comments' % track_id, self._receive_comments,
                   limit=200)
@@ -178,8 +188,9 @@ class SoundcloudApiClient(RestApi):
             track_id = json[0]["track_id"]
             self.emit('comments-received', track_id, json)
 
-    def save_token(self):
+    def save_auth(self):
         config.set("browsers", "soundcloud_token", self.access_token or "")
+        config.set("browsers", "soundcloud_user_id", self.user_id or "")
 
     def put_favorite(self, track_id):
         print_d("Saving track %s as favorite" % track_id)
@@ -240,6 +251,7 @@ class SoundcloudApiClient(RestApi):
         try:
             song.update(title=r.title,
                         artist=r.user["username"],
+                        soundcloud_user_id=text_type(r.user_id),
                         website=r.permalink_url,
                         genre=u"\n".join(r.genre and r.genre.split(",") or []))
             if dl:

--- a/quodlibet/quodlibet/browsers/soundcloud/library.py
+++ b/quodlibet/quodlibet/browsers/soundcloud/library.py
@@ -50,6 +50,7 @@ class SoundcloudLibrary(SongLibrary):
     def _on_songs_received(self, client, songs):
         new = len(self.add(songs))
         print_d("Got %d songs (%d new)." % (len(songs), new))
+        self.emit('changed', songs)
 
     def _on_comments_received(self, client, track_id, comments):
         def bookmark_for(com):

--- a/quodlibet/quodlibet/browsers/soundcloud/query.py
+++ b/quodlibet/quodlibet/browsers/soundcloud/query.py
@@ -41,6 +41,7 @@ _QL_TO_SC = {
     'artist': ('q', None),
     'title': ('q', None),
     'comments': ('q', None),
+    'soundcloud_user_id': ('user_id', None)
 }
 SUPPORTED = set(_QL_TO_SC.keys()) | {"rating"}
 

--- a/quodlibet/quodlibet/browsers/soundcloud/util.py
+++ b/quodlibet/quodlibet/browsers/soundcloud/util.py
@@ -76,7 +76,7 @@ class State(int):
 
 @enum
 class FilterType(int):
-    SEP, SEARCH, FAVORITES = range(3)
+    SEP, SEARCH, FAVORITES, MINE = range(4)
 
 
 class EnterAuthCodeDialog(GetStringDialog):

--- a/quodlibet/quodlibet/qltk/icons.py
+++ b/quodlibet/quodlibet/qltk/icons.py
@@ -88,6 +88,7 @@ class Icons(str):
     MEDIA_PLAYBACK_STOP = "media-playback-stop"  # "_Stop"
     MEDIA_PLAYLIST_REPEAT = "media-playlist-repeat"
     MEDIA_PLAYLIST_SHUFFLE = "media-playlist-shuffle"
+    MEDIA_RECORD = "media-record"
     MEDIA_SKIP_BACKWARD = "media-skip-backward"  # "Pre_vious"
     MEDIA_SKIP_FORWARD = "media-skip-forward"  # "_Next"
     MULTIMEDIA_PLAYER = "multimedia-player"

--- a/quodlibet/quodlibet/util/http.py
+++ b/quodlibet/quodlibet/util/http.py
@@ -198,7 +198,6 @@ class FallbackHTTPRequest(DefaultHTTPRequest):
             return # redirection, wait for another emission of got-headers
         self.istream = Gio.MemoryInputStream.new()
         self.message.connect('got-chunk', self._chunk)
-        print_d('Sent request to {0}'.format(self._uri))
         self.emit('sent', self.message)
 
     def _chunk(self, message, buffer):

--- a/quodlibet/tests/test_soundcloudFile.py
+++ b/quodlibet/tests/test_soundcloudFile.py
@@ -20,8 +20,8 @@ TRACK_ID = 1234
 class TSoundcloudFile(TestCase):
     class FakeClient(SoundcloudApiClient):
 
-        def __init__(self, token=None):
-            super(TSoundcloudFile.FakeClient, self).__init__(token)
+        def __init__(self):
+            super(TSoundcloudFile.FakeClient, self).__init__()
             self.online = True
             self.favoritings = defaultdict(int)
             self.unfavoritings = defaultdict(int)

--- a/quodlibet/tests/test_soundcloudLibrary.py
+++ b/quodlibet/tests/test_soundcloudLibrary.py
@@ -68,8 +68,8 @@ class TSoundcloudLibrary(TestCase):
         def get_tracks(self, query):
             self._on_track_data(None, [TRACK], None)
 
-        def __init__(self, token=None):
-            super(TSoundcloudLibrary.FakeClient, self).__init__(token)
+        def __init__(self):
+            super(TSoundcloudLibrary.FakeClient, self).__init__()
 
         def authenticate_user(self):
             pass


### PR DESCRIPTION
 * Add new category (filter) for my (soundcloud) tracks
 * Gather and persist to config the `user_id` from API
 * Move config handling entirely into the API class rather than in
 two places which was a bit weird
 * Add a new `soundcloud_user_id` QL tag with mapping from API
 * Use the known value to template a QL filter for my tracks whilst
 actually doing the query in the background for all API results
 (there should be 1:1 here though, but the browser works by
 overlaying the QL filter on all the cached results so it kinda has
 to do this)
 * BUGFIX: ordering of filters (categories)
 * BUGFIX: async updating issue by connecting library properly to
 browser (assumes everything API is a change)
 * BUGFIX: actually disable invalid items (favourites, my tracks)
 when user is logged out and re-enable on login.