### PR TITLE
Album art mods

### DIFF
--- a/quodlibet/quodlibet/ext/songsmenu/albumart.py
+++ b/quodlibet/quodlibet/ext/songsmenu/albumart.py
@@ -693,21 +693,57 @@ class AlbumArtWindow(qltk.Window, PluginConfigMixin):
         sw_list.set_shadow_type(Gtk.ShadowType.IN)
         sw_list.add(treeview)
 
-        self.search_field = Gtk.Entry()
+        search_labelraw = Gtk.Label('raw')
+        search_labelraw.set_alignment(xalign=1.0, yalign=0.5)
+        self.search_fieldraw = Gtk.Entry()
+        self.search_fieldraw.connect('activate', self.start_search)
+        self.search_fieldraw.connect('changed', self.__searchfieldchanged)
+        search_labelclean = Gtk.Label('clean')
+        search_labelclean.set_alignment(xalign=1.0, yalign=0.5)
+        self.search_fieldclean = Gtk.Label()
+        self.search_fieldclean.set_can_focus(False)
+        self.search_fieldclean.set_alignment(xalign=0.0, yalign=0.5)
+
+        self.search_radioraw = Gtk.RadioButton(group=None, label=None)
+        self.search_radioraw.connect("toggled", self.__searchtypetoggled,
+                                     "raw")
+        self.search_radioclean = Gtk.RadioButton(group=self.search_radioraw,
+                                                 label=None)
+        self.search_radioclean.connect("toggled", self.__searchtypetoggled,
+                                       "clean")
+        #note: set_active(False) appears to have no effect
+        #self.search_radioraw.set_active(
+        #    self.config_get_bool('searchraw', False))
+        if self.config_get_bool('searchraw', False):
+            self.search_radioraw.set_active(True)
+        else:
+            self.search_radioclean.set_active(True)
+
         self.search_button = Button(_("_Search"), Icons.EDIT_FIND)
         self.search_button.connect('clicked', self.start_search)
-        self.search_field.connect('activate', self.start_search)
+        search_button_box = Gtk.Alignment()
+        search_button_box.set(1, 0, 0, 0)
+        search_button_box.add(self.search_button)
+
+        search_table = Gtk.Table(rows=3, columns=4, homogeneous=False)
+        search_table.attach(search_labelraw, 0, 1, 0, 1,
+                            xoptions=Gtk.AttachOptions.FILL, xpadding=6)
+        search_table.attach(self.search_radioraw, 1, 2, 0, 1,
+                            xoptions=0, xpadding=0)
+        search_table.attach(self.search_fieldraw, 2, 4, 0, 1)
+        search_table.attach(search_labelclean, 0, 1, 1, 2,
+                            xoptions=Gtk.AttachOptions.FILL, xpadding=6)
+        search_table.attach(self.search_radioclean, 1, 2, 1, 2,
+                            xoptions=0, xpadding=0)
+        search_table.attach(self.search_fieldclean, 2, 4, 1, 2, xpadding=4)
+        search_table.attach(search_button_box, 3, 4, 2, 3)
 
         widget_space = 5
-
-        search_hbox = Gtk.HBox(spacing=widget_space)
-        search_hbox.pack_start(self.search_field, True, True, 0)
-        search_hbox.pack_start(self.search_button, False, True, 0)
 
         self.progress = Gtk.ProgressBar()
 
         left_vbox = Gtk.VBox(spacing=widget_space)
-        left_vbox.pack_start(search_hbox, False, True, 0)
+        left_vbox.pack_start(search_table, False, True, 0)
         left_vbox.pack_start(sw_list, True, True, 0)
 
         hpaned = Paned()
@@ -722,10 +758,15 @@ class AlbumArtWindow(qltk.Window, PluginConfigMixin):
 
         left_vbox.pack_start(self.progress, False, True, 0)
 
+        self.connect('destroy', self.__save_config)
+
         song = songs[0]
         text = SEARCH_PATTERN.format(song)
         self.set_text(text)
         self.start_search()
+
+    def __save_config(self, widget):
+        self.config_set('searchraw', self.search_radioraw.get_active())
 
     def __drag_data_get(self, view, ctx, sel, tid, etime, treeselection):
         model, iter = treeselection.get_selected()
@@ -734,10 +775,19 @@ class AlbumArtWindow(qltk.Window, PluginConfigMixin):
         cover = model.get_value(iter, 1)
         sel.set_uris([cover['cover']])
 
+    def __searchfieldchanged(self, *data):
+        search = data[0].get_text()
+        clean = cleanup_query(search, ' ')
+        self.search_fieldclean.set_text('<b>' + clean + '</b>')
+        self.search_fieldclean.set_use_markup(True)
+
+    def __searchtypetoggled(self, *data):
+        self.config_set('searchraw', self.search_radioraw.get_active())
+
     def start_search(self, *data):
         """Start the search using the text from the text entry"""
 
-        text = self.search_field.get_text()
+        text = self.search_fieldraw.get_text()
         if not text or self.search_lock:
             return
 
@@ -757,7 +807,8 @@ class AlbumArtWindow(qltk.Window, PluginConfigMixin):
                     CONFIG_ENG_PREFIX + eng['config_id'], True):
                 search.add_engine(eng['class'], eng['replace'])
 
-        search.start(text)
+        raw = self.search_radioraw.get_active()
+        search.start(text, raw)
 
         # Focus the list
         self.treeview.grab_focus()
@@ -770,8 +821,8 @@ class AlbumArtWindow(qltk.Window, PluginConfigMixin):
     def set_text(self, text):
         """set the text and move the cursor to the end"""
 
-        self.search_field.set_text(text)
-        self.search_field.emit('move-cursor', Gtk.MovementStep.BUFFER_ENDS,
+        self.search_fieldraw.set_text(text)
+        self.search_fieldraw.emit('move-cursor', Gtk.MovementStep.BUFFER_ENDS,
             0, False)
 
     def __select_callback(self, selection, image):
@@ -839,13 +890,13 @@ class CoverSearch(object):
 
         self._stop = True
 
-    def start(self, query):
+    def start(self, query, raw):
         """Start search. The callback function will be called after each of
         the search engines has finished."""
 
         for engine, replace in self.engine_list:
             thr = threading.Thread(target=self.__search_thread,
-                                   args=(engine, query, replace))
+                                   args=(engine, query, replace, raw))
             thr.setDaemon(True)
             thr.start()
 
@@ -853,14 +904,17 @@ class CoverSearch(object):
         if not len(self.engine_list):
             GLib.idle_add(self.callback, [], 1)
 
-    def __search_thread(self, engine, query, replace):
+    def __search_thread(self, engine, query, replace, raw):
         """Creates searching threads which call the callback function after
         they are finished"""
 
-        clean_query = self.__cleanup_query(query, replace)
+        search = query if raw else cleanup_query(query, replace)
+
+        print_d("[AlbumArt] running search %r on engine %s" %
+                (search, engine.__name__))
         result = []
         try:
-            result = engine().start(clean_query)
+            result = engine().start(search)
         except Exception:
             print_w("[AlbumArt] %s: %r" % (engine.__name__, query))
             print_exc()
@@ -870,30 +924,31 @@ class CoverSearch(object):
         progress = float(self.finished) / len(self.engine_list)
         GLib.idle_add(self.callback, result, progress)
 
-    def __cleanup_query(self, query, replace):
-        """split up at '-', remove some chars, only keep the longest words..
-        more false positives but much better results"""
 
-        query = query.lower()
-        if query.startswith("the "):
-            query = query[4:]
+def cleanup_query(query, replace):
+    """split up at '-', remove some chars, only keep the longest words..
+    more false positives but much better results"""
 
-        split = query.split('-')
-        replace_str = ('+', '&', ',', '.', '!', '´',
-                       '\'', ':', ' and ', '(', ')')
-        new_query = ''
-        for part in split:
-            for stri in replace_str:
-                part = part.replace(stri, replace)
+    query = query.lower()
+    if query.startswith("the "):
+        query = query[4:]
 
-            p_split = part.split()
-            p_split.sort(key=len, reverse=True)
-            end = max(int(len(p_split) / 4), max(4 - len(p_split), 2))
-            p_split = p_split[:end]
+    split = query.split('-')
+    replace_str = ('+', '&', ',', '.', '!', '´',
+                   '\'', ':', ' and ', '(', ')')
+    new_query = ''
+    for part in split:
+        for stri in replace_str:
+            part = part.replace(stri, replace)
 
-            new_query += ' '.join(p_split) + ' '
+        p_split = part.split()
+        p_split.sort(key=len, reverse=True)
+        end = max(int(len(p_split) / 4), max(4 - len(p_split), 2))
+        p_split = p_split[:end]
 
-        return new_query.rstrip()
+        new_query += ' '.join(p_split) + ' '
+
+    return new_query.rstrip()
 
 
 def get_size_of_url(url):

--- a/quodlibet/quodlibet/ext/songsmenu/albumart.py
+++ b/quodlibet/quodlibet/ext/songsmenu/albumart.py
@@ -295,7 +295,7 @@ class DiscogsParser(object):
         page = 1
         while len(self.covers) < limit:
             self.__parse_page(page, query)
-            if page < self.page_count:
+            if page >= self.page_count:
                 break
             page += 1
 

--- a/quodlibet/quodlibet/ext/songsmenu/albumart.py
+++ b/quodlibet/quodlibet/ext/songsmenu/albumart.py
@@ -52,6 +52,8 @@ CONFIG_ENG_PREFIX = 'engine_'
 SEARCH_PATTERN = Pattern(
     '<albumartist|<albumartist>|<artist>> - <album|<album>|<title>>')
 
+REQUEST_LIMIT_MAX = 15
+
 
 def get_encoding_from_socket(socket):
     content_type = socket.headers.get("Content-Type", "")
@@ -719,6 +721,19 @@ class AlbumArtWindow(qltk.Window, PluginConfigMixin):
         else:
             self.search_radioclean.set_active(True)
 
+        search_labelresultsmax = Gtk.Label('limit')
+        search_labelresultsmax.set_alignment(xalign=1.0, yalign=0.5)
+        search_labelresultsmax.set_tooltip_text(
+             _("Per engine 'at best' results limit"))
+        search_adjresultsmax = Gtk.Adjustment(
+            value=int(self.config_get("resultsmax", 3)), lower=1,
+            upper=REQUEST_LIMIT_MAX, step_incr=1,
+            page_incr=0, page_size=0)
+        self.search_spinresultsmax = Gtk.SpinButton(
+            adjustment=search_adjresultsmax, climb_rate=0.2, digits=0)
+        self.search_spinresultsmax.set_alignment(xalign=0.5)
+        self.search_spinresultsmax.set_can_focus(False)
+
         self.search_button = Button(_("_Search"), Icons.EDIT_FIND)
         self.search_button.connect('clicked', self.start_search)
         search_button_box = Gtk.Alignment()
@@ -736,6 +751,10 @@ class AlbumArtWindow(qltk.Window, PluginConfigMixin):
         search_table.attach(self.search_radioclean, 1, 2, 1, 2,
                             xoptions=0, xpadding=0)
         search_table.attach(self.search_fieldclean, 2, 4, 1, 2, xpadding=4)
+        search_table.attach(search_labelresultsmax, 0, 2, 2, 3,
+                            xoptions=Gtk.AttachOptions.FILL, xpadding=6)
+        search_table.attach(self.search_spinresultsmax, 2, 3, 2, 3,
+                            xoptions=Gtk.AttachOptions.FILL, xpadding=0)
         search_table.attach(search_button_box, 3, 4, 2, 3)
 
         widget_space = 5
@@ -767,6 +786,8 @@ class AlbumArtWindow(qltk.Window, PluginConfigMixin):
 
     def __save_config(self, widget):
         self.config_set('searchraw', self.search_radioraw.get_active())
+        self.config_set('resultsmax',
+                        self.search_spinresultsmax.get_value_as_int())
 
     def __drag_data_get(self, view, ctx, sel, tid, etime, treeselection):
         model, iter = treeselection.get_selected()
@@ -808,7 +829,8 @@ class AlbumArtWindow(qltk.Window, PluginConfigMixin):
                 search.add_engine(eng['class'], eng['replace'])
 
         raw = self.search_radioraw.get_active()
-        search.start(text, raw)
+        limit = self.search_spinresultsmax.get_value_as_int()
+        search.start(text, raw, limit)
 
         # Focus the list
         self.treeview.grab_focus()
@@ -890,13 +912,13 @@ class CoverSearch(object):
 
         self._stop = True
 
-    def start(self, query, raw):
+    def start(self, query, raw, limit):
         """Start search. The callback function will be called after each of
         the search engines has finished."""
 
         for engine, replace in self.engine_list:
             thr = threading.Thread(target=self.__search_thread,
-                                   args=(engine, query, replace, raw))
+                                   args=(engine, query, replace, raw, limit))
             thr.setDaemon(True)
             thr.start()
 
@@ -904,7 +926,7 @@ class CoverSearch(object):
         if not len(self.engine_list):
             GLib.idle_add(self.callback, [], 1)
 
-    def __search_thread(self, engine, query, replace, raw):
+    def __search_thread(self, engine, query, replace, raw, limit):
         """Creates searching threads which call the callback function after
         they are finished"""
 
@@ -914,7 +936,7 @@ class CoverSearch(object):
                 (search, engine.__name__))
         result = []
         try:
-            result = engine().start(search)
+            result = engine().start(search, limit)
         except Exception:
             print_w("[AlbumArt] %s: %r" % (engine.__name__, query))
             print_exc()

--- a/quodlibet/quodlibet/plugins/__init__.py
+++ b/quodlibet/quodlibet/plugins/__init__.py
@@ -494,6 +494,12 @@ class PluginConfigMixin(object):
         return config.getboolean(PM.CONFIG_SECTION, cls._config_key(name),
                                  default)
 
+    @classmethod
+    def config_get_stringlist(cls, name, default=False):
+        """Gets a config string list for this plugin"""
+        return config.getstringlist(PM.CONFIG_SECTION, cls._config_key(name),
+                                 default)
+
     def config_entry_changed(self, entry, key):
         """React to a change in an gtk.Entry (by saving it to config)"""
         if entry.get_property('sensitive'):


### PR DESCRIPTION
Hi,

**Here I aim to improve the Album Art Downloading experience**

This is achieved (certainly it is/was for me ..but hopefully this will affect others usage positively too) via this patch set which i split into two parts. Please read the notes having looked at the pictures for context in each instance.

**1. Custom filename for output**
-commit: allow configurable custom files names for downloaded art

image: [pre custom filename](http://picpaste.com/9781e0a66574e7f404efed35cd33ca59.png)
image: [post custom filename](http://picpaste.com/6cba6319ae0e5327188cfebc80b2efb2.png)
_**note:**_ the main quodlibet prefs now allows the playbar's cover image to be selected based on a custom filename ..great ..but somewhat useless to me if i name all my 'covers' 'front', and yet i cannot download via the downloader to that chosen name, for me 'front.jpg'.

So to be clear.. **with** the changes, I **can** set custom filenames for the download target, **without**, I **cannot**. That is why I wish this to be included in quodlibet.

**2. Search string clarity and custom search sizes**
-commit: expose album art downloader's blackbox
-commit: expose album art downloader query results limit 

image: [search changes](http://picpaste.com/432f981dbcb4393ecab2bace0c1a4588.png)
_**note:**_ the changes are in red. clearly, we would now have the ability to switch between 'raw' input search string, and the 'clean' (..ed via blackbox) string as per the original, pre-commit setup

image: [original search example](http://picpaste.com/65e0b228818c55590d1e97cabae05765.png)
_**note:**_ here is the original search results for a 'American Pie: The Wedding' search.
_**note2:**_ do try to ignore the **correct** top match in this pic as at the time I did this work the quodlibet Amazon service was down, do you (Lazka) remember the poke from declension about this last month? ..that was me poking declension ..and that's where this all started! thus ONLY Discogs results were returned, they were terrible/useless and limited in number and I wanted to know why!

image: [new 'raw' search](http://picpaste.com/0626e1259519f0eea57237cd69bf1b23.png)
_**note:**_ the original 'blackbox' / 'cleaned' search is below this 'raw' search. it is now totally obvious as to why the original search failed ..the cleaning routine for the search (the blackbox) was overzelous. now we recover better matches from Discogs, and more of them if we want!

So to be clear.. **with** the changes, I **can** get the search results I want from both cover providers, **without**, I **cannot**. That is why I wish this to be included in quodlibet. Given quodlibet is (IMO) pitched at a slightly more advanced user, I don't think they'd baulk at exposure to this extra detail either.


**Further implementation notes:**
-Everywhere possible I've left defaults as they were and disabled the additional features.

**Configs**
-My current config mods, not required in any way, but as an example..

[plugins]
cover_filenames = front.jpg,back.jpg,cd.jpg,\<artist\>.jpg
cover_resultsmax = 10
cover_searchraw = False
