### PR TITLE
Waveform Seekbar time indication (#2419)

### DIFF
--- a/quodlibet/quodlibet/ext/events/waveformseekbar.py
+++ b/quodlibet/quodlibet/ext/events/waveformseekbar.py
@@ -446,7 +446,8 @@ class WaveformScale(Gtk.EventBox):
             hover_color = Gdk.RGBA()
             hover_color.parse(hover_color_config)
         else:
-            # Generate default hover_color by blending elapsed_color and fg_color
+            # Generate default hover_color by blending elapsed_color and
+            # fg_color
             opacity = 0.4
             r = (opacity * elapsed_color.alpha * elapsed_color.red +
                  (1 - opacity) * fg_color.alpha * fg_color.red)
@@ -568,8 +569,8 @@ class WaveformSeekBarPlugin(EventPlugin):
             hbox.pack_start(entry, True, True, 0)
             return hbox
 
-        box = create_color(_("Override foreground color:"), CONFIG.elapsed_color,
-                           elapsed_color_changed)
+        box = create_color(_("Override foreground color:"),
+                           CONFIG.elapsed_color, elapsed_color_changed)
         vbox.pack_start(box, True, True, 0)
 
         box = create_color(_("Override hover color:"), CONFIG.hover_color,

--- a/quodlibet/quodlibet/ext/events/waveformseekbar.py
+++ b/quodlibet/quodlibet/ext/events/waveformseekbar.py
@@ -365,9 +365,6 @@ class WaveformScale(Gtk.EventBox):
         position_width = self.position * width * pixel_ratio
         mouse_position = self.mouse_position * scale_factor
 
-        if self._seeking:
-            position_width = mouse_position
-
         hw = line_width / 2.0
         # Avoiding object lookups is slightly faster
         data = self._rms_vals
@@ -377,7 +374,11 @@ class WaveformScale(Gtk.EventBox):
             for x in range(int(floor(cx * pixel_ratio)),
                            int(ceil((cx + cw) * pixel_ratio)), 1):
 
-                if mouse_position >= 0:
+                if self._seeking and mouse_position >= 0:
+                    # The user is seeking
+                    fg_color = (elapsed_color if x < mouse_position
+                                else remaining_color)
+                elif mouse_position >= 0:
                     # The mouse is hovering the seekbar
                     fg_color = (hover_color if x < mouse_position
                                 else remaining_color)
@@ -501,6 +502,7 @@ class WaveformScale(Gtk.EventBox):
             length = self._player.info("~#length")
             self._player.seek(ratio * length * 1000)
             self._seeking = False
+            self.queue_draw()
             return True
 
     def set_position(self, position):

--- a/quodlibet/quodlibet/ext/events/waveformseekbar.py
+++ b/quodlibet/quodlibet/ext/events/waveformseekbar.py
@@ -364,7 +364,7 @@ class WaveformScale(Gtk.EventBox):
 
         position_width = self.position * width * pixel_ratio
         mouse_position = (
-            self.mouse_position if self.mouse_position >= 0
+            self.mouse_position * scale_factor if self.mouse_position >= 0
             else position_width
         )
 

--- a/quodlibet/quodlibet/ext/events/waveformseekbar.py
+++ b/quodlibet/quodlibet/ext/events/waveformseekbar.py
@@ -363,10 +363,7 @@ class WaveformScale(Gtk.EventBox):
         cr.set_line_join(cairo.LINE_JOIN_ROUND)
 
         position_width = self.position * width * pixel_ratio
-        mouse_position = (
-            self.mouse_position * scale_factor if self.mouse_position >= 0
-            else position_width
-        )
+        mouse_position = self.mouse_position * scale_factor
 
         if self._seeking:
             position_width = mouse_position
@@ -380,11 +377,18 @@ class WaveformScale(Gtk.EventBox):
             for x in range(int(floor(cx * pixel_ratio)),
                            int(ceil((cx + cw) * pixel_ratio)), 1):
 
-                fg_color = hover_color
-                if x < position_width and x < mouse_position:
-                    fg_color = elapsed_color
-                elif x >= position_width and x >= mouse_position:
-                    fg_color = remaining_color
+                if mouse_position >= 0:
+                    # The mouse is hovering the seekbar
+                    fg_color = (hover_color if x < mouse_position
+                                else remaining_color)
+
+                    # Draw a line of width scale_factor at the current position
+                    if position_width - scale_factor <= x < position_width:
+                        fg_color = elapsed_color
+                else:
+                    fg_color = (elapsed_color if x < position_width
+                                else remaining_color)
+
                 cr.set_source_rgba(*list(fg_color))
 
                 # Basic anti-aliasing / oversampling

--- a/quodlibet/quodlibet/ext/events/waveformseekbar.py
+++ b/quodlibet/quodlibet/ext/events/waveformseekbar.py
@@ -14,6 +14,7 @@ from math import ceil, floor
 
 from quodlibet import _, app
 from quodlibet import print_w
+from quodlibet import util
 from quodlibet.plugins import PluginConfig, IntConfProp, \
     ConfProp
 from quodlibet.plugins.events import EventPlugin
@@ -171,6 +172,7 @@ class WaveformSeekBar(Gtk.Box):
         if player.info in songs:
             # Trigger a re-computation of the waveform
             self._create_waveform(player.info, CONFIG.max_data_points)
+            self._resize_labels(player.info)
             # Only update the label if some tag value changed
             self._update_label(player)
 
@@ -178,6 +180,7 @@ class WaveformSeekBar(Gtk.Box):
         if player.info and player.info.is_file:
             # Trigger a re-computation of the waveform
             self._create_waveform(player.info, CONFIG.max_data_points)
+            self._resize_labels(player.info)
 
         self._waveform_scale.set_placeholder(True)
         self._update(player, True)
@@ -250,6 +253,20 @@ class WaveformSeekBar(Gtk.Box):
 
         self._hovering = False
         self._update_label(self._player)
+
+    def _resize_labels(self, song):
+        length = util.format_time_display(song("~#length"))
+
+        # Get the width needed to display the length of the song (the text
+        # displayed in the labels will always be shorter than that)
+        layout = self._remaining_label.get_layout()
+        layout.set_text(length, -1)
+        width, height = layout.get_pixel_size()
+
+        # Set it as the minimum width of the labels to prevent them from
+        # changing width
+        self._remaining_label.set_size_request(width, -1)
+        self._elapsed_label.set_size_request(width, -1)
 
 
 class WaveformScale(Gtk.EventBox):

--- a/quodlibet/quodlibet/ext/events/waveformseekbar.py
+++ b/quodlibet/quodlibet/ext/events/waveformseekbar.py
@@ -382,10 +382,6 @@ class WaveformScale(Gtk.EventBox):
                     # The mouse is hovering the seekbar
                     fg_color = (hover_color if x < mouse_position
                                 else remaining_color)
-
-                    # Draw a line of width scale_factor at the current position
-                    if position_width - scale_factor <= x < position_width:
-                        fg_color = elapsed_color
                 else:
                     fg_color = (elapsed_color if x < position_width
                                 else remaining_color)

--- a/quodlibet/quodlibet/ext/events/waveformseekbar.py
+++ b/quodlibet/quodlibet/ext/events/waveformseekbar.py
@@ -595,8 +595,8 @@ class WaveformSeekBarPlugin(EventPlugin):
                            hover_color_changed)
         vbox.pack_start(box, True, True, 0)
 
-        box = create_color(_("Override remaining color:"), CONFIG.remaining_color,
-                           remaining_color_changed)
+        box = create_color(_("Override remaining color:"),
+                           CONFIG.remaining_color, remaining_color_changed)
         vbox.pack_start(box, True, True, 0)
 
         return vbox

--- a/quodlibet/quodlibet/ext/events/waveformseekbar.py
+++ b/quodlibet/quodlibet/ext/events/waveformseekbar.py
@@ -255,6 +255,11 @@ class WaveformSeekBar(Gtk.Box):
         self._update_label(self._player)
 
     def _resize_labels(self, song):
+        """Resize the labels to make sure there is enough space to display the
+        length of the songs.
+
+        This prevents the waveform from changing size when the position changes
+        from 9:59 to 10:00 for example."""
         length = util.format_time_display(song("~#length"))
 
         # Get the width needed to display the length of the song (the text


### PR DESCRIPTION
This pull request fixes issue #2419:

- It adds a soundcloud-like visual effect when the mouse hovers the waveform seekbar, and shows the time pointed by the mouse instead of the current position.
![peek 01-09-2017 20-17](https://user-images.githubusercontent.com/10254983/29985045-dc024e40-8f4c-11e7-8082-f8b42a72ec70.gif)
- It allows to seek by dragging (pressing the mouse button, moving it, then releasing it), in the same way as a Gtk.Scale.

Here is what it looks like with various popular gtk themes (from top to bottom: Adwaita-dark, Adwaita, Arc-Dark, Arc, Ambiance, Radiance):

![waveformseekbar-hover](https://user-images.githubusercontent.com/10254983/29985075-fac1674e-8f4c-11e7-8e70-a084789fdb1e.png)

As you can see the default "hover color" (the one to the left of the mouse cursor in the screenshots above) is not always great. It is computed by blending the two other colors, and I could not find any other way that works well for all the themes I tested. I hope it's good enough, considering that the three colors used in the waveform are configurable in the plugin's options. If not, I could remove the visual effect, and only change the time labels when hovering.
