### PR TITLE
Set the library parameter of new playlists (fixes #2564)

### DIFF
--- a/quodlibet/quodlibet/browsers/playlists/main.py
+++ b/quodlibet/quodlibet/browsers/playlists/main.py
@@ -213,7 +213,7 @@ class PlaylistsBrowser(Browser, DisplayPatternMixin):
 
     def __configure_buttons(self, library):
         new_pl = qltk.Button(_("_New"), Icons.DOCUMENT_NEW, Gtk.IconSize.MENU)
-        new_pl.connect('clicked', self.__new_playlist)
+        new_pl.connect('clicked', self.__new_playlist, library)
         import_pl = qltk.Button(_("_Import"), Icons.LIST_ADD,
                                 Gtk.IconSize.MENU)
         import_pl.connect('clicked', self.__import, library)
@@ -537,8 +537,8 @@ class PlaylistsBrowser(Browser, DisplayPatternMixin):
         text = self.get_filter_text()
         config.set("browsers", "query_text", text)
 
-    def __new_playlist(self, activator):
-        playlist = FileBackedPlaylist.new(PLAYLISTS)
+    def __new_playlist(self, activator, library):
+        playlist = FileBackedPlaylist.new(PLAYLISTS, library=library)
         self.model.append(row=[playlist])
         self._select_playlist(playlist, scroll=True)
 

--- a/quodlibet/quodlibet/browsers/playlists/main.py
+++ b/quodlibet/quodlibet/browsers/playlists/main.py
@@ -615,7 +615,8 @@ class PlaylistsBrowser(Browser, DisplayPatternMixin):
             playlist = model[iter][0]
             playlist[:] = songs
         elif songs:
-            playlist = FileBackedPlaylist.from_songs(PLAYLISTS, songs)
+            playlist = FileBackedPlaylist.from_songs(PLAYLISTS, songs,
+                                                     self.__class__.library)
             GLib.idle_add(self._select_playlist, playlist)
         if playlist:
             self.changed(playlist, refresh=False)

--- a/quodlibet/quodlibet/browsers/playlists/main.py
+++ b/quodlibet/quodlibet/browsers/playlists/main.py
@@ -616,7 +616,7 @@ class PlaylistsBrowser(Browser, DisplayPatternMixin):
             playlist[:] = songs
         elif songs:
             playlist = FileBackedPlaylist.from_songs(PLAYLISTS, songs,
-                                                     self.__class__.library)
+                                                     self.library)
             GLib.idle_add(self._select_playlist, playlist)
         if playlist:
             self.changed(playlist, refresh=False)


### PR DESCRIPTION
This pull request fixes issue #2564.

The problem was that the library was not passed to `FileBackedPlaylist.new` when a new playlist is created, and thus the library could not be updated in `FileBackedPlaylist.extend`.
