### PR TITLE
ViewLyrics: fix issue when enabling the plugin

### DIFF
--- a/quodlibet/quodlibet/ext/events/viewlyrics.py
+++ b/quodlibet/quodlibet/ext/events/viewlyrics.py
@@ -53,8 +53,8 @@ class ViewLyrics(EventPlugin, UserInterfacePlugin):
         self.textview.show()
 
         self.scrolled_window.show()
-        self.plugin_on_song_started(app.player.info)
         self._sig = None
+        self.plugin_on_song_started(app.player.info)
 
     def create_sidebar(self):
         vbox = Gtk.VBox(margin=0)


### PR DESCRIPTION
### Steps to reproduce

- if the viewlyrics plugin is enabled, disable it and restart quodlibet
- enable the viewlyrics plugin. The following error appears in the logs:
```
D: 11.519: PluginManager.enable: Enable 'View Lyrics'
D: 11.531: ViewLyrics.plugin_on_song_started: Looking for lyrics for [...]
E: 11.533: PluginManager.enable:
    Traceback (most recent call last):
      File ".../quodlibet/quodlibet/quodlibet/plugins/__init__.py", line 359, in enable
        obj.enabled()
      File ".../quodlibet/quodlibet/quodlibet/ext/events/viewlyrics.py", line 56, in enabled
        self.plugin_on_song_started(app.player.info)
      File ".../quodlibet/quodlibet/quodlibet/ext/events/viewlyrics.py", line 93, in plugin_on_song_started
        if self._sig:
    AttributeError: 'ViewLyrics' object has no attribute '_sig'
D: 11.534: UserInterfacePluginHandler.plugin_enable: Enabling sidebar for <class 'quodlibet.fake.plugins.viewlyrics.ViewLyrics'>
```
- start playing a song. An error dialog appears, with the same error:
```
D: 21.554: ViewLyrics.plugin_on_song_started: Looking for lyrics for [...]
E: 21.555: plugins.events.__invoke: Error during plugin_on_song_started on <class 'quodlibet.fake.plugins.viewlyrics.ViewLyrics'>
E: 21.557: errorreport.main.errorhook:
    Traceback (most recent call last):
      File ".../quodlibet/quodlibet/quodlibet/plugins/events.py", line 141, in __invoke
        handler(*args)
      File ".../quodlibet/quodlibet/quodlibet/ext/events/viewlyrics.py", line 93, in plugin_on_song_started
        if self._sig:
    AttributeError: 'ViewLyrics' object has no attribute '_sig'
```

This pull requests fixes this issue by declaring the `_sig` attribute before calling `plugin_on_song_started` in the `enabled` method.

PS: I'm not sure what your usual workflow is, should I have opened an issue before submitting this PR?