### PR TITLE
Fix error when exporting playlist in python 3 (#2425)

### DIFF
--- a/quodlibet/quodlibet/ext/songsmenu/playlist.py
+++ b/quodlibet/quodlibet/ext/songsmenu/playlist.py
@@ -134,7 +134,7 @@ class PlaylistExport(PlaylistPlugin, SongsMenuPlugin):
 
     def __m3u_export(self, file_path, files):
         try:
-            fhandler = open(file_path, "w")
+            fhandler = open(file_path, "wb")
         except IOError:
             self.__file_error(file_path)
         else:
@@ -149,7 +149,7 @@ class PlaylistExport(PlaylistPlugin, SongsMenuPlugin):
 
     def __pls_export(self, file_path, files):
         try:
-            fhandler = open(file_path, "w")
+            fhandler = open(file_path, "wb")
         except IOError:
             self.__file_error(file_path)
         else:


### PR DESCRIPTION
This pull request fixes #2425 by opening the playlist files in binary mode, allowing to write bytes to them instead of str.