### PR TITLE
Add sidebar plugins (#152)

### DIFF
--- a/quodlibet/quodlibet/ext/events/viewlyrics.py
+++ b/quodlibet/quodlibet/ext/events/viewlyrics.py
@@ -50,7 +50,7 @@ class ViewLyrics(EventPlugin, UserInterfacePlugin):
         # starts playing (see plugin_on_song_started).
 
     def create_sidebar(self):
-        vbox = Gtk.VBox()
+        vbox = Gtk.VBox(margin=6)
         vbox.pack_start(self.scrolled_window, True, True, 0)
         vbox.show_all()
         return vbox

--- a/quodlibet/quodlibet/ext/events/viewlyrics.py
+++ b/quodlibet/quodlibet/ext/events/viewlyrics.py
@@ -13,7 +13,7 @@ from gi.repository import Gtk, Gdk
 from quodlibet import _, print_d, app
 from quodlibet.plugins.events import EventPlugin
 from quodlibet.plugins.gui import UserInterfacePlugin
-from quodlibet.qltk import Icons
+from quodlibet.qltk import Icons, add_css
 
 
 class ViewLyrics(EventPlugin, UserInterfacePlugin):
@@ -40,7 +40,8 @@ class ViewLyrics(EventPlugin, UserInterfacePlugin):
         self.textview.set_wrap_mode(Gtk.WrapMode.WORD)
         self.textview.set_justification(Gtk.Justification.CENTER)
         self.textview.connect('key-press-event', self.key_press_event_cb)
-        self.scrolled_window.add_with_viewport(self.textview)
+        add_css(self.textview, "* { padding: 6px; }")
+        self.scrolled_window.add(self.textview)
         self.textview.show()
 
         self.scrolled_window.show()
@@ -50,7 +51,7 @@ class ViewLyrics(EventPlugin, UserInterfacePlugin):
         # starts playing (see plugin_on_song_started).
 
     def create_sidebar(self):
-        vbox = Gtk.VBox(margin=6)
+        vbox = Gtk.VBox(margin=0)
         vbox.pack_start(self.scrolled_window, True, True, 0)
         vbox.show_all()
         return vbox

--- a/quodlibet/quodlibet/ext/events/viewlyrics.py
+++ b/quodlibet/quodlibet/ext/events/viewlyrics.py
@@ -2,7 +2,7 @@
 #
 # View Lyrics: a Quod Libet plugin for viewing lyrics.
 # Copyright (C) 2008, 2011, 2012 Vasiliy Faronov <vfaronov@gmail.com>
-#                     2013, 2016 Nick Boultbee
+#                        2013-17 Nick Boultbee
 #
 # This program is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2
@@ -10,33 +10,31 @@
 
 from gi.repository import Gtk, Gdk
 
-from quodlibet import _
-from quodlibet import app
+from quodlibet import _, print_d, app
 from quodlibet.plugins.events import EventPlugin
+from quodlibet.plugins.gui import UserInterfacePlugin
 from quodlibet.qltk import Icons
 
 
-class ViewLyrics(EventPlugin):
+class ViewLyrics(EventPlugin, UserInterfacePlugin):
     """The plugin for viewing lyrics in the main window."""
 
     PLUGIN_ID = 'View Lyrics'
     PLUGIN_NAME = _('View Lyrics')
-    PLUGIN_DESC = _('Automatically displays lyrics '
-                    'beneath the song list in the main window.')
+    PLUGIN_DESC = _('Automatically displays tag or file-based lyrics '
+                    'in a sidebar.')
     PLUGIN_ICON = Icons.FORMAT_JUSTIFY_FILL
 
     def enabled(self):
-        self.expander = Gtk.Expander(label=_("_Lyrics"), use_underline=True)
-        self.expander.set_expanded(True)
-
         self.scrolled_window = Gtk.ScrolledWindow()
         self.scrolled_window.set_policy(Gtk.PolicyType.AUTOMATIC,
                                         Gtk.PolicyType.AUTOMATIC)
-        self.scrolled_window.set_size_request(-1, 200)
         self.adjustment = self.scrolled_window.get_vadjustment()
 
         self.textview = Gtk.TextView()
         self.textbuffer = self.textview.get_buffer()
+        self._italics = self.textbuffer.create_tag("italic", style="italic",
+                                                   foreground="grey")
         self.textview.set_editable(False)
         self.textview.set_cursor_visible(False)
         self.textview.set_wrap_mode(Gtk.WrapMode.WORD)
@@ -45,18 +43,21 @@ class ViewLyrics(EventPlugin):
         self.scrolled_window.add_with_viewport(self.textview)
         self.textview.show()
 
-        self.expander.add(self.scrolled_window)
         self.scrolled_window.show()
-
-        app.window.get_child().pack_start(self.expander, False, True, 0)
+        self.plugin_on_song_started(app.player.info)
 
         # We don't show the expander here because it will be shown when a song
         # starts playing (see plugin_on_song_started).
 
+    def create_sidebar(self):
+        vbox = Gtk.VBox()
+        vbox.pack_start(self.scrolled_window, True, True, 0)
+        vbox.show_all()
+        return vbox
+
     def disabled(self):
         self.textview.destroy()
         self.scrolled_window.destroy()
-        self.expander.destroy()
 
     def plugin_on_song_started(self, song):
         """Called when a song is started. Loads the lyrics.
@@ -66,14 +67,19 @@ class ViewLyrics(EventPlugin):
         """
         lyrics = None
         if song is not None:
+            print_d("Attempting to load lyrics for %s" % song("~filename"))
             lyrics = song("~lyrics")
             if lyrics:
                 self.textbuffer.set_text(lyrics)
                 self.adjustment.set_value(0)    # Scroll to the top.
-                self.expander.show()
-
-        if not lyrics:
-            self.expander.hide()
+                self.textview.show()
+            else:
+                title = _("No lyrics found for\n %s") % song("~basename")
+                self.textbuffer.set_text(title)
+                start = self.textbuffer.get_start_iter()
+                end = self.textbuffer.get_end_iter()
+                self.textbuffer.remove_all_tags(start, end)
+                self.textbuffer.apply_tag(self._italics, start, end)
 
     def key_press_event_cb(self, widget, event):
         """Handles up/down "key-press-event" in the lyrics view."""

--- a/quodlibet/quodlibet/ext/songsmenu/console.py
+++ b/quodlibet/quodlibet/ext/songsmenu/console.py
@@ -30,7 +30,7 @@ from quodlibet import _, app, ngettext
 from quodlibet import const
 from quodlibet.plugins.events import EventPlugin
 from quodlibet.plugins.gui import UserInterfacePlugin
-from quodlibet.qltk import Icons
+from quodlibet.qltk import Icons, add_css, Align
 from quodlibet.compat import exec_, PY2
 from quodlibet.plugins.songsmenu import SongsMenuPlugin
 from quodlibet.util.collection import Collection
@@ -66,12 +66,10 @@ class PyConsoleSidebar(EventPlugin, UserInterfacePlugin):
         self.console.namespace = namespace_for(songs)
 
     def create_sidebar(self):
-        frame = Gtk.Frame()
-        frame.show_all()
-        self.sidebar = frame
-        self.sidebar.add(self.console)
+        align = Align(self.console)
+        self.sidebar = align
         self.sidebar.show_all()
-        return frame
+        return align
 
 
 def create_console(songs=None):
@@ -128,8 +126,9 @@ class PythonConsole(Gtk.ScrolledWindow):
 
         self.destroy_cb = destroy_cb
         self.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
-        self.set_shadow_type(Gtk.ShadowType.IN)
+        self.set_shadow_type(Gtk.ShadowType.NONE)
         self.view = Gtk.TextView()
+        add_css(self, "* { background-color: white; padding: 6px; } ")
         self.view.modify_font(Pango.font_description_from_string('Monospace'))
         self.view.set_editable(True)
         self.view.set_wrap_mode(Gtk.WrapMode.CHAR)

--- a/quodlibet/quodlibet/formats/_audio.py
+++ b/quodlibet/quodlibet/formats/_audio.py
@@ -16,7 +16,7 @@ import time
 
 from senf import fsn2uri, fsnative, fsn2text, devnull, bytes2fsn, path2fsn
 
-from quodlibet import _
+from quodlibet import _, print_d
 from quodlibet import util
 from quodlibet import config
 from quodlibet.util.path import mkdir, mtime, expanduser, \
@@ -446,11 +446,13 @@ class AudioFile(dict, ImageContainer):
 
                 # If there are no embedded lyrics, try to read them from
                 # the external file.
+                fn = self.lyric_filename
                 try:
-                    fileobj = open(self.lyric_filename, "rUb")
+                    fileobj = open(fn, "rUb")
                 except EnvironmentError:
                     return default
                 else:
+                    print_d("Reading lyrics from %s" % fn)
                     return fileobj.read().decode("utf-8", "replace")
             elif key == "filesize":
                 return util.format_size(self("~#filesize", 0))

--- a/quodlibet/quodlibet/main.py
+++ b/quodlibet/quodlibet/main.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Copyright 2004-2005 Joe Wreschnig, Michael Urman, Iñigo Serna
 #           2012,2013 Christoph Reiter
-#           2010-2014 Nick Boultbee
+#           2010-2017 Nick Boultbee
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as
@@ -139,7 +139,10 @@ def main(argv=None):
     from quodlibet.qltk.window import Window
 
     from quodlibet.plugins.events import EventPluginHandler
-    pm.register_handler(EventPluginHandler(library.librarian, player))
+    from quodlibet.plugins.gui import UserInterfacePluginHandler
+    pm.register_handler(EventPluginHandler(library.librarian, player,
+                                           app.window.songlist))
+    pm.register_handler(UserInterfacePluginHandler())
 
     from quodlibet.mmkeys import MMKeysHandler
     from quodlibet.remote import Remote, RemoteError

--- a/quodlibet/quodlibet/plugins/gui.py
+++ b/quodlibet/quodlibet/plugins/gui.py
@@ -42,6 +42,7 @@ class UserInterfacePluginHandler(PluginHandler):
     def plugin_enable(self, plugin):
         self.__plugins[plugin.cls] = pl_obj = plugin.get_instance()
         sidebar = pl_obj.create_sidebar()
+        app.window.hide_side_book()
         if sidebar:
             print_d("Enabling sidebar for %s" % plugin.cls)
             self.__sidebars[plugin] = app.window.add_sidebar(

--- a/quodlibet/quodlibet/plugins/gui.py
+++ b/quodlibet/quodlibet/plugins/gui.py
@@ -6,10 +6,54 @@
 # it under the terms of the GNU General Public License version 2 as
 # published by the Free Software Foundation
 
-from quodlibet import config
+from quodlibet import config, print_d, app
+from quodlibet.plugins import PluginHandler
 from quodlibet.qltk import get_menu_item_top_parent
 from quodlibet.qltk import Icons
 from gi.repository import Gtk
+
+
+class UserInterfacePlugin(object):
+    """Plugins that provide a (Gtk+ Widget)
+    to display as a side bar (currently) in the main Quod Libet Window.
+
+    These can be combined well with an EventPlugin to listen for
+    current song or selection changes.
+
+    TODO: generalise this better. See #152, #2273, #1991.
+    """
+
+    PLUGIN_INSTANCE = True
+
+    def create_sidebar(self):
+        """If defined, returns a Gtk.Box to populate the sidebar"""
+        pass
+
+
+class UserInterfacePluginHandler(PluginHandler):
+    def __init__(self):
+
+        self.__plugins = {}
+        self.__sidebars = {}
+
+    def plugin_handle(self, plugin):
+        return issubclass(plugin.cls, UserInterfacePlugin)
+
+    def plugin_enable(self, plugin):
+        self.__plugins[plugin.cls] = pl_obj = plugin.get_instance()
+        sidebar = pl_obj.create_sidebar()
+        if sidebar:
+            print_d("Enabling sidebar for %s" % plugin.cls)
+            self.__sidebars[plugin] = app.window.add_sidebar(
+                sidebar, name=plugin.name)
+            sidebar.show_all()
+
+    def plugin_disable(self, plugin):
+        widget = self.__sidebars.get(plugin)
+        if widget:
+            print_d("Removing sidebar %s" % widget)
+            app.window.remove_sidebar(widget)
+        self.__plugins.pop(plugin.cls)
 
 
 class MenuItemPlugin(Gtk.ImageMenuItem):

--- a/quodlibet/quodlibet/qltk/quodlibetwindow.py
+++ b/quodlibet/quodlibet/qltk/quodlibetwindow.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Copyright 2004-2005 Joe Wreschnig, Michael Urman, Iñigo Serna
 #           2012 Christoph Reiter
-#           2012-2016 Nick Boultbee
+#           2012-2017 Nick Boultbee
 #           2017 Uriel Zajaczkovski
 #
 # This program is free software; you can redistribute it and/or modify
@@ -23,6 +23,7 @@ from quodlibet import qltk
 from quodlibet import util
 from quodlibet import app
 from quodlibet import _
+from quodlibet.qltk.paned import ConfigRHPaned
 from quodlibet.compat import listfilter
 
 from quodlibet.qltk.appwindow import AppWindow
@@ -679,6 +680,8 @@ class QuodLibetWindow(Window, PersistentWindowMixin, AppWindow):
 
         main_box = Gtk.VBox()
         self.add(main_box)
+        self.side_book = qltk.Notebook()
+        self.side_book.set_size_request(400, -1)
 
         self.__player = player
         # create main menubar, load/restore accelerator groups
@@ -746,7 +749,11 @@ class QuodLibetWindow(Window, PersistentWindowMixin, AppWindow):
         self.top_bar = top_bar
 
         self.__browserbox = Align(bottom=3)
-        main_box.pack_start(self.__browserbox, True, True, 0)
+        paned = ConfigRHPaned("memory", "sidebar_pos", 0.25)
+        paned.pack2(self.side_book, shrink=True)
+        paned.pack1(self.__browserbox)
+
+        main_box.pack_start(paned, True, True, 0)
 
         play_order = PlayOrderWidget(self.songlist.model, player)
         statusbox = StatusBarBox(play_order, self.qexpander)
@@ -826,6 +833,20 @@ class QuodLibetWindow(Window, PersistentWindowMixin, AppWindow):
         self.connect("destroy", self.__destroy)
 
         self.enable_window_tracking("quodlibet")
+
+    def add_sidebar(self, box, name):
+        vbox = Gtk.Box(margin=6)
+        vbox.pack_start(box, True, True, 0)
+        vbox.show()
+        self.side_book.append_page(vbox, label=name)
+        self.side_book.set_tab_detachable(vbox, False)
+        self.side_book.show_all()
+        return vbox
+
+    def remove_sidebar(self, widget):
+        self.side_book.remove_page(self.side_book.page_num(widget))
+        if not self.side_book.get_children():
+            self.side_book.hide()
 
     def set_seekbar_widget(self, widget):
         """Add an alternative seek bar widget.

--- a/quodlibet/quodlibet/qltk/quodlibetwindow.py
+++ b/quodlibet/quodlibet/qltk/quodlibetwindow.py
@@ -52,7 +52,7 @@ from quodlibet.qltk.songmodel import PlaylistMux
 from quodlibet.qltk.x import RVPaned, Align, ScrolledWindow, Action
 from quodlibet.qltk.x import ToggleAction, RadioAction, HighlightToggleButton
 from quodlibet.qltk.x import SeparatorMenuItem, MenuItem, CellRendererPixbuf
-from quodlibet.qltk import Icons
+from quodlibet.qltk import Icons, add_css
 from quodlibet.qltk.about import AboutDialog
 from quodlibet.util import copool, connect_destroy, connect_after_destroy
 from quodlibet.util.library import get_scan_dirs
@@ -681,6 +681,7 @@ class QuodLibetWindow(Window, PersistentWindowMixin, AppWindow):
         main_box = Gtk.VBox()
         self.add(main_box)
         self.side_book = qltk.Notebook()
+        add_css(self.side_book, "notebook { background-color:white; }")
         self.side_book.set_size_request(400, -1)
 
         self.__player = player
@@ -749,9 +750,10 @@ class QuodLibetWindow(Window, PersistentWindowMixin, AppWindow):
         self.top_bar = top_bar
 
         self.__browserbox = Align(bottom=3)
-        paned = ConfigRHPaned("memory", "sidebar_pos", 0.25)
-        paned.pack2(self.side_book, shrink=True)
-        paned.pack1(self.__browserbox)
+        self.paned = paned = ConfigRHPaned("memory", "sidebar_pos", 0.25)
+        side_book_box = Align(self.side_book, top=6, bottom=3)
+        paned.pack2(side_book_box, shrink=True)
+        paned.pack1(self.__browserbox, resize=True)
 
         main_box.pack_start(paned, True, True, 0)
 
@@ -834,8 +836,11 @@ class QuodLibetWindow(Window, PersistentWindowMixin, AppWindow):
 
         self.enable_window_tracking("quodlibet")
 
+    def hide_side_book(self):
+        self.side_book.hide()
+
     def add_sidebar(self, box, name):
-        vbox = Gtk.Box(margin=6)
+        vbox = Gtk.Box(margin=0)
         vbox.pack_start(box, True, True, 0)
         vbox.show()
         self.side_book.append_page(vbox, label=name)

--- a/quodlibet/quodlibet/qltk/songlist.py
+++ b/quodlibet/quodlibet/qltk/songlist.py
@@ -42,7 +42,7 @@ class SongSelectionInfo(GObject.Object):
     Songs which get included in the status bar summary.
 
     The `changed` signal gets fired after any of the songs in the
-    selection or the selection it self has changed.
+    selection or the selection itself has changed.
     The signal is async.
 
     Two selection states:

--- a/quodlibet/tests/plugin/test_console.py
+++ b/quodlibet/tests/plugin/test_console.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Christoph Reiter
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+
+from gi.repository import Gtk
+
+from quodlibet.formats import AudioFile
+from quodlibet.util.songwrapper import SongWrapper
+from tests.plugin import PluginTestCase
+
+AUDIO_FILE = SongWrapper(AudioFile({'~filename': "/tmp/foobar"}))
+
+
+class TConsole(PluginTestCase):
+
+    def setUp(self):
+        self.mod = self.modules["Python Console Sidebar"]
+
+    def tearDown(self):
+        del self.mod
+
+    def test_sidebar_plugin(self):
+        plugin = self.mod.PyConsoleSidebar()
+        plugin.enabled()
+        self.failUnless(isinstance(plugin.create_sidebar(), Gtk.Widget), True)
+        plugin.plugin_on_songs_selected([AUDIO_FILE])
+        self.failUnlessEqual(plugin.console.namespace.get('songs'),
+                             [AUDIO_FILE])
+        plugin.disabled()


### PR DESCRIPTION
 * Add a new type of plugin, `UserInterfacePlugin` complete with single handler (TODO: more generic way)
 * Add an event to `EventPlugin` for listening to main songlist selection changes. Couldn't reuse the `StatusBar` stuff as that has custom logic around single selections
 * Wire this into the app, and have `enabled` / `disabled` add/remove pages from the notebook (TODO: detachable?)
 * Update Python Console plugin: extract common code from UI and introduce new sidebar event plugin version, that updates itself based on the select songs
 * Convert View Lyrics plugin to a sidebar plugin (i.e. change its layout slightly)
 * Add some basic tests