### PR TITLE
Acoustic fingerprint plugin fixes

### DIFF
--- a/quodlibet/quodlibet/ext/songsmenu/fingerprint/acoustid.py
+++ b/quodlibet/quodlibet/ext/songsmenu/fingerprint/acoustid.py
@@ -104,6 +104,7 @@ class AcoustidSubmissionThread(threading.Thread):
                 "bitrate": song("~#bitrate"),
                 "fileformat": song("~format"),
                 "mbid": song("musicbrainz_trackid"),
+                "track": song("title"),
                 "artist": song.list("artist"),
                 "album": song("album"),
                 "albumartist": song("albumartist"),

--- a/quodlibet/quodlibet/ext/songsmenu/fingerprint/acoustid.py
+++ b/quodlibet/quodlibet/ext/songsmenu/fingerprint/acoustid.py
@@ -59,9 +59,9 @@ class AcoustidSubmissionThread(threading.Thread):
             "user": get_api_key(),
         })
 
-        urldata = "&".join([basedata] + map(urlencode, urldata))
+        urldata = "&".join([basedata] + list(map(urlencode, urldata)))
         obj = cBytesIO()
-        gzip.GzipFile(fileobj=obj, mode="wb").write(urldata)
+        gzip.GzipFile(fileobj=obj, mode="wb").write(urldata.encode())
         urldata = obj.getvalue()
 
         headers = {
@@ -299,7 +299,7 @@ class AcoustidLookupThread(threading.Thread):
 
         urldata = "&".join(req_data)
         obj = cBytesIO()
-        gzip.GzipFile(fileobj=obj, mode="wb").write(urldata)
+        gzip.GzipFile(fileobj=obj, mode="wb").write(urldata.encode())
         urldata = obj.getvalue()
 
         headers = {
@@ -317,7 +317,7 @@ class AcoustidLookupThread(threading.Thread):
         else:
             try:
                 data = response.read()
-                data = json.loads(data)
+                data = json.loads(data.decode())
             except ValueError as e:
                 error = str(e)
             else:

--- a/quodlibet/quodlibet/ext/songsmenu/fingerprint/submit.py
+++ b/quodlibet/quodlibet/ext/songsmenu/fingerprint/submit.py
@@ -90,8 +90,8 @@ class FingerprintDialog(Window):
         submit.connect('clicked', self.__submit_cb)
         cancel = Button(_("_Cancel"))
         connect_obj(cancel, 'clicked', self.__cancel_cb, pool)
-        bbox.pack_start(submit, True, True, 0)
         bbox.pack_start(cancel, True, True, 0)
+        bbox.pack_start(submit, True, True, 0)
 
         outer_box.pack_start(box, True, True, 0)
         outer_box.pack_start(bbox, False, True, 0)

--- a/quodlibet/quodlibet/ext/songsmenu/fingerprint/submit.py
+++ b/quodlibet/quodlibet/ext/songsmenu/fingerprint/submit.py
@@ -39,7 +39,7 @@ class FingerprintDialog(Window):
         super(FingerprintDialog, self).__init__()
         self.set_border_width(12)
         self.set_title(_("Submit Acoustic Fingerprints"))
-        self.set_default_size(300, 0)
+        self.set_default_size(450, 0)
 
         outer_box = Gtk.VBox(spacing=12)
 
@@ -60,7 +60,10 @@ class FingerprintDialog(Window):
 
         self.__stats = stats = Gtk.Label()
         stats.set_alignment(0, 0.5)
+        stats.set_line_wrap(True)
+        stats.set_size_request(426, -1)
         expand = Gtk.Expander.new_with_mnemonic(_("_Details"))
+        expand.set_resize_toplevel(True)
         expand.add(stats)
 
         def expand_cb(expand, *args):


### PR DESCRIPTION
Here are several fixes to the acoustic fingerprint plugins:

1. Acoustic fingerprint submissions were missing the track title. The first commits also adds the track title to these. I don’t know if it was left out intentionally; but the web service accepts the track title as `track` (see https://acoustid.org/webservice).
2. Fingerprint lookup and submission were not working with Python 3. The second commit fixes both.
3. In the fingerprint submit dialog, opening the expander made the dialog very wide, and closing it did retain the large size. The third commit tries to smooth that behavior by making the expander affect the dialog size and making the contained label wrap.
4. The button order in the dialog was inconsistent with most other dialogs (affirmative action normally on the right side).