### PR TITLE
 Update song order in song list when modified

### DIFF
--- a/quodlibet/config.py
+++ b/quodlibet/config.py
@@ -101,6 +101,11 @@ INITIAL: Dict[str, Dict[str, str]] = {
         "column_expands": "",
     },
 
+    "song_list": {
+        # Automatically re-sort song list when tags are modified
+        "auto_sort": "true",
+    },
+
     "browsers": {
 
         # search bar text

--- a/quodlibet/qltk/prefs.py
+++ b/quodlibet/qltk/prefs.py
@@ -61,11 +61,16 @@ class PreferencesWindow(UniqueWindow):
         def __init__(self):
             def create_behaviour_frame():
                 vbox = Gtk.VBox(spacing=6)
-                c = CCB(_("_Jump to playing song automatically"),
+                jump_button = CCB(_("_Jump to playing song automatically"),
                         'settings', 'jump', populate=True,
                         tooltip=_("When the playing song changes, "
                                   "scroll to it in the song list"))
-                vbox.pack_start(c, False, True, 0)
+                autosort_button = CCB(_("Sort songs when tags are modified"),
+                        'song_list', 'auto_sort', populate=True,
+                        tooltip=_("Automatically re-sort songs in the song list when "
+                                  "tags are modified"))
+                vbox.pack_start(jump_button, False, True, 0)
+                vbox.pack_start(autosort_button, False, True, 0)
                 return qltk.Frame(_("Behavior"), child=vbox)
 
             def create_visible_columns_frame():

--- a/quodlibet/qltk/songlist.py
+++ b/quodlibet/qltk/songlist.py
@@ -953,7 +953,7 @@ class SongList(AllTreeView, SongListDnDMixin, DragScroll,
         """
 
         model = self.get_model()
-        if self.is_sorted():
+        if config.getboolean("song_list", "auto_sort") and self.is_sorted():
             iters, complete = self.__find_iters_in_selection(songs)
             if not complete:
                 iters = model.find_all(songs)

--- a/quodlibet/qltk/songlist.py
+++ b/quodlibet/qltk/songlist.py
@@ -799,14 +799,9 @@ class SongList(AllTreeView, SongListDnDMixin, DragScroll,
             model.append_many(songs)
             return
 
-        # FIXME: Replace with something fast
-        old_songs = self.get_songs()
-        old_songs.extend(songs)
-
-        self._sort_songs(old_songs)
-
-        for index, song in sorted(zip(map(old_songs.index, songs), songs)):
-            model.insert(index, row=[song])
+        for song in songs:
+            insert_iter = self.__find_song_position(song)
+            model.insert_before(insert_iter, row=[song])
 
     def set_songs(self, songs, sorted=False, scroll=True, scroll_select=False):
         """Fill the song list.


### PR DESCRIPTION
With these changes the song list order is updated if a song is modified. I personally would like this behaviour so I can for example sort by laststarted or lastplayed during randomized playback and have the list reflect the history of plays without having to manually toggle the sort column.  

Generally this works well, occasionally though when a song is double-clicked and consequently modified/sorted (e.g. laststarted) the selection messes up. In addition to the clicked song the song originally following it is selected too. I was unable to find the cause of this. The only thing I know is that the selection changes after `SongList.__song_updated` (qltk/songlist.py).

Incidentally these changes also allowed me to improve `SongList.add_songs` so it no longer has to re-sort all songs when new ones are added. 