### PR TITLE
Move album art when renaming [#237] 

### DIFF
--- a/quodlibet/quodlibet/config.py
+++ b/quodlibet/quodlibet/config.py
@@ -215,9 +215,9 @@ INITIAL = {
         "spaces": "false",
         "windows": "true",
         "ascii": "false",
-        "moveart": "false",
-        "moveart_overwrite": "false",
-        "removeemptydirs": "false",
+        "move_art": "false",
+        "move_art_overwrite": "false",
+        "remove_empty_dirs": "false",
     },
 
     "tagsfrompath": {
@@ -260,7 +260,7 @@ INITIAL = {
         "prefer_embedded": "false",
         "force_filename": "false",
         "filename": "folder.jpg",
-        "filenames": "cover.jpg,folder.jpg,.folder.jpg",
+        "search_filenames": "cover.jpg,folder.jpg,.folder.jpg",
     },
 
     "display": {

--- a/quodlibet/quodlibet/config.py
+++ b/quodlibet/quodlibet/config.py
@@ -217,6 +217,7 @@ INITIAL = {
         "ascii": "false",
         "moveart": "false",
         "moveart_overwrite": "false",
+        "removeemptydirs": "false",
     },
 
     "tagsfrompath": {

--- a/quodlibet/quodlibet/config.py
+++ b/quodlibet/quodlibet/config.py
@@ -215,6 +215,8 @@ INITIAL = {
         "spaces": "false",
         "windows": "true",
         "ascii": "false",
+        "moveart": "false",
+        "moveart_overwrite": "false",
     },
 
     "tagsfrompath": {
@@ -257,6 +259,7 @@ INITIAL = {
         "prefer_embedded": "false",
         "force_filename": "false",
         "filename": "folder.jpg",
+        "filenames": "cover.jpg,folder.jpg,.folder.jpg",
     },
 
     "display": {

--- a/quodlibet/quodlibet/qltk/_editutils.py
+++ b/quodlibet/quodlibet/qltk/_editutils.py
@@ -141,6 +141,7 @@ class FilterPluginBox(Gtk.VBox):
         hb = Gtk.HBox()
         expander = Gtk.Expander(label=_(u"_More options…"))
         expander.set_use_underline(True)
+        expander.set_no_show_all(True)
         hb.pack_start(expander, True, True, 0)
         self.pack_start(hb, False, True, 0)
 

--- a/quodlibet/quodlibet/qltk/renamefiles.py
+++ b/quodlibet/quodlibet/qltk/renamefiles.py
@@ -28,7 +28,7 @@ from quodlibet.qltk.views import TreeViewColumn
 from quodlibet.qltk.cbes import ComboBoxEntrySave
 from quodlibet.qltk.ccb import ConfigCheckButton
 from quodlibet.qltk.models import ObjectStore
-from quodlibet.qltk import Icons, Button
+from quodlibet.qltk import Icons, Button, Frame
 from quodlibet.qltk.wlw import WritingWindow
 from quodlibet.util import connect_obj, gdecode
 from quodlibet.util.path import strip_win32_incompat_from_path
@@ -165,11 +165,21 @@ class RenameFiles(Gtk.VBox):
 
         self.pack_start(Gtk.VBox(), False, True, 0)
 
+        # rename options
+        rename_options = Gtk.HBox()
+
+        # file name options
         filter_box = FilterPluginBox(self.handler, self.FILTERS)
         filter_box.connect("preview", self.__filter_preview)
         filter_box.connect("changed", self.__filter_changed)
         self.filter_box = filter_box
-        self.pack_start(filter_box, False, True, 0)
+
+        frame_filename_options = Frame("File names", filter_box)
+        frame_filename_options.show_all()
+        rename_options.pack_start(frame_filename_options, False, True, 0)
+
+        # album art options
+        albumart_box = Gtk.VBox()
 
         # move art
         moveart_box = Gtk.VBox()
@@ -180,14 +190,13 @@ class RenameFiles(Gtk.VBox):
              _("See '[albumart] filenames' config entry " +
                "for image search strings"))
         self.moveart.show()
-        moveart_box.pack_start(self.move_art, False, True, 0)
+        moveart_box.pack_start(self.moveart, False, True, 0)
         self.moveart_overwrite = ConfigCheckButton(
              _('_Overwrite album art at target'),
              "rename", "move_art_overwrite", populate=True)
         self.moveart_overwrite.show()
         moveart_box.pack_start(self.moveart_overwrite, False, True, 0)
-        self.pack_start(moveart_box, False, True, 0)
-
+        albumart_box.pack_start(moveart_box, False, True, 0)
         # remove empty
         removeemptydirs_box = Gtk.VBox()
         self.removeemptydirs = ConfigCheckButton(
@@ -195,7 +204,13 @@ class RenameFiles(Gtk.VBox):
              "rename", "remove_empty_dirs", populate=True)
         self.removeemptydirs.show()
         removeemptydirs_box.pack_start(self.removeemptydirs, False, True, 0)
-        self.pack_start(removeemptydirs_box, False, True, 0)
+        albumart_box.pack_start(removeemptydirs_box, False, True, 0)
+
+        frame_albumart_options = Frame("Album art", albumart_box)
+        frame_albumart_options.show_all()
+        rename_options.pack_start(frame_albumart_options, False, True, 0)
+
+        self.pack_start(rename_options, False, True, 0)
 
         # Save button
         self.save = Button(_("_Save"), Icons.DOCUMENT_SAVE)

--- a/quodlibet/quodlibet/qltk/renamefiles.py
+++ b/quodlibet/quodlibet/qltk/renamefiles.py
@@ -269,7 +269,7 @@ class RenameFiles(Gtk.VBox):
         was_changed = set()
         skip_all = False
         self.view.freeze_child_notify()
-        move_art = config.getboolean("rename", "move_art")
+        should_move_art = config.getboolean("rename", "move_art")
         moveart_sets = {}
         remove_empty_dirs = config.getboolean("rename", "remove_empty_dirs")
 
@@ -280,10 +280,15 @@ class RenameFiles(Gtk.VBox):
             old_name = entry.name
             old_pathfile = song['~filename']
             new_name = entry.new_name
-            new_pathfile = new_name if (
-                os.path.abspath(os.path.join(os.getcwd(), new_name)) !=
-                os.path.abspath(new_name)) else (
-                os.path.join(os.path.dirname(old_pathfile), new_name))
+            new_pathfile = ""
+            # ensure target is a full path
+            if os.path.abspath(new_name) != \
+                   os.path.abspath(os.path.join(os.getcwd(), new_name)):
+                new_pathfile = new_name
+            else:
+                # must be a relative pattern, so prefix the path
+                new_pathfile = \
+                    os.path.join(os.path.dirname(old_pathfile), new_name)
 
             try:
                 library.rename(song, text2fsn(new_name), changed=was_changed)
@@ -316,7 +321,7 @@ class RenameFiles(Gtk.VBox):
                 if resp != Gtk.ResponseType.OK and resp != RESPONSE_SKIP_ALL:
                     break
 
-            if move_art:
+            if should_move_art:
                 self.__moveart(moveart_sets, old_pathfile, new_pathfile, song)
 
             if remove_empty_dirs:

--- a/quodlibet/quodlibet/qltk/renamefiles.py
+++ b/quodlibet/quodlibet/qltk/renamefiles.py
@@ -361,7 +361,7 @@ class RenameFiles(Gtk.VBox):
 
         path_old = os.path.dirname(os.path.realpath(pathfile_old))
         path_new = os.path.dirname(os.path.realpath(pathfile_new))
-        if os.path.samefile(path_old, path_new):
+        if os.path.realpath(path_old) == os.path.realpath(path_new):
             return
         if (path_old in art_sets.keys() and not art_sets[path_old]):
             return

--- a/quodlibet/quodlibet/qltk/renamefiles.py
+++ b/quodlibet/quodlibet/qltk/renamefiles.py
@@ -350,10 +350,17 @@ class RenameFiles(Gtk.VBox):
         if path_old in art_sets.keys():
             images = art_sets[path_old]
         else:
-            art_sets[path_old] = images
+            def glob_escape(s):
+                for c in ['[', '*', '?']:
+                    s = s.replace(c, '[' + c + ']')
+                return s
+
             # generate art set for path
+            art_sets[path_old] = images
+            path_old_escaped = glob_escape(path_old)
             for suffix in self.IMAGE_EXTENSIONS:
-                images.extend(glob.glob(os.path.join(path_old, "*." + suffix)))
+                images.extend(glob.glob(os.path.join(path_old_escaped,
+                                                     "*." + suffix)))
         if len(images) > 0:
             # set not empty yet, (re)process
             filenames = config.getstringlist("albumart", "filenames")

--- a/quodlibet/quodlibet/qltk/renamefiles.py
+++ b/quodlibet/quodlibet/qltk/renamefiles.py
@@ -175,15 +175,15 @@ class RenameFiles(Gtk.VBox):
         moveart_box = Gtk.VBox()
         self.moveart = ConfigCheckButton(
              _('_Move album art'),
-             "rename", "moveart", populate=True)
+             "rename", "move_art", populate=True)
         self.moveart.set_tooltip_text(
              _("See '[albumart] filenames' config entry " +
                "for image search strings"))
         self.moveart.show()
-        moveart_box.pack_start(self.moveart, False, True, 0)
+        moveart_box.pack_start(self.move_art, False, True, 0)
         self.moveart_overwrite = ConfigCheckButton(
              _('_Overwrite album art at target'),
-             "rename", "moveart_overwrite", populate=True)
+             "rename", "move_art_overwrite", populate=True)
         self.moveart_overwrite.show()
         moveart_box.pack_start(self.moveart_overwrite, False, True, 0)
         self.pack_start(moveart_box, False, True, 0)
@@ -192,7 +192,7 @@ class RenameFiles(Gtk.VBox):
         removeemptydirs_box = Gtk.VBox()
         self.removeemptydirs = ConfigCheckButton(
              _('_Remove empty directories'),
-             "rename", "removeemptydirs", populate=True)
+             "rename", "remove_empty_dirs", populate=True)
         self.removeemptydirs.show()
         removeemptydirs_box.pack_start(self.removeemptydirs, False, True, 0)
         self.pack_start(removeemptydirs_box, False, True, 0)
@@ -269,9 +269,9 @@ class RenameFiles(Gtk.VBox):
         was_changed = set()
         skip_all = False
         self.view.freeze_child_notify()
-        moveart = config.getboolean("rename", "moveart")
+        move_art = config.getboolean("rename", "move_art")
         moveart_sets = {}
-        removeemptydirs = config.getboolean("rename", "removeemptydirs")
+        remove_empty_dirs = config.getboolean("rename", "remove_empty_dirs")
 
         for entry in itervalues(model):
             if entry.new_name is None:
@@ -316,10 +316,10 @@ class RenameFiles(Gtk.VBox):
                 if resp != Gtk.ResponseType.OK and resp != RESPONSE_SKIP_ALL:
                     break
 
-            if moveart:
+            if move_art:
                 self.__moveart(moveart_sets, old_pathfile, new_pathfile, song)
 
-            if removeemptydirs:
+            if remove_empty_dirs:
                 path_old = os.path.dirname(old_pathfile)
                 if not os.listdir(path_old):
                     try:
@@ -363,7 +363,7 @@ class RenameFiles(Gtk.VBox):
                                                      "*." + suffix)))
         if len(images) > 0:
             # set not empty yet, (re)process
-            filenames = config.getstringlist("albumart", "filenames")
+            filenames = config.getstringlist("albumart", "search_filenames")
             moves = []
             for fn in filenames:
                 fn = os.path.join(path_old, fn)
@@ -378,7 +378,7 @@ class RenameFiles(Gtk.VBox):
                 elif fn in images and fn not in moves:
                     moves.append(fn)
             if len(moves) > 0:
-                overwrite = config.getboolean("rename", "moveart_overwrite")
+                overwrite = config.getboolean("rename", "move_art_overwrite")
                 for fnmove in moves:
                     try:
                         # existing files safeguarded until move successful,

--- a/quodlibet/quodlibet/qltk/renamefiles.py
+++ b/quodlibet/quodlibet/qltk/renamefiles.py
@@ -188,6 +188,15 @@ class RenameFiles(Gtk.VBox):
         moveart_box.pack_start(self.moveart_overwrite, False, True, 0)
         self.pack_start(moveart_box, False, True, 0)
 
+        # remove empty
+        removeemptydirs_box = Gtk.VBox()
+        self.removeemptydirs = ConfigCheckButton(
+             _('_Remove empty directories'),
+             "rename", "removeemptydirs", populate=True)
+        self.removeemptydirs.show()
+        removeemptydirs_box.pack_start(self.removeemptydirs, False, True, 0)
+        self.pack_start(removeemptydirs_box, False, True, 0)
+
         # Save button
         self.save = Button(_("_Save"), Icons.DOCUMENT_SAVE)
         self.save.show()
@@ -262,6 +271,7 @@ class RenameFiles(Gtk.VBox):
         self.view.freeze_child_notify()
         moveart = config.getboolean("rename", "moveart")
         moveart_sets = {}
+        removeemptydirs = config.getboolean("rename", "removeemptydirs")
 
         for entry in itervalues(model):
             if entry.new_name is None:
@@ -308,6 +318,15 @@ class RenameFiles(Gtk.VBox):
 
             if moveart:
                 self.__moveart(moveart_sets, old_pathfile, new_pathfile, song)
+
+            if removeemptydirs:
+                path_old = os.path.dirname(old_pathfile)
+                if not os.listdir(path_old):
+                    try:
+                        os.rmdir(path_old)
+                        print_d("Removed empty directory: %r" % path_old, self)
+                    except Exception:
+                        util.print_exc()
 
             if win.step():
                 break

--- a/quodlibet/quodlibet/qltk/renamefiles.py
+++ b/quodlibet/quodlibet/qltk/renamefiles.py
@@ -7,6 +7,8 @@
 
 import os
 import unicodedata
+import glob
+import shutil
 
 from gi.repository import Gtk, Gdk
 from senf import fsn2text, text2fsn
@@ -14,19 +16,23 @@ from senf import fsn2text, text2fsn
 import quodlibet
 from quodlibet import qltk
 from quodlibet import util
+from quodlibet import config
 from quodlibet import _
 
 from quodlibet.plugins import PluginManager
 from quodlibet.pattern import FileFromPattern
+from quodlibet.pattern import ArbitraryExtensionFileFromPattern
 from quodlibet.qltk._editutils import FilterPluginBox, FilterCheckButton
 from quodlibet.qltk._editutils import EditingPluginHandler
 from quodlibet.qltk.views import TreeViewColumn
 from quodlibet.qltk.cbes import ComboBoxEntrySave
+from quodlibet.qltk.ccb import ConfigCheckButton
 from quodlibet.qltk.models import ObjectStore
 from quodlibet.qltk import Icons, Button
 from quodlibet.qltk.wlw import WritingWindow
 from quodlibet.util import connect_obj, gdecode
 from quodlibet.util.path import strip_win32_incompat_from_path
+from quodlibet.util.dprint import print_d
 from quodlibet.compat import itervalues
 
 
@@ -124,6 +130,7 @@ class RenameFiles(Gtk.VBox):
     FILTERS = [SpacesToUnderscores, StripWindowsIncompat, StripDiacriticals,
                StripNonASCII, Lowercase]
     handler = RenameFilesPluginHandler()
+    IMAGE_EXTENSIONS = ['jpg', 'jpeg', 'png', 'bmp']
 
     @classmethod
     def init_plugins(cls):
@@ -163,6 +170,23 @@ class RenameFiles(Gtk.VBox):
         filter_box.connect("changed", self.__filter_changed)
         self.filter_box = filter_box
         self.pack_start(filter_box, False, True, 0)
+
+        # move art
+        moveart_box = Gtk.VBox()
+        self.moveart = ConfigCheckButton(
+             _('_Move album art'),
+             "rename", "moveart", populate=True)
+        self.moveart.set_tooltip_text(
+             _("See '[albumart] filenames' config entry " +
+               "for image search strings"))
+        self.moveart.show()
+        moveart_box.pack_start(self.moveart, False, True, 0)
+        self.moveart_overwrite = ConfigCheckButton(
+             _('_Overwrite album art at target'),
+             "rename", "moveart_overwrite", populate=True)
+        self.moveart_overwrite.show()
+        moveart_box.pack_start(self.moveart_overwrite, False, True, 0)
+        self.pack_start(moveart_box, False, True, 0)
 
         # Save button
         self.save = Button(_("_Save"), Icons.DOCUMENT_SAVE)
@@ -236,13 +260,20 @@ class RenameFiles(Gtk.VBox):
         was_changed = set()
         skip_all = False
         self.view.freeze_child_notify()
+        moveart = config.getboolean("rename", "moveart")
+        moveart_sets = {}
 
         for entry in itervalues(model):
-            song = entry.song
-            new_name = entry.new_name
-            old_name = entry.name
-            if new_name is None:
+            if entry.new_name is None:
                 continue
+            song = entry.song
+            old_name = entry.name
+            old_pathfile = song['~filename']
+            new_name = entry.new_name
+            new_pathfile = new_name if (
+                os.path.abspath(os.path.join(os.getcwd(), new_name)) !=
+                os.path.abspath(new_name)) else (
+                os.path.join(os.path.dirname(old_pathfile), new_name))
 
             try:
                 library.rename(song, text2fsn(new_name), changed=was_changed)
@@ -274,6 +305,10 @@ class RenameFiles(Gtk.VBox):
                 library.reload(song, changed=was_changed)
                 if resp != Gtk.ResponseType.OK and resp != RESPONSE_SKIP_ALL:
                     break
+
+            if moveart:
+                self.__moveart(moveart_sets, old_pathfile, new_pathfile, song)
+
             if win.step():
                 break
 
@@ -281,6 +316,70 @@ class RenameFiles(Gtk.VBox):
         win.destroy()
         library.changed(was_changed)
         self.save.set_sensitive(False)
+
+    def __moveart(self, art_sets, pathfile_old, pathfile_new, song):
+
+        path_old = os.path.dirname(os.path.realpath(pathfile_old))
+        path_new = os.path.dirname(os.path.realpath(pathfile_new))
+        if os.path.samefile(path_old, path_new):
+            return
+        if (path_old in art_sets.keys() and len(art_sets[path_old]) == 0):
+            return
+
+        # get art set for path
+        images = []
+        if path_old in art_sets.keys():
+            images = art_sets[path_old]
+        else:
+            art_sets[path_old] = images
+            # generate art set for path
+            for suffix in self.IMAGE_EXTENSIONS:
+                images.extend(glob.glob(os.path.join(path_old, "*." + suffix)))
+        if len(images) > 0:
+            # set not empty yet, (re)process
+            filenames = config.getstringlist("albumart", "filenames")
+            moves = []
+            for fn in filenames:
+                fn = os.path.join(path_old, fn)
+                if "<" in fn:
+                    # resolve path
+                    fnres = ArbitraryExtensionFileFromPattern(fn).format(song)
+                    if fnres in images and fnres not in moves:
+                        moves.append(fnres)
+                elif "*" in fn:
+                    moves.extend(f for f in glob.glob(fn)
+                                     if f in images and f not in moves)
+                elif fn in images and fn not in moves:
+                    moves.append(fn)
+            if len(moves) > 0:
+                overwrite = config.getboolean("rename", "moveart_overwrite")
+                for fnmove in moves:
+                    try:
+                        # existing files safeguarded until move successful,
+                        # then deleted if overwrite set
+                        fnmoveto = os.path.join(path_new,
+                                                os.path.split(fnmove)[1])
+                        fnmoveto_orig = ""
+                        if os.path.exists(fnmoveto):
+                            fnmoveto_orig = fnmoveto + ".orig"
+                            if not os.path.exists(fnmoveto_orig):
+                                os.rename(fnmoveto, fnmoveto_orig)
+                            else:
+                                suffix = 1
+                                while os.path.exists(fnmoveto_orig +
+                                                     "." + str(suffix)):
+                                    suffix += 1
+                                fnmoveto_orig = (fnmoveto_orig +
+                                                 "." + str(suffix))
+                                os.rename(fnmoveto, fnmoveto_orig)
+                        print_d("Renaming image %r to %r" %
+                                   (fnmove, fnmoveto), self)
+                        shutil.move(fnmove, fnmoveto)
+                        if overwrite and fnmoveto_orig:
+                            os.remove(fnmoveto_orig)
+                        images.remove(fnmove)
+                    except Exception:
+                        util.print_exc()
 
     def __preview(self, songs):
         model = self.view.get_model()

--- a/quodlibet/quodlibet/qltk/renamefiles.py
+++ b/quodlibet/quodlibet/qltk/renamefiles.py
@@ -347,7 +347,7 @@ class RenameFiles(Gtk.VBox):
         path_new = os.path.dirname(os.path.realpath(pathfile_new))
         if os.path.samefile(path_old, path_new):
             return
-        if (path_old in art_sets.keys() and len(art_sets[path_old]) == 0):
+        if (path_old in art_sets.keys() and not art_sets[path_old]):
             return
 
         # get art set for path
@@ -356,7 +356,7 @@ class RenameFiles(Gtk.VBox):
             images = art_sets[path_old]
         else:
             def glob_escape(s):
-                for c in ['[', '*', '?']:
+                for c in '[*?':
                     s = s.replace(c, '[' + c + ']')
                 return s
 
@@ -366,7 +366,7 @@ class RenameFiles(Gtk.VBox):
             for suffix in self.IMAGE_EXTENSIONS:
                 images.extend(glob.glob(os.path.join(path_old_escaped,
                                                      "*." + suffix)))
-        if len(images) > 0:
+        if images:
             # set not empty yet, (re)process
             filenames = config.getstringlist("albumart", "search_filenames")
             moves = []

--- a/quodlibet/tests/test_qltk_renamefiles.py
+++ b/quodlibet/tests/test_qltk_renamefiles.py
@@ -5,13 +5,17 @@
 # (at your option) any later version.
 
 import os
+import glob
+from gi.repository import Gtk, GObject
 
-from tests import TestCase
+from tests import TestCase, mkdtemp
 
 from senf import fsnative
 
+from quodlibet import config
+from quodlibet.formats import AudioFile
 from quodlibet.qltk.renamefiles import StripDiacriticals, StripNonASCII, \
-    Lowercase, SpacesToUnderscores, StripWindowsIncompat
+    Lowercase, SpacesToUnderscores, StripWindowsIncompat, RenameFiles
 from quodlibet.compat import text_type
 
 
@@ -110,3 +114,241 @@ class TLowercase(TFilter, TFilterMixin):
         v = self.c.filter(empty, fsnative(u"Foobar.BAZ"))
         self.failUnlessEqual(v, fsnative(u"foobar.baz"))
         self.failUnless(isinstance(v, fsnative))
+
+
+class Renamer(Gtk.EventBox):
+
+    __gsignals__ = {
+        'changed': (GObject.SignalFlags.RUN_LAST, None, (object,)),
+    }
+
+    def __init__(self, *args, **kwargs):
+        super(Renamer, self).__init__()
+
+        from quodlibet.library.libraries import SongLibrary
+
+        self.library = SongLibrary()
+        box = Gtk.EventBox()
+        self.renamer = RenameFiles(self.library, box)
+        box.add(self.renamer)
+
+        self.renamer.test_mode = True
+
+    def add_songs(self, songs):
+        self.library.add(songs)
+
+    def rename(self, pattern, songs):
+        self.renamer.combo.get_child().set_text(pattern)
+        self.renamer._preview(songs)
+        self.renamer._rename(self.library)
+
+
+class Song(AudioFile):
+    """A mock AudioFile belong to one of three albums,
+    based on a single number"""
+    def __init__(self, target, num):
+        super(Song, self).__init__()
+
+        self["title"] = "title_%d" % (num + 1)
+        self["artist"] = "artist"
+        self["album"] = "album"
+        self["labelid"] = self["album"]
+        self["~filename"] = \
+            fsnative(os.path.join(target, self["title"] + ".mp3"))
+
+
+class TMoveArt(TestCase):
+
+    Kind = Renamer
+
+    def setUp(self):
+        self.renamer = self.Kind()
+
+    def tearDown(self):
+        self.renamer.destroy()
+
+    def reset_environment(self):
+        config.init()
+        self.root_path = mkdtemp()
+        self.filenames = \
+            ['cover.jpg', 'info.jpg', 'title.jpg', 'title2.jpg']
+
+    def generate_songs(self, path, quantity):
+        return list(map(lambda num, path=path:
+                            Song(path, num), range(quantity)))
+
+    def generate_files(self, path, filenames):
+        pathfiles = []
+        for f in filenames:
+            pathfile = os.path.join(path, f)
+            if not os.path.isdir(os.path.dirname(pathfile)):
+                os.makedirs(os.path.dirname(pathfile))
+            with open(pathfile, "w") as fh:
+                fh.write(f)
+            pathfiles.append(pathfile)
+
+        return pathfiles
+
+    def art_set(self, path):
+        return self.generate_files(path, self.filenames)
+
+    def song_set(self, path):
+        songs = self.generate_songs(path, 1)
+        return (self.generate_files(path,
+            list(map(lambda song: os.path.basename(song['~filename']),
+                         songs))), songs)
+
+    def source_target(self, root_path, album, artist):
+        return (os.path.join(root_path, album, artist),
+                os.path.join(root_path + "_2", album, artist))
+
+    def moveart_set(self, artist='artist', album='album',
+                     source=None, target=None, file_pattern="<title>"):
+        source2, target2 = \
+            self.source_target(self.root_path, artist, album)
+        if not source:
+            source = source2
+        if not target:
+            target = target2
+        self.art_set(source)
+        song_files, songs = self.song_set(source)
+        self.renamer.add_songs(songs)
+        pattern = os.path.join(target, file_pattern)
+        self.renamer.rename(pattern, songs)
+        return (source, target)
+
+    def test_moveart_no_move(self):
+        self.reset_environment()
+
+        # move art not set, no art files should move
+        count_expected = 0
+        source, target = self.moveart_set()
+        target_files = glob.glob(os.path.join(target, '*.jpg'))
+        count_target = len(target_files)
+        self.failUnlessEqual(count_target, count_expected)
+
+    def test_moveart_move_defaults(self):
+        self.reset_environment()
+        config.set("rename", "move_art", True)
+
+        # single match for default search_filenames
+        # "cover.jpg,folder.jpg,.folder.jpg"
+        count_expected = 1
+        source, target = self.moveart_set()
+        target_files = glob.glob(os.path.join(target, '*.jpg'))
+        count_target = len(target_files)
+        self.failUnlessEqual(count_target, count_expected)
+
+    def test_moveart_move_all_wildcard(self):
+        self.reset_environment()
+        config.set("rename", "move_art", True)
+        config.set("albumart", "search_filenames", "*.jpg")
+
+        # wildcard added to search_filenames for catchall"
+        count_expected = 4
+        source, target = self.moveart_set()
+        target_files = glob.glob(os.path.join(target, '*.jpg'))
+        count_target = len(target_files)
+        self.failUnlessEqual(count_target, count_expected)
+
+    def test_moveart_move_escape_glob_characters(self):
+        self.reset_environment()
+        config.set("rename", "move_art", True)
+        config.set("albumart", "search_filenames", "*.jpg")
+        self.filenames = ['artist_[x].jpg']
+
+        # test whether we cope with non-escaped special glob characters"
+        count_expected = 1
+        source, target = self.moveart_set()
+        target_files = glob.glob(os.path.join(target, '*.jpg'))
+        count_target = len(target_files)
+        self.failUnlessEqual(count_target, count_expected)
+
+    def test_moveart_relative_pattern(self):
+        self.reset_environment()
+        config.set("rename", "move_art", True)
+        config.set("albumart", "search_filenames", "*.jpg")
+
+        # should be a no-op"
+        count_expected = 4
+        source, target = self.moveart_set(target='')
+        target_files = glob.glob(os.path.join(target, '*.jpg'))
+        count_target = len(target_files)
+        self.failUnlessEqual(count_target, count_expected)
+
+    def test_moveart_selective_pattern(self):
+        self.reset_environment()
+        config.set("rename", "move_art", True)
+        config.set("albumart", "search_filenames", "<artist>.jpg")
+        self.filenames = ['cover.jpg', 'artist.jpg']
+
+        # should be a no-op
+        count_expected = 1
+        source, target = self.moveart_set(target='')
+        target_files = glob.glob(os.path.join(target, '*.jpg'))
+        count_target = len(target_files)
+        self.failUnlessEqual(count_target, count_expected)
+
+    def test_moveart_overwrite(self):
+        self.reset_environment()
+        config.set("rename", "move_art", True)
+        config.set("albumart", "search_filenames", "*.jpg")
+        self.filenames = ['art.jpg']
+
+        # move set
+        source, target = self.moveart_set()
+        # fail as target audio already exists
+        self.assertRaises(Exception, self.moveart_set())
+
+        # remove audio
+        os.remove(os.path.join(target, 'title_1.mp3'))
+
+        # move exising target art to .orig suffix
+        count_expected = 2
+        self.moveart_set()
+        target_files = glob.glob(os.path.join(target, '*jpg*'))
+        count_target = len(target_files)
+        self.failUnlessEqual(count_target, count_expected)
+
+        # remove audio
+        os.remove(os.path.join(target, 'title_1.mp3'))
+        os.remove(os.path.join(target, 'art.jpg.orig'))
+        config.set("rename", "move_art_overwrite", True)
+
+        # overwrite existing target arg
+        count_expected = 1
+        self.moveart_set()
+        target_files = glob.glob(os.path.join(target, '*jpg*'))
+        count_target = len(target_files)
+        self.failUnlessEqual(count_target, count_expected)
+
+    def test_moveart_multi_source(self):
+        self.reset_environment()
+        config.set("rename", "move_art", True)
+        config.set("albumart", "search_filenames", "*.jpg")
+
+        source, target = \
+            self.source_target(self.root_path, 'artist', 'album')
+        source2, target2 = \
+            self.source_target(self.root_path, 'artist', 'album2')
+
+        self.filenames = ['art.jpg']
+        self.art_set(source)
+        self.filenames = ['art2.jpg']
+        self.art_set(source2)
+
+        song_files, songs = self.song_set(source)
+        song_files2, songs2 = self.song_set(source2)
+
+        self.renamer.add_songs(songs + songs2)
+
+        # avoid audio file clashes
+        pattern = os.path.join(target, '[<album>] artist - <title>')
+        self.renamer.rename(pattern, songs + songs2)
+
+        # album art sets merged
+        count_expected = 2
+        self.moveart_set()
+        target_files = glob.glob(os.path.join(target, '*.jpg'))
+        count_target = len(target_files)
+        self.failUnlessEqual(count_target, count_expected)


### PR DESCRIPTION
Hi,

**Here I aim to improve the file renaming experience for users with external album art**

I've attempted to move all 'relevant' album art from a music file's source directory to its target directory when it is renamed. Which art is moved is dependent on the '[albumart] -> filenames' config option which allows for wildcards and quodlibet constants, e.g. **front.jpg,back.jpg,cd\*.jpg,\<artist\>.jpg** via a fairly basic priority first matters algorithm. Although no doubt there will be situations / setups that this change won't fully support / handle, my thought is certainly 'anything is better than nothing', and aside from the algorithm not looking in subfolders, I struggle to see much that the flexibility of priority/wildcards/\<constants\> couldn't handle.

commit: move album art when renaming [#237]

image: [additional rename options](http://picpaste.com/00e9db5a6b0a9d35d9e8e30acb4d1206.png)
_**note:**_ for this patch, in attempt to find corner cases I tested:
-with/without custom config entries
-rel/abs target paths
-target with/without audio
-target with/without images
-multiple art files in source
-multiple source folders with art
_**note2:**_ for consideration:
-use of shutil (uses 'copy2'). safer but issues with file attribute changes
-rather trivial attempt to ease scaling with 'art sets' dict
-no testing in either python3 or non gnu/linux environments at all sorry!
_**note3:**_ limitations:
-no support for image names specified as <b>both</b> template and wildcard .e.g. \<artist\>*.jpg

**With** the changes, I **don't** have to manually navigate to folders and construct a move command for the album art files ..which is very painful for me! ..**without**, I **do** have to. That is why I wish this to be included in quodlibet.

**Further implementation notes:**
-Everywhere possible I've left defaults as they were and disabled the additional features.

**Configs**
-My current config mods, not required in any way, but as an example..

[albumart]
filenames = front.jpg,back.jpg,cd*.jpg,\<artist\>.jpg

[rename]
moveart = true
moveart_overwrite = true
removeemptydirs = true