### PR TITLE
Query refactoring (#2546)

### DIFF
--- a/quodlibet/quodlibet/browsers/albums/main.py
+++ b/quodlibet/quodlibet/browsers/albums/main.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Copyright 2004-2007 Joe Wreschnig, Michael Urman, Iñigo Serna
 #           2009-2010 Steven Robertson
-#      2012,2013,2016 Nick Boultbee
+#           2012-2017 Nick Boultbee
 #           2009-2014 Christoph Reiter
 #
 # This program is free software; you can redistribute it and/or modify
@@ -357,6 +357,7 @@ class AlbumList(Browser, util.InstanceTracker, VisibleUpdate,
 
     _PATTERN_FN = os.path.join(quodlibet.get_user_dir(), "album_pattern")
     _DEFAULT_PATTERN_TEXT = DEFAULT_PATTERN_TEXT
+    STAR = ["~people", "album"]
 
     name = _("Album List")
     accelerated_name = _("_Album List")
@@ -507,7 +508,8 @@ class AlbumList(Browser, util.InstanceTracker, VisibleUpdate,
 
         self.accelerators = Gtk.AccelGroup()
         search = SearchBarBox(completion=AlbumTagCompletion(),
-                              accel_group=self.accelerators)
+                              accel_group=self.accelerators,
+                              star=self.STAR)
         search.connect('query-changed', self.__update_filter)
         connect_obj(search, 'focus-out', lambda w: w.grab_focus(), view)
         self.__search = search
@@ -589,7 +591,7 @@ class AlbumList(Browser, util.InstanceTracker, VisibleUpdate,
         model = self.view.get_model()
 
         self.__filter = None
-        query = Query(text, star=["~people", "album"])
+        query = self.__search.query
         if not query.matches_all:
             self.__filter = query.search
         self.__bg_filter = background_filter()

--- a/quodlibet/quodlibet/browsers/albums/main.py
+++ b/quodlibet/quodlibet/browsers/albums/main.py
@@ -589,8 +589,9 @@ class AlbumList(Browser, util.InstanceTracker, VisibleUpdate,
         model = self.view.get_model()
 
         self.__filter = None
-        if not Query.match_all(text):
-            self.__filter = Query(text, star=["~people", "album"]).search
+        query = Query(text, star=["~people", "album"])
+        if not query.matches_all:
+            self.__filter = query.search
         self.__bg_filter = background_filter()
 
         self.__inhibit()
@@ -712,7 +713,7 @@ class AlbumList(Browser, util.InstanceTracker, VisibleUpdate,
 
     def filter_text(self, text):
         self.__search.set_text(text)
-        if Query.is_parsable(text):
+        if Query(text).is_parsable:
             self.__update_filter(self.__search, text)
             self.__inhibit()
             self.view.set_cursor((0,))
@@ -764,7 +765,7 @@ class AlbumList(Browser, util.InstanceTracker, VisibleUpdate,
         entry.set_text(text)
 
         # update_filter expects a parsable query
-        if Query.is_parsable(text):
+        if Query(text).is_parsable:
             self.__update_filter(entry, text, scroll_up=False, restore=True)
 
         keys = config.gettext("browsers", "albums").split("\n")

--- a/quodlibet/quodlibet/browsers/collection/main.py
+++ b/quodlibet/quodlibet/browsers/collection/main.py
@@ -282,9 +282,10 @@ class CollectionBrowser(Browser, util.InstanceTracker):
 
     def __update_filter(self, entry, text):
         self.__filter = None
-        if not Query.match_all(text):
-            tags = self.__model.tags + ["album"]
-            self.__filter = Query(text, star=tags).search
+        tags = self.__model.tags + ["album"]
+        query = Query(text, star=tags)
+        if not query.matches_all:
+            self.__filter = query.search
         self.__bg_filter = background_filter()
 
         self.view.get_model().refilter()
@@ -349,7 +350,7 @@ class CollectionBrowser(Browser, util.InstanceTracker):
 
     def filter_text(self, text):
         self.__search.set_text(text)
-        if Query.is_parsable(text):
+        if Query(text).is_parsable:
             self.__update_filter(self.__search, text)
             self.activate()
 

--- a/quodlibet/quodlibet/browsers/collection/main.py
+++ b/quodlibet/quodlibet/browsers/collection/main.py
@@ -223,8 +223,10 @@ class CollectionBrowser(Browser, util.InstanceTracker):
         prefs.connect('clicked', lambda *x: Preferences(self))
 
         self.accelerators = Gtk.AccelGroup()
+        tags = self.__model.tags + ["album"]
         search = SearchBarBox(completion=AlbumTagCompletion(),
-                              accel_group=self.accelerators)
+                              accel_group=self.accelerators,
+                              star=tags)
         search.connect('query-changed', self.__update_filter)
         connect_obj(search, 'focus-out', lambda w: w.grab_focus(), view)
         self.__search = search
@@ -282,8 +284,7 @@ class CollectionBrowser(Browser, util.InstanceTracker):
 
     def __update_filter(self, entry, text):
         self.__filter = None
-        tags = self.__model.tags + ["album"]
-        query = Query(text, star=tags)
+        query = self.__search.query
         if not query.matches_all:
             self.__filter = query.search
         self.__bg_filter = background_filter()

--- a/quodlibet/quodlibet/browsers/covergrid/main.py
+++ b/quodlibet/quodlibet/browsers/covergrid/main.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Copyright 2004-2007 Joe Wreschnig, Michael Urman, Iñigo Serna
 #           2009-2010 Steven Robertson
-#      2012,2013,2016 Nick Boultbee
+#           2012-2017 Nick Boultbee
 #           2009-2014 Christoph Reiter
 #
 # This program is free software; you can redistribute it and/or modify
@@ -399,8 +399,9 @@ class CoverGrid(Browser, util.InstanceTracker, VisibleUpdate,
         model = self.view.get_model()
 
         self.__filter = None
-        if not Query.match_all(text):
-            self.__filter = Query(text, star=["~people", "album"]).search
+        query = Query(text, star=["~people", "album"])
+        if not query.matches_all:
+            self.__filter = query.search
         self.__bg_filter = background_filter()
 
         self.__inhibit()
@@ -550,7 +551,7 @@ class CoverGrid(Browser, util.InstanceTracker, VisibleUpdate,
 
     def filter_text(self, text):
         self.__search.set_text(text)
-        if Query.is_parsable(text):
+        if Query(text).is_parsable:
             self.__update_filter(self.__search, text)
             # self.__inhibit()
             #self.view.set_cursor((0,), None, False)
@@ -623,7 +624,7 @@ class CoverGrid(Browser, util.InstanceTracker, VisibleUpdate,
         entry.set_text(text)
 
         # update_filter expects a parsable query
-        if Query.is_parsable(text):
+        if Query(text).is_parsable:
             self.__update_filter(entry, text, scroll_up=False, restore=True)
 
         keys = config.gettext("browsers", "covergrid", "").split("\n")

--- a/quodlibet/quodlibet/browsers/covergrid/main.py
+++ b/quodlibet/quodlibet/browsers/covergrid/main.py
@@ -121,6 +121,7 @@ class CoverGrid(Browser, util.InstanceTracker, VisibleUpdate,
 
     _PATTERN_FN = os.path.join(quodlibet.get_user_dir(), "album_pattern")
     _DEFAULT_PATTERN_TEXT = DEFAULT_PATTERN_TEXT
+    STAR = ["~people", "album"]
 
     name = _("Cover Grid")
     accelerated_name = _("_Cover Grid")
@@ -314,7 +315,8 @@ class CoverGrid(Browser, util.InstanceTracker, VisibleUpdate,
 
         self.accelerators = Gtk.AccelGroup()
         search = SearchBarBox(completion=AlbumTagCompletion(),
-                              accel_group=self.accelerators)
+                              accel_group=self.accelerators,
+                              star=self.STAR)
         search.connect('query-changed', self.__update_filter)
         connect_obj(search, 'focus-out', lambda w: w.grab_focus(), view)
         self.__search = search
@@ -399,7 +401,7 @@ class CoverGrid(Browser, util.InstanceTracker, VisibleUpdate,
         model = self.view.get_model()
 
         self.__filter = None
-        query = Query(text, star=["~people", "album"])
+        query = self.__search.query
         if not query.matches_all:
             self.__filter = query.search
         self.__bg_filter = background_filter()

--- a/quodlibet/quodlibet/browsers/iradio.py
+++ b/quodlibet/quodlibet/browsers/iradio.py
@@ -847,7 +847,7 @@ class InternetRadio(Browser, util.InstanceTracker):
     def restore(self):
         text = config.gettext("browsers", "query_text")
         self.__searchbar.set_text(text)
-        if Query.is_parsable(text):
+        if Query(text).is_parsable:
             self.__filter_changed(self.__searchbar, text, restore=True)
 
         keys = config.get("browsers", "radio").splitlines()
@@ -880,7 +880,7 @@ class InternetRadio(Browser, util.InstanceTracker):
 
     def filter_text(self, text):
         self.__searchbar.set_text(text)
-        if Query.is_parsable(text):
+        if Query(text).is_parsable:
             self.__filter_changed(self.__searchbar, text)
             self.activate()
 

--- a/quodlibet/quodlibet/browsers/iradio.py
+++ b/quodlibet/quodlibet/browsers/iradio.py
@@ -536,7 +536,8 @@ class InternetRadio(Browser, util.InstanceTracker):
         completion = LibraryTagCompletion(self.__stations)
         self.accelerators = Gtk.AccelGroup()
         self.__searchbar = search = SearchBarBox(completion=completion,
-                                                 accel_group=self.accelerators)
+                                                 accel_group=self.accelerators,
+                                                 star=self.STAR)
         search.connect('query-changed', self.__filter_changed)
 
         menu = Gtk.Menu()

--- a/quodlibet/quodlibet/browsers/paned/main.py
+++ b/quodlibet/quodlibet/browsers/paned/main.py
@@ -2,7 +2,7 @@
 # Copyright 2004-2008 Joe Wreschnig, Michael Urman, Iñigo Serna
 #           2009,2010 Steven Robertson
 #           2009-2013 Christoph Reiter
-#           2011,2013 Nick Boultbee
+#           2011-2017 Nick Boultbee
 #                2017 Fredrik Strupe
 #
 # This program is free software; you can redistribute it and/or modify
@@ -182,6 +182,7 @@ class PanedBrowser(Browser, util.InstanceTracker):
     def activate(self):
         star = dict.fromkeys(SongList.star)
         star.update(self.__star)
+        # TODO: get query from SearchBarBox (but with dynamic star)
         query = Query(self._get_text(), star.keys())
         if query.is_parsable:
             self._filter = query.search

--- a/quodlibet/quodlibet/browsers/paned/main.py
+++ b/quodlibet/quodlibet/browsers/paned/main.py
@@ -180,11 +180,11 @@ class PanedBrowser(Browser, util.InstanceTracker):
         return True
 
     def activate(self):
-        text = self._get_text()
-        if Query.is_parsable(text):
-            star = dict.fromkeys(SongList.star)
-            star.update(self.__star)
-            self._filter = Query(text, star.keys()).search
+        star = dict.fromkeys(SongList.star)
+        star.update(self.__star)
+        query = Query(self._get_text(), star.keys())
+        if query.is_parsable:
+            self._filter = query.search
             songs = filter(self._filter, self._library)
             bg = background_filter()
             if bg:

--- a/quodlibet/quodlibet/browsers/playlists/main.py
+++ b/quodlibet/quodlibet/browsers/playlists/main.py
@@ -487,8 +487,9 @@ class PlaylistsBrowser(Browser, DisplayPatternMixin):
 
         text = self.get_filter_text()
         # TODO: remove static dependency on Query
-        if Query.is_parsable(text):
-            self._query = Query(text, SongList.star)
+        query = Query(text, SongList.star)
+        if query.is_parsable:
+            self._query = query
             songs = self._query.filter(songs)
         GLib.idle_add(self.songs_selected, songs, resort)
 

--- a/quodlibet/quodlibet/browsers/playlists/main.py
+++ b/quodlibet/quodlibet/browsers/playlists/main.py
@@ -31,7 +31,6 @@ from quodlibet.qltk.views import RCMHintedTreeView
 from quodlibet.qltk.x import ScrolledWindow, Align, MenuItem, SymbolicIconImage
 from quodlibet.qltk import Icons
 from quodlibet.qltk.chooser import choose_files, create_chooser_filter
-from quodlibet.query import Query
 from quodlibet.util import connect_obj
 from quodlibet.util.dprint import print_d, print_w
 from quodlibet.util.collection import FileBackedPlaylist
@@ -180,10 +179,13 @@ class PlaylistsBrowser(Browser, DisplayPatternMixin):
         self._sb_box = self.__create_searchbar(library)
         self._main_box = self.__create_box()
         self.show_all()
-        self._query = None
 
         for child in self.get_children():
             child.show_all()
+
+    @property
+    def _query(self):
+        return self._sb_box.query
 
     def __destroy(self, *args):
         del self._sb_box
@@ -197,7 +199,7 @@ class PlaylistsBrowser(Browser, DisplayPatternMixin):
         self.accelerators = Gtk.AccelGroup()
         completion = LibraryTagCompletion(library.librarian)
         sbb = SearchBarBox(completion=completion,
-                           accel_group=self.accelerators)
+                           accel_group=self.accelerators, star=SongList.star)
         sbb.connect('query-changed', self.__text_parse)
         sbb.connect('focus-out', self.__focus)
         return sbb
@@ -484,13 +486,9 @@ class PlaylistsBrowser(Browser, DisplayPatternMixin):
 
     def activate(self, widget=None, resort=True):
         songs = self._get_playlist_songs()
-
-        text = self.get_filter_text()
-        # TODO: remove static dependency on Query
-        query = Query(text, SongList.star)
-        if query.is_parsable:
-            self._query = query
-            songs = self._query.filter(songs)
+        query = self._sb_box.query
+        if query and query.is_parsable:
+            songs = query.filter(songs)
         GLib.idle_add(self.songs_selected, songs, resort)
 
     @classmethod

--- a/quodlibet/quodlibet/browsers/search.py
+++ b/quodlibet/quodlibet/browsers/search.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2004-2016 Joe Wreschnig, Michael Urman, Iñigo Serna,
+# Copyright 2004-2017 Joe Wreschnig, Michael Urman, Iñigo Serna,
 #                     Christoph Reiter, Steven Robertson, Nick Boultbee
 #
 # This program is free software; you can redistribute it and/or modify
@@ -13,11 +13,9 @@ from quodlibet import config
 from quodlibet import qltk
 from quodlibet import _
 from quodlibet.browsers import Browser
-from quodlibet.query import Query
 from quodlibet.qltk.ccb import ConfigCheckMenuItem
 from quodlibet.qltk.completion import LibraryTagCompletion
 from quodlibet.qltk.menubutton import MenuButton
-from quodlibet.qltk.songlist import SongList
 from quodlibet.qltk.searchbar import LimitSearchBarBox
 from quodlibet.qltk.x import Align, SymbolicIconImage
 from quodlibet.qltk import Icons
@@ -101,13 +99,8 @@ class SearchBar(Browser):
         qltk.get_top_parent(widget).songlist.grab_focus()
 
     def _get_songs(self):
-        text = self._get_text()
-        try:
-            self._query = Query(text, star=SongList.star)
-        except Query.error:
-            pass
-        else:
-            return self._query.filter(self._library)
+        self._query = self._sb_box.query
+        return self._query.filter(self._library) if self._query else None
 
     def activate(self):
         songs = self._get_songs()

--- a/quodlibet/quodlibet/browsers/soundcloud/library.py
+++ b/quodlibet/quodlibet/browsers/soundcloud/library.py
@@ -34,12 +34,11 @@ class SoundcloudLibrary(SongLibrary):
     def query_with_refresh(self, text, sort=None, star=STAR):
         """Queries Soundcloud for some (more) relevant results, then filters"""
         current = self._contents.values()
-        try:
-            query = SoundcloudQuery(text, star=star)
-            self.client.get_tracks(query.terms)
-        except SoundcloudQuery.error as e:
-            print_w("Couldn't filter for query '%s' (%s)" % (text, e))
+
+        query = SoundcloudQuery(text, star=star)
+        if not query.is_parsable:
             return current
+        self.client.get_tracks(query.terms)
         filtered = query.filter(current)
         print_d("Filtered %d results to %d" % (len(current), len(filtered)))
         return filtered

--- a/quodlibet/quodlibet/browsers/soundcloud/main.py
+++ b/quodlibet/quodlibet/browsers/soundcloud/main.py
@@ -334,10 +334,10 @@ class SoundcloudBrowser(Browser, util.InstanceTracker):
 
     def filter_text(self, text):
         self.__searchbar.set_text(text)
-        if SoundcloudQuery.is_parsable(text):
+        if SoundcloudQuery(text).is_parsable:
             self.activate()
         else:
-            print_w("Not parseable: %s" % text)
+            print_d("Not parsable: %s" % text)
 
     def get_filter_text(self):
         return self.__searchbar.get_text()

--- a/quodlibet/quodlibet/browsers/soundcloud/query.py
+++ b/quodlibet/quodlibet/browsers/soundcloud/query.py
@@ -10,11 +10,11 @@ import operator
 from collections import defaultdict
 from datetime import datetime
 
+from quodlibet import print_d
 from quodlibet.formats import AudioFile
-from quodlibet.query import Query
+from quodlibet.query import Query, QueryType
 from quodlibet.query._match import Tag, Inter, Union, Numcmp, NumexprTag, \
-    Numexpr, True_, error
-
+    Numexpr, True_, error, False_
 
 error
 
@@ -51,7 +51,12 @@ class SoundcloudQuery(Query):
     def __init__(self, string, star=None, clock=time.time):
         super(SoundcloudQuery, self).__init__(string, star)
         self._clock = clock
-        self.terms = self._extract_terms(self._match)
+        try:
+            self.terms = self._extract_terms(self._match)
+        except self.error as e:
+            print_d("Couldn't use query: %s" % e)
+            self.type = QueryType.INVALID
+            self.terms = []
 
     def _extract_terms(self, node):
         """ Return a dict of sets keyed on API search term,
@@ -126,4 +131,6 @@ class SoundcloudQuery(Query):
             return terms_from_re(node.pattern, tag)
         elif isinstance(node, True_):
             return set()
+        elif isinstance(node, False_):
+            raise self.error("False can never be queried")
         raise self.error("Unhandled node: %r" % (node,))

--- a/quodlibet/quodlibet/browsers/soundcloud/query.py
+++ b/quodlibet/quodlibet/browsers/soundcloud/query.py
@@ -56,7 +56,7 @@ class SoundcloudQuery(Query):
         except self.error as e:
             print_d("Couldn't use query: %s" % e)
             self.type = QueryType.INVALID
-            self.terms = []
+            self.terms = {}
 
     def _extract_terms(self, node):
         """ Return a dict of sets keyed on API search term,

--- a/quodlibet/quodlibet/qltk/dbus_.py
+++ b/quodlibet/quodlibet/qltk/dbus_.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # Copyright 2006 Federico Pelloni <federico.pelloni@gmail.com>
 #           2013 Christoph Reiter
+#           2017 Nick Boultbee
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of version 2 of the GNU General Public License as
@@ -103,13 +104,10 @@ class DBusHandler(dbus.service.Object):
         return self._player.paused
 
     @dbus.service.method('net.sacredchao.QuodLibet', in_signature='s')
-    def Query(self, query):
-        if query is not None:
-            try:
-                results = Query(query, star=SongList.star).search
-            except Query.error:
-                pass
-            else:
+    def Query(self, text):
+        if text is not None:
+            query = Query(text, star=SongList.star)
+            if query.is_parsable:
                 return [self.__dict(s) for s in itervalues(self.library)
-                        if results(s)]
+                        if query.search(s)]
         return None

--- a/quodlibet/quodlibet/qltk/searchbar.py
+++ b/quodlibet/quodlibet/qltk/searchbar.py
@@ -141,7 +141,7 @@ class SearchBarBox(Gtk.HBox):
             return
 
         text = self.get_text().strip()
-        if text and Query.is_parsable(text):
+        if text and Query(text).is_parsable:
             # Adding the active text to the model triggers a changed signal
             # (get_active is no longer -1), so inhibit
             self.__inhibit()
@@ -152,7 +152,7 @@ class SearchBarBox(Gtk.HBox):
     def __filter_changed(self, *args):
         self.__deferred_changed.abort()
         text = self.get_text()
-        if Query.is_parsable(text):
+        if Query(text).is_parsable:
             GLib.idle_add(self.emit, 'query-changed', text)
 
     def __text_changed(self, *args):

--- a/quodlibet/quodlibet/qltk/searchbar.py
+++ b/quodlibet/quodlibet/qltk/searchbar.py
@@ -40,7 +40,8 @@ class SearchBarBox(Gtk.HBox):
     DEFAULT_TIMEOUT = 400
 
     def __init__(self, filename=None, completion=None, accel_group=None,
-                 timeout=DEFAULT_TIMEOUT, validator=Query.validator):
+                 timeout=DEFAULT_TIMEOUT, validator=Query.validator,
+                 star=None):
         super(SearchBarBox, self).__init__(spacing=6)
 
         if filename is None:
@@ -61,13 +62,14 @@ class SearchBarBox(Gtk.HBox):
         if completion:
             entry.set_completion(completion)
 
+        self._star = star
+        self.query = None
         self.__sig = combo.connect('text-changed', self.__text_changed)
 
         entry.connect('clear', self.__filter_changed)
         entry.connect('backspace', self.__text_changed)
         entry.connect('populate-popup', self.__menu)
         entry.connect('activate', self.__filter_changed)
-        entry.connect('activate', self.__save_search)
         entry.connect('focus-out-event', self.__save_search)
 
         entry.set_placeholder_text(_("Search"))
@@ -92,11 +94,16 @@ class SearchBarBox(Gtk.HBox):
         """Set the text without firing any signals"""
 
         self.__deferred_changed.abort()
+        self._update_query_from(text)
 
         # deactivate all signals and change the entry text
         self.__inhibit()
         self.__entry.set_text(text)
         self.__uninhibit()
+
+    def _update_query_from(self, text):
+        # TODO: remove tight coupling to Query
+        self.query = Query(text, star=self._star)
 
     def get_text(self):
         """Get the active text as unicode"""
@@ -141,7 +148,7 @@ class SearchBarBox(Gtk.HBox):
             return
 
         text = self.get_text().strip()
-        if text and Query(text).is_parsable:
+        if text and self.query.is_parsable:
             # Adding the active text to the model triggers a changed signal
             # (get_active is no longer -1), so inhibit
             self.__inhibit()
@@ -152,8 +159,10 @@ class SearchBarBox(Gtk.HBox):
     def __filter_changed(self, *args):
         self.__deferred_changed.abort()
         text = self.get_text()
-        if Query(text).is_parsable:
+        self._update_query_from(text)
+        if self.query.is_parsable:
             GLib.idle_add(self.emit, 'query-changed', text)
+            self.__save_search(args[0:1], args[1:])
 
     def __text_changed(self, *args):
         if not self.__entry.is_sensitive():

--- a/quodlibet/quodlibet/query/_match.py
+++ b/quodlibet/quodlibet/query/_match.py
@@ -94,7 +94,7 @@ class False_(Node):
         return False
 
     def filter(self, list_):
-        return list(list_)
+        return []
 
     def __repr__(self):
         return "<False>"

--- a/quodlibet/quodlibet/query/_match.py
+++ b/quodlibet/quodlibet/query/_match.py
@@ -2,7 +2,7 @@
 # Copyright 2004-2005 Joe Wreschnig, Michael Urman
 #           2011 Christoph Reiter
 #           2016 Ryan Dellenbaugh
-#           2016 Nick Boultbee
+#        2016-17 Nick Boultbee
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as
@@ -85,6 +85,26 @@ class True_(Node):
     def __and__(self, other):
         other = other._unpack()
         return other
+
+
+class False_(Node):
+    """Always False"""
+
+    def search(self, data):
+        return False
+
+    def filter(self, list_):
+        return list(list_)
+
+    def __repr__(self):
+        return "<False>"
+
+    def __or__(self, other):
+        other = other._unpack()
+        return other
+
+    def __and__(self, other):
+        return self
 
 
 class Union(Node):

--- a/quodlibet/quodlibet/query/_query.py
+++ b/quodlibet/quodlibet/query/_query.py
@@ -8,6 +8,7 @@
 # published by the Free Software Foundation
 
 from quodlibet import print_d
+from quodlibet.util.dprint import frame_info
 from . import _match as match
 from ._match import error, Node, False_
 from ._parser import QueryParser
@@ -55,7 +56,8 @@ class Query(Node):
             "!(foo, bar)" -> !star1,star2=(foo, bar)
             etc...
         """
-        print_d("Creating query %s" % string)
+        print_d("Creating query \"%s\", called from %s"
+                % (string, frame_info(1)))
         if star is None:
             star = self.STAR
 

--- a/quodlibet/quodlibet/query/_query.py
+++ b/quodlibet/quodlibet/query/_query.py
@@ -1,14 +1,15 @@
 # -*- coding: utf-8 -*-
 # Copyright 2004-2005 Joe Wreschnig, Michael Urman
-#           2015-2016 Nick Boultbee,
+#           2015-2017 Nick Boultbee,
 #                2016 Ryan Dellenbaugh
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as
 # published by the Free Software Foundation
 
+from quodlibet import print_d
 from . import _match as match
-from ._match import error, Node
+from ._match import error, Node, False_
 from ._parser import QueryParser
 from quodlibet.util import re_escape, enum, cached_property
 from quodlibet.compat import PY2, text_type
@@ -54,7 +55,7 @@ class Query(Node):
             "!(foo, bar)" -> !star1,star2=(foo, bar)
             etc...
         """
-
+        print_d("Creating query %s" % string)
         if star is None:
             star = self.STAR
 
@@ -84,7 +85,10 @@ class Query(Node):
             except self.error:
                 pass
 
-        raise error('Query is not VALID or TEXT')
+        # raise error('Query is not VALID or TEXT')
+        print_d("Query '%s' is invalid" % string)
+        self.type = QueryType.INVALID
+        self._match = False_()
 
     @classmethod
     def StrictQueryMatcher(cls, string):
@@ -108,39 +112,20 @@ class Query(Node):
     def filter(self):
         return self._match.filter
 
-    @classmethod
-    def is_valid(cls, string):
-        """Whether a full query can be parsed"""
+    @property
+    def valid(self):
+        """Whether a query is a valid full (not free-text) query"""
+        return self.type == QueryType.VALID
 
-        return cls.get_type(string) == QueryType.VALID
-
-    @classmethod
-    def match_all(cls, string):
+    @property
+    def matches_all(self):
         """Whether the resulting query will not filter anything"""
+        return isinstance(self._match, match.True_)
 
-        try:
-            return isinstance(cls(string)._match, match.True_)
-        except cls.error:
-            return False
-
-    @classmethod
-    def is_parsable(cls, string):
-        """Whether the text can be parsed"""
-
-        try:
-            cls(string)
-        except cls.error:
-            return False
-        return True
-
-    @classmethod
-    def get_type(cls, string):
-        """Returns a QueryType instance for the given query"""
-
-        try:
-            return cls(string).type
-        except error:
-            return QueryType.INVALID
+    @property
+    def is_parsable(self):
+        """Whether the text can be parsed at all"""
+        return self.type is not QueryType.INVALID
 
     def _unpack(self):
         # so that other classes can see the wrapped one and optimize
@@ -160,10 +145,11 @@ class Query(Node):
     def validator(cls, string):
         """Returns True/False for a query, None for a text only query"""
 
-        type_ = cls.get_type(string)
+        query = cls(string)
+        type_ = query.type
         if type_ == QueryType.VALID:
             # in case of an empty but valid query we say it's "text"
-            if cls.match_all(string):
+            if query.matches_all:
                 return None
             return True
         elif type_ == QueryType.INVALID:

--- a/quodlibet/quodlibet/util/library.py
+++ b/quodlibet/quodlibet/util/library.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2004-2013 Joe Wreschnig, Michael Urman, Iñigo Serna,
+# Copyright 2004-2017 Joe Wreschnig, Michael Urman, Iñigo Serna,
 #     Christoph Reiter, Nick Boultbee
 #
 # This program is free software; you can redistribute it and/or modify
@@ -37,7 +37,9 @@ def background_filter():
     if not bg:
         return
     try:
-        return Query(bg, SongList.star).search
+        query = Query(bg, SongList.star)
+        if query.is_parsable:
+            return query.search
     except Query.error:
         pass
 

--- a/quodlibet/quodlibet/util/library.py
+++ b/quodlibet/quodlibet/util/library.py
@@ -36,12 +36,9 @@ def background_filter():
     bg = config.gettext("browsers", "background")
     if not bg:
         return
-    try:
-        query = Query(bg, SongList.star)
-        if query.is_parsable:
-            return query.search
-    except Query.error:
-        pass
+    query = Query(bg, SongList.star)
+    if query.is_parsable:
+        return query.search
 
 
 def split_scan_dirs(joined_paths):

--- a/quodlibet/tests/test_browsers_soundcloud.py
+++ b/quodlibet/tests/test_browsers_soundcloud.py
@@ -9,11 +9,11 @@ from unittest import TestCase
 import time
 
 from quodlibet import config
-from quodlibet.browsers.soundcloud import query
 from quodlibet.browsers.soundcloud.api import SoundcloudApiClient
 from quodlibet.browsers.soundcloud.query import SoundcloudQuery, convert_time
 
 from quodlibet import const
+from quodlibet.query import QueryType
 from quodlibet.util.dprint import print_d
 
 NONE = set([])
@@ -33,12 +33,8 @@ class TestExtract(TestCase):
         self.verify("artist=jay z", {"jay z"})
 
     def test_extract_unsupported(self):
-        try:
-            self.verify("musicbrainz_discid=12345", NONE)
-        except query.error:
-            pass
-        else:
-            self.fail("Should have thrown")
+        self.failUnlessEqual(SoundcloudQuery("musicbrainz_discid=12345").type,
+                             QueryType.INVALID)
 
     def test_extract_composite_text(self):
         self.verify("&(foo, bar)", {"foo", "bar"})

--- a/quodlibet/tests/test_query.py
+++ b/quodlibet/tests/test_query.py
@@ -16,142 +16,142 @@ from tests import TestCase, skip
 
 class TQuery_is_valid(TestCase):
     def test_re(self):
-        self.failUnless(Query.is_valid('t = /an re/'))
-        self.failUnless(Query.is_valid('t = /an re/c'))
-        self.failUnless(Query.is_valid('t = /an\\/re/'))
-        self.failIf(Query.is_valid('t = /an/re/'))
-        self.failUnless(Query.is_valid('t = /aaa/lsic'))
-        self.failIf(Query.is_valid('t = /aaa/icslx'))
+        self.failUnless(Query('t = /an re/').valid)
+        self.failUnless(Query('t = /an re/c').valid)
+        self.failUnless(Query('t = /an\\/re/').valid)
+        self.failIf(Query('t = /an/re/').valid)
+        self.failUnless(Query('t = /aaa/lsic').valid)
+        self.failIf(Query('t = /aaa/icslx').valid)
 
     def test_str(self):
-        self.failUnless(Query.is_valid('t = "a str"'))
-        self.failUnless(Query.is_valid('t = "a str"c'))
-        self.failUnless(Query.is_valid('t = "a\\"str"'))
+        self.failUnless(Query('t = "a str"').valid)
+        self.failUnless(Query('t = "a str"c').valid)
+        self.failUnless(Query('t = "a\\"str"').valid)
         # there's no equivalent failure for strings since 'str"' would be
         # read as a set of modifiers
 
     def test_tag(self):
-        self.failUnless(Query.is_valid('t = tag'))
-        self.failUnless(Query.is_valid('t = !tag'))
-        self.failUnless(Query.is_valid('t = |(tag, bar)'))
-        self.failUnless(Query.is_valid('t = a"tag"'))
-        self.failIf(Query.is_valid('t = a, tag'))
-        self.failUnless(Query.is_valid('tag with spaces = tag'))
+        self.failUnless(Query('t = tag').valid)
+        self.failUnless(Query('t = !tag').valid)
+        self.failUnless(Query('t = |(tag, bar)').valid)
+        self.failUnless(Query('t = a"tag"').valid)
+        self.failIf(Query('t = a, tag').valid)
+        self.failUnless(Query('tag with spaces = tag').valid)
 
     def test_empty(self):
-        self.failUnless(Query.is_valid(''))
-        self.failUnless(Query.is_parsable(''))
+        self.failUnless(Query('').valid)
+        self.failUnless(Query('').is_parsable)
         self.failUnless(Query(''))
 
     def test_emptylist(self):
-        self.failIf(Query.is_valid("a = &()"))
-        self.failIf(Query.is_valid("a = |()"))
-        self.failIf(Query.is_valid("|()"))
-        self.failIf(Query.is_valid("&()"))
+        self.failIf(Query("a = &()").valid)
+        self.failIf(Query("a = |()").valid)
+        self.failIf(Query("|()").valid)
+        self.failIf(Query("&()").valid)
 
     def test_nonsense(self):
-        self.failIf(Query.is_valid('a string'))
-        self.failIf(Query.is_valid('t = #(a > b)'))
-        self.failIf(Query.is_valid("=a= = /b/"))
-        self.failIf(Query.is_valid("a = &(/b//"))
-        self.failIf(Query.is_valid("(a = &(/b//)"))
+        self.failIf(Query('a string').valid)
+        self.failIf(Query('t = #(a > b)').valid)
+        self.failIf(Query("=a= = /b/").valid)
+        self.failIf(Query("a = &(/b//").valid)
+        self.failIf(Query("(a = &(/b//)").valid)
 
     def test_trailing(self):
-        self.failIf(Query.is_valid('t = /an re/)'))
-        self.failIf(Query.is_valid('|(a, b = /a/, c, d = /q/) woo'))
+        self.failIf(Query('t = /an re/)').valid)
+        self.failIf(Query('|(a, b = /a/, c, d = /q/) woo').valid)
 
     def test_not(self):
-        self.failUnless(Query.is_valid('t = !/a/'))
-        self.failUnless(Query.is_valid('t = !!/a/'))
-        self.failUnless(Query.is_valid('!t = "a"'))
-        self.failUnless(Query.is_valid('!!t = "a"'))
-        self.failUnless(Query.is_valid('t = !|(/a/, !"b")'))
-        self.failUnless(Query.is_valid('t = !!|(/a/, !"b")'))
-        self.failUnless(Query.is_valid('!|(t = /a/)'))
+        self.failUnless(Query('t = !/a/').valid)
+        self.failUnless(Query('t = !!/a/').valid)
+        self.failUnless(Query('!t = "a"').valid)
+        self.failUnless(Query('!!t = "a"').valid)
+        self.failUnless(Query('t = !|(/a/, !"b")').valid)
+        self.failUnless(Query('t = !!|(/a/, !"b")').valid)
+        self.failUnless(Query('!|(t = /a/)').valid)
 
     def test_taglist(self):
-        self.failUnless(Query.is_valid('a, b = /a/'))
-        self.failUnless(Query.is_valid('a, b, c = |(/a/)'))
-        self.failUnless(Query.is_valid('|(a, b = /a/, c, d = /q/)'))
-        self.failIf(Query.is_valid('a = /a/, b'))
+        self.failUnless(Query('a, b = /a/').valid)
+        self.failUnless(Query('a, b, c = |(/a/)').valid)
+        self.failUnless(Query('|(a, b = /a/, c, d = /q/)').valid)
+        self.failIf(Query('a = /a/, b').valid)
 
     def test_andor(self):
-        self.failUnless(Query.is_valid('a = |(/a/, /b/)'))
-        self.failUnless(Query.is_valid('a = |(/b/)'))
-        self.failUnless(Query.is_valid('|(a = /b/, c = /d/)'))
+        self.failUnless(Query('a = |(/a/, /b/)').valid)
+        self.failUnless(Query('a = |(/b/)').valid)
+        self.failUnless(Query('|(a = /b/, c = /d/)').valid)
 
-        self.failUnless(Query.is_valid('a = &(/a/, /b/)'))
-        self.failUnless(Query.is_valid('a = &(/b/)'))
-        self.failUnless(Query.is_valid('&(a = /b/, c = /d/)'))
+        self.failUnless(Query('a = &(/a/, /b/)').valid)
+        self.failUnless(Query('a = &(/b/)').valid)
+        self.failUnless(Query('&(a = /b/, c = /d/)').valid)
 
     def test_numcmp(self):
-        self.failUnless(Query.is_valid("#(t < 3)"))
-        self.failUnless(Query.is_valid("#(t <= 3)"))
-        self.failUnless(Query.is_valid("#(t > 3)"))
-        self.failUnless(Query.is_valid("#(t >= 3)"))
-        self.failUnless(Query.is_valid("#(t = 3)"))
-        self.failUnless(Query.is_valid("#(t != 3)"))
+        self.failUnless(Query("#(t < 3)").valid)
+        self.failUnless(Query("#(t <= 3)").valid)
+        self.failUnless(Query("#(t > 3)").valid)
+        self.failUnless(Query("#(t >= 3)").valid)
+        self.failUnless(Query("#(t = 3)").valid)
+        self.failUnless(Query("#(t != 3)").valid)
 
-        self.failIf(Query.is_valid("#(t !> 3)"))
-        self.failIf(Query.is_valid("#(t >> 3)"))
+        self.failIf(Query("#(t !> 3)").valid)
+        self.failIf(Query("#(t >> 3)").valid)
 
     def test_numcmp_func(self):
-        self.assertTrue(Query.is_valid("#(t:min < 3)"))
+        self.assertTrue(Query("#(t:min < 3)").valid)
         self.assertTrue(
-            Query.is_valid("&(#(playcount:min = 0), #(added < 1 month ago))"))
+            Query("&(#(playcount:min = 0), #(added < 1 month ago))").valid)
 
     def test_trinary(self):
-        self.failUnless(Query.is_valid("#(2 < t < 3)"))
-        self.failUnless(Query.is_valid("#(2 >= t > 3)"))
+        self.failUnless(Query("#(2 < t < 3)").valid)
+        self.failUnless(Query("#(2 >= t > 3)").valid)
         # useless, but valid
-        self.failUnless(Query.is_valid("#(5 > t = 2)"))
+        self.failUnless(Query("#(5 > t = 2)").valid)
 
     def test_list(self):
-        self.failUnless(Query.is_valid("#(t < 3, t > 9)"))
-        self.failUnless(Query.is_valid("t = &(/a/, /b/)"))
-        self.failUnless(Query.is_valid("s, t = |(/a/, /b/)"))
-        self.failUnless(Query.is_valid("|(t = /a/, s = /b/)"))
+        self.failUnless(Query("#(t < 3, t > 9)").valid)
+        self.failUnless(Query("t = &(/a/, /b/)").valid)
+        self.failUnless(Query("s, t = |(/a/, /b/)").valid)
+        self.failUnless(Query("|(t = /a/, s = /b/)").valid)
 
     def test_nesting(self):
-        self.failUnless(Query.is_valid("|(s, t = &(/a/, /b/),!#(2 > q > 3))"))
+        self.failUnless(Query("|(s, t = &(/a/, /b/),!#(2 > q > 3))").valid)
 
     def test_extension(self):
-        self.failUnless(Query.is_valid("@(name)"))
-        self.failUnless(Query.is_valid("@(name: extension body)"))
-        self.failUnless(Query.is_valid("@(name: body (with (nested) parens))"))
-        self.failUnless(Query.is_valid(r"@(name: body \\ with \) escapes)"))
+        self.failUnless(Query("@(name)").valid)
+        self.failUnless(Query("@(name: extension body)").valid)
+        self.failUnless(Query("@(name: body (with (nested) parens))").valid)
+        self.failUnless(Query(r"@(name: body \\ with \) escapes)").valid)
 
-        self.failIf(Query.is_valid("@()"))
-        self.failIf(Query.is_valid(r"@(invalid %name!\\)"))
-        self.failIf(Query.is_valid("@(name: mismatched ( parenthesis)"))
-        self.failIf(Query.is_valid(r"@(\()"))
-        self.failIf(Query.is_valid("@(name:unclosed body"))
-        self.failIf(Query.is_valid("@ )"))
+        self.failIf(Query("@()").valid)
+        self.failIf(Query(r"@(invalid %name!\\)").valid)
+        self.failIf(Query("@(name: mismatched ( parenthesis)").valid)
+        self.failIf(Query(r"@(\()").valid)
+        self.failIf(Query("@(name:unclosed body").valid)
+        self.failIf(Query("@ )").valid)
 
     def test_numexpr(self):
-        self.failUnless(Query.is_valid("#(t < 3*4)"))
-        self.failUnless(Query.is_valid("#(t * (1+r) < 7)"))
-        self.failUnless(Query.is_valid("#(0 = t)"))
-        self.failUnless(Query.is_valid("#(t < r < 9)"))
-        self.failUnless(Query.is_valid("#((t-9)*r < -(6*2) = g*g-1)"))
-        self.failUnless(Query.is_valid("#(t + 1 + 2 + -4 * 9 > g*(r/4 + 6))"))
-        self.failUnless(Query.is_valid("#(date < 2010-4)"))
-        self.failUnless(Query.is_valid("#(date < 2010 - 4)"))
-        self.failUnless(Query.is_valid("#(date > 0000)"))
-        self.failUnless(Query.is_valid("#(date > 00004)"))
-        self.failUnless(Query.is_valid("#(t > 3 minutes)"))
-        self.failUnless(Query.is_valid("#(added > today)"))
-        self.failUnless(Query.is_valid("#(length < 5:00)"))
-        self.failUnless(Query.is_valid("#(filesize > 5M)"))
-        self.failUnless(Query.is_valid("#(added < 7 days ago)"))
+        self.failUnless(Query("#(t < 3*4)").valid)
+        self.failUnless(Query("#(t * (1+r) < 7)").valid)
+        self.failUnless(Query("#(0 = t)").valid)
+        self.failUnless(Query("#(t < r < 9)").valid)
+        self.failUnless(Query("#((t-9)*r < -(6*2) = g*g-1)").valid)
+        self.failUnless(Query("#(t + 1 + 2 + -4 * 9 > g*(r/4 + 6))").valid)
+        self.failUnless(Query("#(date < 2010-4)").valid)
+        self.failUnless(Query("#(date < 2010 - 4)").valid)
+        self.failUnless(Query("#(date > 0000)").valid)
+        self.failUnless(Query("#(date > 00004)").valid)
+        self.failUnless(Query("#(t > 3 minutes)").valid)
+        self.failUnless(Query("#(added > today)").valid)
+        self.failUnless(Query("#(length < 5:00)").valid)
+        self.failUnless(Query("#(filesize > 5M)").valid)
+        self.failUnless(Query("#(added < 7 days ago)").valid)
 
-        self.failIf(Query.is_valid("#(3*4)"))
-        self.failIf(Query.is_valid("#(t = 3 + )"))
-        self.failIf(Query.is_valid("#(t = -)"))
-        self.failIf(Query.is_valid("#(-4 <)"))
-        self.failIf(Query.is_valid("#(t < ()"))
-        self.failIf(Query.is_valid("#((t +) - 1 > 8)"))
-        self.failIf(Query.is_valid("#(t += 8)"))
+        self.failIf(Query("#(3*4)").valid)
+        self.failIf(Query("#(t = 3 + )").valid)
+        self.failIf(Query("#(t = -)").valid)
+        self.failIf(Query("#(-4 <)").valid)
+        self.failIf(Query("#(t < ()").valid)
+        self.failIf(Query("#((t +) - 1 > 8)").valid)
+        self.failIf(Query("#(t += 8)").valid)
 
 
 class TQuery(TestCase):
@@ -416,9 +416,9 @@ class TQuery(TestCase):
             q.filter(iter([self.s1, self.s2])), [self.s1, self.s2])
 
     def test_match_all(self):
-        self.failUnless(Query.match_all(""))
-        self.failUnless(Query.match_all("    "))
-        self.failIf(Query.match_all("foo"))
+        self.failUnless(Query("").matches_all)
+        self.failUnless(Query("    ").matches_all)
+        self.failIf(Query("foo").matches_all)
 
     def test_utf8(self):
         # also handle undecoded values
@@ -502,12 +502,12 @@ class TQuery(TestCase):
 class TQuery_get_type(TestCase):
     def test_red(self):
         for p in ["a = /w", "|(sa#"]:
-            self.failUnlessEqual(QueryType.INVALID, Query.get_type(p))
+            self.failUnlessEqual(QueryType.INVALID, Query(p).type)
 
     def test_black(self):
         for p in ["a test", "more test hooray"]:
-            self.failUnlessEqual(QueryType.TEXT, Query.get_type(p))
+            self.failUnlessEqual(QueryType.TEXT, Query(p).type)
 
     def test_green(self):
         for p in ["a = /b/", "&(a = b, c = d)", "/abc/", "!x", "!&(abc, def)"]:
-            self.failUnlessEqual(QueryType.VALID, Query.get_type(p))
+            self.failUnlessEqual(QueryType.VALID, Query(p).type)


### PR DESCRIPTION
 * Use (existing) `INVALID` state for invalid Query objects, instead of raising errors at construction. This means we can model an invalid query fully, in combination with a new `False_` Node which never matches anything.
 * Similar change for `SoundcloudQuery` (subclass)
 * Convert classmethods to instance methods (and make them properties for readability), removing implicit calls to constructor - making them explicit. In reality this was mainly moving of brackets :smile:
 * Also, this meant there were potentially edge-cases around a parseable query with default STAR not being parsable / useful with the custom STAR, but not sure if that's important.
 * Improve performance by building queries less - reuse instances instead
 * Keep `Query.validator` for now, it's weird but fairly harmless (can be dealt with another time)
* Make `SearchBarBox` take an optional `star` with which to create queries
 * Move `STAR` into each browser that doesn't define it explicitly and use this to create the SBB
 * Instead of rebuilding queries, reuse the browser's SBB's pre-created one (which is updated on change)
 * Update SBB event handling slightly to avoid extra calls there too
 * Also update debug message to add caller information