### PR TITLE
tests: flake8 support

### DIFF
--- a/quodlibet/MANIFEST.in
+++ b/quodlibet/MANIFEST.in
@@ -21,6 +21,7 @@ include data/README.rst
 include MANIFEST.in
 include quodlibet/packages/README.rst
 include *.py
+include setup.cfg
 recursive-include docs *.py Makefile *.rst *.png *.ico *.svg *.css
 prune docs/_build_guide
 prune docs/_build_all

--- a/quodlibet/setup.cfg
+++ b/quodlibet/setup.cfg
@@ -1,0 +1,4 @@
+[flake8]
+ignore=E12,E261,E265,E713,W602,E402,E731,W503,E741,E305,W601,E722
+builtins=unicode,xrange,long,unichr,cmp,reload,execfile
+exclude=build,dist,quodlibet/optpackages,quodlibet/packages

--- a/quodlibet/tests/quality/test_pep8.py
+++ b/quodlibet/tests/quality/test_pep8.py
@@ -16,7 +16,7 @@ from quodlibet.util import is_wine
 from tests import TestCase
 from tests.helper import capture_output
 
-from .util import iter_project_py_files
+from .util import iter_project_py_files, setup_cfg
 
 try:
     import pep8 as pycodestyle
@@ -52,13 +52,10 @@ def check_files(files, ignore=[]):
 
 @pytest.mark.quality
 class TPEP8(TestCase):
-    IGNORE = ["E12", "E261", "E265", "E713", "W602", "E402", "E731",
-              "W503", "E741", "E305", "W601", "E722"]
-
     def test_all(self):
         assert pycodestyle is not None, "pep8/pycodestyle is missing"
 
         files = iter_project_py_files()
-        errors = check_files(files, ignore=self.IGNORE)
+        errors = check_files(files, ignore=setup_cfg.ignore)
         if errors:
             raise Exception("\n".join(errors))

--- a/quodlibet/tests/quality/test_pyflakes.py
+++ b/quodlibet/tests/quality/test_pyflakes.py
@@ -12,9 +12,10 @@ from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor
 import pytest
 
 from quodlibet.util import is_wine
+from .util import iter_project_py_files, setup_cfg
 
 os.environ["PYFLAKES_NODOCTEST"] = "1"
-os.environ["PYFLAKES_BUILTINS"] = "execfile,reload"
+os.environ["PYFLAKES_BUILTINS"] = ",".join(setup_cfg.builtins)
 
 try:
     from pyflakes.scripts import pyflakes
@@ -23,8 +24,6 @@ except ImportError:
 
 from tests import TestCase
 from tests.helper import capture_output
-
-from .util import iter_project_py_files
 
 
 def create_pool():


### PR DESCRIPTION
flake8 reads its config from the setup.cfg file in the root dir.
To not duplicate the config parse that file in our pep/pyflakes tests.

While flake8 is slower than our tests it's nice to test single files or
directories with it. Also maybe some IDE might parse the config..?