### PR TITLE
make 'lyric_filename()' search harder

### DIFF
--- a/quodlibet/quodlibet/formats/_audio.py
+++ b/quodlibet/quodlibet/formats/_audio.py
@@ -559,7 +559,7 @@ class AudioFile(dict, ImageContainer):
             rpf = RootPathFile(root, pathfile)
             expanded.append(rpf)
             if not os.path.exists(pathfile) and os.name == "nt":
-                # add a special character encoded version
+                # prioritise a special character encoded version
                 #
                 # most 'alien' chars are supported for 'nix fs paths, and we
                 # only pass the proposed path through 'escape_filename' (which
@@ -569,7 +569,7 @@ class AudioFile(dict, ImageContainer):
                 # insensitive. clearly this is not biting anyone though (yet!)
                 pathfile = os.path.sep.join([rpf.root, rpf.end_escaped])
                 rpf = RootPathFile(rpf.root, pathfile)
-                expanded.append(rpf)
+                expanded.insert(len(expanded) - 1, rpf)
             return expanded
 
         def sanitise(sep, parts):

--- a/quodlibet/quodlibet/formats/_audio.py
+++ b/quodlibet/quodlibet/formats/_audio.py
@@ -543,7 +543,34 @@ class AudioFile(dict, ImageContainer):
         file. User defined '[memory] lyric_rootpaths' and
         '[memory] lyric_filenames' matches take precedence"""
 
-        from quodlibet.pattern import ArbitraryExtensionFileFromPattern
+        from quodlibet.pattern \
+            import ArbitraryExtensionFileFromPattern as expand_patterns
+
+        rx_params = re.compile('[^\\\]<[^' + re.escape(os.sep) + ']*[^\\\]>')
+
+        def expand_pathfile(rpf):
+            """Return the expanded RootPathFile"""
+            expanded = []
+            root = expanduser(rpf.root)
+            pathfile = expanduser(rpf.pathfile)
+            if rx_params.search(pathfile):
+                root = expand_patterns(root).format(self)
+                pathfile = expand_patterns(pathfile).format(self)
+            rpf = RootPathFile(root, pathfile)
+            expanded.append(rpf)
+            if not os.path.exists(pathfile) and os.name == "nt":
+                # add a special character encoded version
+                #
+                # most 'alien' chars are supported for 'nix fs paths, and we
+                # only pass the proposed path through 'escape_filename' (which
+                # apparently doesn't respect case) if we don't care about case!
+                #
+                # FIX: assumes 'nix build used on a case-sensitive fs, nt case
+                # insensitive. clearly this is not biting anyone though (yet!)
+                pathfile = os.path.sep.join([rpf.root, rpf.end_escaped])
+                rpf = RootPathFile(rpf.root, pathfile)
+                expanded.append(rpf)
+            return expanded
 
         def sanitise(sep, parts):
             """Return a santisied version of a path's parts"""
@@ -586,33 +613,15 @@ class AudioFile(dict, ImageContainer):
         # expand each raw pathfile in turn and test for existence
         match_ = ""
         pathfiles_expanded = OrderedDict()
-        rx_params = re.compile('[^\\\]<[^' + re.escape(os.sep) + ']*[^\\\]>')
-        expand_patterns = ArbitraryExtensionFileFromPattern
         for pf, rpf in pathfiles.items():
-            root = expanduser(rpf.root)
-            pathfile = expanduser(pf)
-            if rx_params.search(pathfile):
-                root = expand_patterns(root).format(self)
-                pathfile = expand_patterns(pathfile).format(self)
-            # resolved as late as possible
-            pathfiles_expanded[pathfile] = RootPathFile(root, pathfile)
-            if os.path.exists(pathfile):
-                match_ = pathfile
-                break
-            elif os.name == "nt":
-                # try a special character encoded version
-                #
-                # only pass the proposed path through 'escape_filename' (which
-                # apparently doesn't respect case) if we don't care about case.
-                # most 'alien' chars are supported for 'nix fs paths too
-                #
-                # FIX: assumes 'nix build used on a case-sensitive fs, nt case
-                # insensitive. clearly this is not biting anyone though (yet!)
-                pathfile = os.path.sep.join([root, rpf.end_escaped])
-                pathfiles_expanded[pathfile] = RootPathFile(root, pathfile)
+            for rpf in expand_pathfile(rpf):  # resolved as late as possible
+                pathfile = rpf.pathfile
+                pathfiles_expanded[pathfile] = rpf
                 if os.path.exists(pathfile):
                     match_ = pathfile
                     break
+            if match_ != "":
+                break
 
         if not match_:
             # search even harder!

--- a/quodlibet/quodlibet/formats/_audio.py
+++ b/quodlibet/quodlibet/formats/_audio.py
@@ -639,6 +639,7 @@ class AudioFile(dict, ImageContainer):
                 for path_ext in paths_mod_ext:
                     if os.path.exists(path_ext):
                         # persistence has paid off!
+                        #print_d("extended search match!")
                         match_ = path_ext
                         break
                 if match_:

--- a/quodlibet/quodlibet/formats/_audio.py
+++ b/quodlibet/quodlibet/formats/_audio.py
@@ -546,8 +546,8 @@ class AudioFile(dict, ImageContainer):
         from quodlibet.pattern import ArbitraryExtensionFileFromPattern
 
         def sanitise(sep, parts):
-            return sep.join(list(map(lambda s: s.replace(u'/', u'')[:128],
-                                     parts)))
+            return sep.join(part.replace(u'/', u'')[:128]
+                                for part in parts)
 
         # setup defaults (user-defined take precedence)
         # root search paths
@@ -628,9 +628,8 @@ class AudioFile(dict, ImageContainer):
                 extra_extensions = [x for x in lyric_extensions if x != ext]
 
                 # join valid new extensions to pathfile stub and return
-                return list(map(lambda ext: '.'.join([path, ext])
-                                                if ext else path,
-                                      extra_extensions))
+                return ['.'.join([path, ext]) if ext else path
+                           for ext in extra_extensions]
 
             # look for a match by modifying the extension for each of the
             # (now fully resolved) 'pathfiles_expanded' search items

--- a/quodlibet/quodlibet/formats/_audio.py
+++ b/quodlibet/quodlibet/formats/_audio.py
@@ -14,6 +14,7 @@
 import os
 import shutil
 import time
+from collections import OrderedDict
 
 from senf import fsn2uri, fsnative, fsn2text, devnull, bytes2fsn, path2fsn
 
@@ -537,24 +538,77 @@ class AudioFile(dict, ImageContainer):
 
     @property
     def lyric_filename(self):
-        """Returns the (potential) lyrics filename for this file"""
+        """Returns the validated, or default, lyrics filename for this
+        file. User defined '[memory] lyric_rootpaths' and
+        '[memory] lyric_filenames' matches take precedent"""
 
-        filename = self.comma("title").replace(u'/', u'')[:128] + u'.lyric'
-        sub_dir = ((self.comma("lyricist") or self.comma("artist"))
-                  .replace(u'/', u'')[:128])
+        from quodlibet.pattern import ArbitraryExtensionFileFromPattern
 
-        if os.name == "nt":
-            # this was added at a later point. only use escape_filename here
-            # to keep the linux case the same as before
-            filename = escape_filename(filename)
-            sub_dir = escape_filename(sub_dir)
-        else:
-            filename = fsnative(filename)
-            sub_dir = fsnative(sub_dir)
+        lyric_paths = \
+            config.getstringlist("memory", "lyric_rootpaths", [])
+        # add default
+        lyric_paths.append(u'~/.lyrics')
+        lyric_filenames = \
+            config.getstringlist("memory", "lyric_filenames", [])
+        # add defaults
+        lyric_filenames.append(
+            (self.comma("lyricist") or self.comma("artist"))
+            .replace(u'/', u'')[:128] + os.sep +
+            self.comma("title").replace(u'/', u'')[:128] + u'.lyric')
+        lyric_filenames.append(
+            (self.comma("lyricist") or self.comma("artist"))
+            .replace(u'/', u'')[:128] + ' - ' +
+            self.comma("title").replace(u'/', u'')[:128] + u'.lyric')
 
-        path = os.path.join(
-            expanduser(fsnative(u"~/.lyrics")), sub_dir, filename)
-        return path
+        # generate all paths
+        pathfiles = OrderedDict()
+        pathfiles_expanded = OrderedDict()
+        for p in lyric_paths:
+            for f in lyric_filenames:
+                pathfile = ""
+                if os.name == "nt":
+                    # this was added at a later point. only use
+                    # escape_filename here to keep the linux case
+                    # the same as before
+                    pathfile = \
+                        os.path.join(p, os.path.dirname(f),
+                                     escape_filename(os.path.basename(f)))
+                else:
+                    pathfile = \
+                        os.path.join(p, os.path.dirname(f),
+                                    fsnative(os.path.basename(f)))
+                if not pathfile in pathfiles:
+                    pathfiles[pathfile] = pathfile
+
+        #print_d("looking for lyrics files:\n%s" % '\n'.join(pathfiles.keys()))
+
+        match_ = ""
+        for pathfile in pathfiles.keys():
+            path = expanduser(pathfile)
+            if '<' in path:
+                path = ArbitraryExtensionFileFromPattern(pathfile).format(self)
+            pathfiles_expanded[path] = path  # resolved as late as possible
+            if os.path.exists(path):
+                match_ = path
+                break
+
+        if not match_:
+            # look at modified extensions
+            lyric_extensions = ('lyric', 'lyrics', '', 'txt')
+            for pathfile in pathfiles_expanded.keys():
+                ext = os.path.splitext(pathfile)[1][1:]
+                path = pathfile[:-1 * len(ext)].strip('.') if ext else pathfile
+                for ext2 in lyric_extensions:
+                    if ext2 == ext:
+                        continue
+                    path_ext = '.'.join([path, ext2]) if ext2 else path
+                    if os.path.exists(path_ext):
+                        match_ = path_ext
+                        break
+                if match_:
+                    break
+
+        return match_ if match_ else list(pathfiles_expanded.keys())[0]
 
     @property
     def has_rating(self):

--- a/quodlibet/quodlibet/formats/_audio.py
+++ b/quodlibet/quodlibet/formats/_audio.py
@@ -25,6 +25,7 @@ from quodlibet import config
 from quodlibet.util.path import mkdir, mtime, expanduser, normalize_path, \
                                 ismount, get_home_dir, RootPathFile
 from quodlibet.util.string import encode, decode, isascii
+from quodlibet.util.environment import is_windows
 
 from quodlibet.util import iso639
 from quodlibet.util import human_sort_key as human, capitalize
@@ -558,7 +559,7 @@ class AudioFile(dict, ImageContainer):
                 pathfile = expand_patterns(pathfile).format(self)
             rpf = RootPathFile(root, pathfile)
             expanded.append(rpf)
-            if not os.path.exists(pathfile) and os.name == "nt":
+            if not os.path.exists(pathfile) and is_windows():
                 # prioritise a special character encoded version
                 #
                 # most 'alien' chars are supported for 'nix fs paths, and we

--- a/quodlibet/quodlibet/formats/_audio.py
+++ b/quodlibet/quodlibet/formats/_audio.py
@@ -544,6 +544,10 @@ class AudioFile(dict, ImageContainer):
 
         from quodlibet.pattern import ArbitraryExtensionFileFromPattern
 
+        def sanitise(sep, parts):
+            return sep.join(list(map(lambda s: s.replace(u'/', u'')[:128],
+                                     parts)))
+
         lyric_paths = \
             config.getstringlist("memory", "lyric_rootpaths", [])
         # add default
@@ -552,13 +556,13 @@ class AudioFile(dict, ImageContainer):
             config.getstringlist("memory", "lyric_filenames", [])
         # add defaults
         lyric_filenames.append(
-            (self.comma("lyricist") or self.comma("artist"))
-            .replace(u'/', u'')[:128] + os.sep +
-            self.comma("title").replace(u'/', u'')[:128] + u'.lyric')
+            sanitise(os.sep, [(self.comma("lyricist") or
+                              self.comma("artist")),
+                              self.comma("title")]) + u'.lyric')
         lyric_filenames.append(
-            (self.comma("lyricist") or self.comma("artist"))
-            .replace(u'/', u'')[:128] + ' - ' +
-            self.comma("title").replace(u'/', u'')[:128] + u'.lyric')
+            sanitise(' - ', [(self.comma("lyricist") or
+                             self.comma("artist")),
+                             self.comma("title")]) + u'.lyric')
 
         # generate all paths
         pathfiles = OrderedDict()

--- a/quodlibet/quodlibet/formats/_audio.py
+++ b/quodlibet/quodlibet/formats/_audio.py
@@ -12,6 +12,7 @@
 # more readable, unless they're also faster.
 
 import os
+import re
 import shutil
 import time
 from collections import OrderedDict
@@ -587,9 +588,10 @@ class AudioFile(dict, ImageContainer):
         #print_d("looking for lyrics files:\n%s" % '\n'.join(pathfiles.keys()))
 
         match_ = ""
+        rx_params = re.compile('[^\\\]<[^' + re.escape(os.sep) + ']*[^\\\]>')
         for pathfile in pathfiles.keys():
             path = expanduser(pathfile)
-            if '<' in path:
+            if rx_params.search(path):
                 path = ArbitraryExtensionFileFromPattern(pathfile).format(self)
             pathfiles_expanded[path] = path  # resolved as late as possible
             if os.path.exists(path):

--- a/quodlibet/quodlibet/formats/_audio.py
+++ b/quodlibet/quodlibet/formats/_audio.py
@@ -553,8 +553,10 @@ class AudioFile(dict, ImageContainer):
         # root search paths
         lyric_paths = \
             config.getstringlist("memory", "lyric_rootpaths", [])
-        # ensure a default path
+        # ensure default paths
         lyric_paths.append(os.path.join(get_home_dir(), ".lyrics"))
+        lyric_paths.append(
+            os.path.join(os.path.dirname(self.comma('~filename'))))
         # search pathfile names
         lyric_filenames = \
             config.getstringlist("memory", "lyric_filenames", [])

--- a/quodlibet/quodlibet/formats/_audio.py
+++ b/quodlibet/quodlibet/formats/_audio.py
@@ -546,7 +546,8 @@ class AudioFile(dict, ImageContainer):
         from quodlibet.pattern import ArbitraryExtensionFileFromPattern
 
         def sanitise(sep, parts):
-            return sep.join(part.replace(u'/', u'')[:128]
+            """Return a santisied version of a path's parts"""
+            return sep.join(part.replace(os.path.sep, u'')[:128]
                                 for part in parts)
 
         # setup defaults (user-defined take precedence)

--- a/quodlibet/quodlibet/formats/_audio.py
+++ b/quodlibet/quodlibet/formats/_audio.py
@@ -23,7 +23,7 @@ from quodlibet import _, print_d
 from quodlibet import util
 from quodlibet import config
 from quodlibet.util.path import mkdir, mtime, expanduser, \
-    normalize_path, escape_filename, ismount
+    normalize_path, escape_filename, ismount, get_home_dir
 from quodlibet.util.string import encode, decode, isascii
 
 from quodlibet.util import iso639
@@ -554,7 +554,7 @@ class AudioFile(dict, ImageContainer):
         lyric_paths = \
             config.getstringlist("memory", "lyric_rootpaths", [])
         # ensure a default path
-        lyric_paths.append(u'~/.lyrics')
+        lyric_paths.append(os.path.join(get_home_dir(), ".lyrics"))
         # search pathfile names
         lyric_filenames = \
             config.getstringlist("memory", "lyric_filenames", [])

--- a/quodlibet/quodlibet/util/path.py
+++ b/quodlibet/quodlibet/util/path.py
@@ -472,8 +472,8 @@ class RootPathFile:
 
     @property
     def end_escaped(self):
-        escaped = list(map(lambda part: escape_filename(part),
-                           self.end.split(os.path.sep)))
+        escaped = [escape_filename(part)
+                    for part in self.end.split(os.path.sep)]
         return os.path.sep.join(escaped)
 
     @property

--- a/quodlibet/quodlibet/util/path.py
+++ b/quodlibet/quodlibet/util/path.py
@@ -481,7 +481,7 @@ class RootPathFile:
         return os.path.sep.join([self.root, self.end_escaped])
 
     @property
-    def is_valid(self):
+    def valid(self):
         valid = True
         if os.path.exists(self.pathfile):
             return valid

--- a/quodlibet/tests/test_formats__audio.py
+++ b/quodlibet/tests/test_formats__audio.py
@@ -18,6 +18,7 @@ from quodlibet.formats import decode_value, MusicFile, FILESYSTEM_TAGS
 from quodlibet.util.tags import _TAGS as TAGS
 from quodlibet.util.path import normalize_path, mkdir, get_home_dir, unquote, \
                                 escape_filename, RootPathFile
+from quodlibet.util.environment import is_windows
 
 from .helper import temp_filename
 
@@ -539,7 +540,7 @@ class TAudioFile(TestCase):
             root = os.path.dirname(filename)
 
             path_variants = \
-                ['<oldskool>'] if (os.name == "nt") \
+                ['<oldskool>'] if is_windows() \
                                else ['\<artist\>', '\<artist>', '<artist\>']
             for path_variant in path_variants:
                 s['artist'] = path_variant + " SpongeBob SquarePants"

--- a/quodlibet/tests/test_formats__audio.py
+++ b/quodlibet/tests/test_formats__audio.py
@@ -546,9 +546,9 @@ class TAudioFile(TestCase):
                 s['artist'] = path_variant + " SpongeBob SquarePants"
                 parts = [root, s["artist"] + " - " + s["title"] + ".lyric"]
                 rpf = RootPathFile(root, os.path.sep.join(parts))
-                if not rpf.is_valid:
+                if not rpf.valid:
                     rpf = RootPathFile(rpf.root, rpf.pathfile_escaped)
-                self.assertTrue(rpf.is_valid,
+                self.assertTrue(rpf.valid,
                                 "even escaped target file is not valid")
                 with io.open(rpf.pathfile, "w", encoding='utf-8') as f:
                     f.write(u"")
@@ -575,15 +575,15 @@ class TAudioFile(TestCase):
             # ensure valid dir existence
             for p in rpf.end.split(os.path.sep)[:-1]:
                 rootp = os.path.sep.join([root, p])
-                if not RootPathFile(root, rootp).is_valid:
+                if not RootPathFile(root, rootp).valid:
                     rootp = os.path.sep.join([root, escape_filename(p)])
-                self.assertTrue(RootPathFile(root, rootp).is_valid,
+                self.assertTrue(RootPathFile(root, rootp).valid,
                                 "even escaped target dir part is not valid!")
                 if not os.path.exists(rootp):
                     mkdir(rootp)
                     rmdirs.append(rootp)
 
-            if not rpf.is_valid:
+            if not rpf.valid:
                 rpf = RootPathFile(rpf.root, rpf.pathfile_escaped)
 
             with io.open(rpf.pathfile, "w", encoding='utf-8') as f:

--- a/quodlibet/tests/test_formats__audio.py
+++ b/quodlibet/tests/test_formats__audio.py
@@ -411,6 +411,11 @@ class TAudioFile(TestCase):
 
     def test_lyric_filename_search(self):
 
+        def assertEqual(a, b):
+            # don't truncate the bloody error message..
+            msg_fail = str("item1: %s !=\nitem2: %s" % (a, b))
+            self.assertEqual(a, b, msg_fail)
+
         with temp_filename() as filename:
             s = AudioFile()
             s.sanitize(filename)
@@ -428,7 +433,7 @@ class TAudioFile(TestCase):
             fp_searched = unquote(s.lyric_filename)
             os.remove(fp)
             os.rmdir(p)
-            self.failUnlessEqual(fp_searched, fp)
+            assertEqual(fp_searched, fp)
 
             # test built-in default local path
             root = os.path.dirname(filename)
@@ -437,7 +442,7 @@ class TAudioFile(TestCase):
                 f.write(u"")
             fp_searched = unquote(s.lyric_filename)
             os.remove(fp)
-            self.failUnlessEqual(fp_searched, fp)
+            assertEqual(fp_searched, fp)
 
             # custom lyrics file location / naming
             config.set("memory", "lyric_filenames",
@@ -448,7 +453,7 @@ class TAudioFile(TestCase):
             # test custom default (fnf fallback!)
             fp = os.path.join(root, artist + ".-." + title)
             fp_searched = unquote(s.lyric_filename)
-            self.failUnlessEqual(fp_searched, fp)
+            assertEqual(fp_searched, fp)
 
             # test user defined
             fp = os.path.join(root, artist + " - " + title + ".lyric")
@@ -456,7 +461,7 @@ class TAudioFile(TestCase):
                 f.write(u"")
             fp_searched = unquote(s.lyric_filename)
             os.remove(fp)
-            self.failUnlessEqual(fp_searched, fp)
+            assertEqual(fp_searched, fp)
 
             # test order priority
             root2 = os.path.join(get_home_dir(), ".lyrics") # built-in default
@@ -473,7 +478,7 @@ class TAudioFile(TestCase):
             os.remove(fp2)
             os.rmdir(p2)
             os.remove(fp)
-            self.failUnlessEqual(fp_searched, fp)
+            assertEqual(fp_searched, fp)
 
             # test modified extension fallback search
             fp = os.path.join(root, artist + " - " + title + ".txt")
@@ -481,7 +486,7 @@ class TAudioFile(TestCase):
                 f.write(u"")
             fp_searched = unquote(s.lyric_filename)
             os.remove(fp)
-            self.failUnlessEqual(fp_searched, fp)
+            assertEqual(fp_searched, fp)
 
             # reset to pickup default (no <attr>) templates
             config.remove_option("memory", "lyric_filenames")
@@ -495,7 +500,7 @@ class TAudioFile(TestCase):
                     f.write(u"")
                 fp_searched = unquote(s.lyric_filename)
                 os.remove(fp)
-                self.failUnlessEqual(fp_searched, fp)
+                assertEqual(fp_searched, fp)
 
             # test '<' and '>' in name across path
             # (not parsed (transparent to test))
@@ -509,7 +514,7 @@ class TAudioFile(TestCase):
             fp_searched = unquote(s.lyric_filename)
             os.remove(fp)
             os.rmdir(p)
-            self.failUnlessEqual(fp_searched, fp)
+            assertEqual(fp_searched, fp)
 
         # reset config, other tests expect different defaults!
         config.remove_option("memory", "lyric_rootpaths")

--- a/quodlibet/tests/test_formats__audio.py
+++ b/quodlibet/tests/test_formats__audio.py
@@ -8,6 +8,7 @@ from tests import TestCase, get_data_path
 
 import os
 import io
+from contextlib import contextmanager
 from senf import fsnative, fsn2text, bytes2fsn, mkstemp, mkdtemp
 
 from quodlibet import config
@@ -418,6 +419,24 @@ class TAudioFile(TestCase):
         s['title'] = "Theme Tune"
         return s
 
+    @contextmanager
+    def lyric_filename_test_setup(self, no_config=False):
+
+        with temp_filename() as filename:
+            s = self.lyric_filename_search_test_song(filename)
+            root = os.path.dirname(filename)
+
+            if not no_config:
+                config.set("memory", "lyric_filenames",
+                           "<artist>.-.<title>,<artist> - <title>.lyrics_mod")
+            config.set("memory", "lyric_rootpaths", root)
+
+            s.root = root
+            yield s
+
+            if not no_config:
+                self.lyric_filename_search_clean_config()
+
     def lyric_filename_search_clean_config(self):
         """reset config to ensure other tests aren't affected"""
         config.remove_option("memory", "lyric_rootpaths")
@@ -425,29 +444,25 @@ class TAudioFile(TestCase):
 
     def test_lyric_filename_search_builtin_default(self):
         """test built-in default"""
-        with temp_filename() as filename:
-            s = self.lyric_filename_search_test_song(filename)
-            root = os.path.join(get_home_dir(), ".lyrics")
-            fp = os.path.join(root, s["artist"], s["title"] + ".lyric")
+        with self.lyric_filename_test_setup(no_config=True) as ts:
+            fp = os.path.join(ts.root, ts["artist"], ts["title"] + ".lyric")
             p = os.path.dirname(fp)
             mkdir(p)
             with io.open(fp, "w", encoding='utf-8') as f:
                 f.write(u"")
-            search = unquote(s.lyric_filename)
+            search = unquote(ts.lyric_filename)
             os.remove(fp)
             os.rmdir(p)
             self.assertEqual(search, fp)
 
     def test_lyric_filename_search_builtin_default_local_path(self):
         """test built-in default local path"""
-        with temp_filename() as filename:
-            s = self.lyric_filename_search_test_song(filename)
-            root = os.path.dirname(filename)
-            fp = os.path.join(root, s["artist"] + " - " +
-                                    s["title"] + ".lyric")
+        with self.lyric_filename_test_setup(no_config=True) as ts:
+            fp = os.path.join(ts.root, ts["artist"] + " - " +
+                                       ts["title"] + ".lyric")
             with io.open(fp, "w", encoding='utf-8') as f:
                 f.write(u"")
-            search = s.lyric_filename
+            search = ts.lyric_filename
             os.remove(fp)
             if is_windows():
                 fp = fp.lower()  # account for 'os.path.normcase' santisatation
@@ -456,99 +471,73 @@ class TAudioFile(TestCase):
 
     def test_lyric_filename_search_file_not_found(self):
         """test default file not found fallback"""
-        with temp_filename() as filename:
-            s = self.lyric_filename_search_test_song(filename)
-            config.set("memory", "lyric_filenames",
-                           "<artist>.-.<title>,<artist> - <title>.lyrics_mod")
-            root = os.path.dirname(filename)
-            config.set("memory", "lyric_rootpaths", root)
-            fp = os.path.join(root, s["artist"] + ".-." + s["title"])
-            search = unquote(s.lyric_filename)
+        with self.lyric_filename_test_setup() as ts:
+            fp = os.path.join(ts.root, ts["artist"] + ".-." + ts["title"])
+            search = unquote(ts.lyric_filename)
             self.assertEqual(search, fp)
-        self.lyric_filename_search_clean_config()
 
     def test_lyric_filename_search_custom_path(self):
         """test custom lyrics file location / naming"""
-        with temp_filename() as filename:
-            s = self.lyric_filename_search_test_song(filename)
-            config.set("memory", "lyric_filenames",
-                           "<artist>.-.<title>,<artist> - <title>.lyrics_mod")
-            root = os.path.dirname(filename)
-            config.set("memory", "lyric_rootpaths", root)
-
-            fp = os.path.join(root, s["artist"] + " - " +
-                                    s["title"] + ".lyric")
+        with self.lyric_filename_test_setup() as ts:
+            fp = os.path.join(ts.root, ts["artist"] + " - " +
+                                       ts["title"] + ".lyric")
             with io.open(fp, "w", encoding='utf-8') as f:
                 f.write(u"")
-            search = s.lyric_filename
+            search = ts.lyric_filename
             os.remove(fp)
             self.assertEqual(search, fp)
-        self.lyric_filename_search_clean_config()
 
     def test_lyric_filename_search_order_priority(self):
         """test custom lyrics order priority"""
-        with temp_filename() as filename:
-            s = self.lyric_filename_search_test_song(filename)
-            config.set("memory", "lyric_filenames",
-                           "<artist>.-.<title>,<artist> - <title>.lyrics_mod")
-            root = os.path.dirname(filename)
-            config.set("memory", "lyric_rootpaths", root)
+        with self.lyric_filename_test_setup() as ts:
             root2 = os.path.join(get_home_dir(), ".lyrics") # built-in default
-            fp2 = os.path.join(root2, s["artist"] + " - " +
-                                      s["title"] + ".lyric")
+            fp2 = os.path.join(root2, ts["artist"] + " - " +
+                                      ts["title"] + ".lyric")
             p2 = os.path.dirname(fp2)
             mkdir(p2)
             with io.open(fp2, "w", encoding='utf-8') as f:
                 f.write(u"")
-            fp = os.path.join(root, s["artist"] + " - " +
-                                    s["title"] + ".lyric")
+            fp = os.path.join(ts.root, ts["artist"] + " - " +
+                                       ts["title"] + ".lyric")
             with io.open(fp, "w", encoding='utf-8') as f:
                 f.write(u"")
             mkdir(p2)
-            search = s.lyric_filename
+            search = ts.lyric_filename
             os.remove(fp2)
             os.rmdir(p2)
             os.remove(fp)
             self.assertEqual(search, fp)
-        self.lyric_filename_search_clean_config()
 
     def test_lyric_filename_search_modified_extension_fallback(self):
         """test modified extension fallback search"""
-        with temp_filename() as filename:
-            s = self.lyric_filename_search_test_song(filename)
-            config.set("memory", "lyric_filenames",
-                           "<artist>.-.<title>,<artist> - <title>.lyrics_mod")
-            root = os.path.dirname(filename)
-            config.set("memory", "lyric_rootpaths", root)
-
-            fp = os.path.join(root, s["artist"] + " - " + s["title"] + ".txt")
+        with self.lyric_filename_test_setup() as ts:
+            fp = os.path.join(ts.root,
+                              ts["artist"] + " - " + ts["title"] + ".txt")
             with io.open(fp, "w", encoding='utf-8') as f:
                 f.write(u"")
-            search = s.lyric_filename
+            search = ts.lyric_filename
             os.remove(fp)
             self.assertEqual(search, fp)
-        self.lyric_filename_search_clean_config()
 
     def test_lyric_filename_search_special_characters(self):
         """test '<' and/or '>' in name (not parsed (transparent to test))"""
-        with temp_filename() as filename:
-            s = self.lyric_filename_search_test_song(filename)
-            root = os.path.dirname(filename)
+        with self.lyric_filename_test_setup(no_config=True) as ts:
 
-            path_variants = \
-                ['<oldskool>'] if is_windows() \
-                               else ['\<artist\>', '\<artist>', '<artist\>']
+            path_variants = ['<oldskool>'] \
+                if is_windows() else ['\<artist\>', '\<artist>', '<artist\>']
+
             for path_variant in path_variants:
-                s['artist'] = path_variant + " SpongeBob SquarePants"
-                parts = [root, s["artist"] + " - " + s["title"] + ".lyric"]
-                rpf = RootPathFile(root, os.path.sep.join(parts))
+                ts['artist'] = path_variant + " SpongeBob SquarePants"
+                parts = [ts.root,
+                         ts["artist"] + " - " + ts["title"] + ".lyric"]
+                rpf = RootPathFile(ts.root, os.path.sep.join(parts))
                 if not rpf.valid:
                     rpf = RootPathFile(rpf.root, rpf.pathfile_escaped)
                 self.assertTrue(rpf.valid,
                                 "even escaped target file is not valid")
                 with io.open(rpf.pathfile, "w", encoding='utf-8') as f:
                     f.write(u"")
-                search = s.lyric_filename
+                search = ts.lyric_filename
                 os.remove(rpf.pathfile)
                 fp = rpf.pathfile
                 if is_windows():
@@ -556,29 +545,25 @@ class TAudioFile(TestCase):
                     fp = fp.lower()
                     search = search.lower() # compensate for the above
                 self.assertEqual(search, fp)
-        self.lyric_filename_search_clean_config()
 
     def test_lyric_filename_search_special_characters_across_path(self):
         """test '<' and/or '>' in name across path separator (not parsed
         (transparent to test))"""
-        with temp_filename() as filename:
-            s = self.lyric_filename_search_test_song(filename)
-            root = os.path.dirname(filename)
-
+        with self.lyric_filename_test_setup(no_config=True) as ts:
             # test '<' and '>' in name across path
             # (not parsed (transparent to test))
-            s['artist'] = "a < b"
-            s['title'] = "b > a"
-            parts = [root, s["artist"], s["title"] + ".lyric"]
-            rpf = RootPathFile(root, os.path.sep.join(parts))
-            rootp = root
+            ts['artist'] = "a < b"
+            ts['title'] = "b > a"
+            parts = [ts.root, ts["artist"], ts["title"] + ".lyric"]
+            rpf = RootPathFile(ts.root, os.path.sep.join(parts))
+            rootp = ts.root
             rmdirs = []
             # ensure valid dir existence
             for p in rpf.end.split(os.path.sep)[:-1]:
-                rootp = os.path.sep.join([root, p])
-                if not RootPathFile(root, rootp).valid:
-                    rootp = os.path.sep.join([root, escape_filename(p)])
-                self.assertTrue(RootPathFile(root, rootp).valid,
+                rootp = os.path.sep.join([ts.root, p])
+                if not RootPathFile(ts.root, rootp).valid:
+                    rootp = os.path.sep.join([ts.root, escape_filename(p)])
+                self.assertTrue(RootPathFile(ts.root, rootp).valid,
                                 "even escaped target dir part is not valid!")
                 if not os.path.exists(rootp):
                     mkdir(rootp)
@@ -590,7 +575,7 @@ class TAudioFile(TestCase):
             with io.open(rpf.pathfile, "w", encoding='utf-8') as f:
                 f.write(u"")
             # search for lyric file
-            search = s.lyric_filename
+            search = ts.lyric_filename
             # clean up test lyric file / path
             os.remove(rpf.pathfile)
             for p in rmdirs:
@@ -601,7 +586,6 @@ class TAudioFile(TestCase):
                 fp = fp.lower()  # account for 'os.path.normcase' santisatation
                 search = search.lower()  # compensate for the above
             self.assertEqual(search, fp)
-        self.lyric_filename_search_clean_config()
 
     def test_lyrics_from_file(self):
         with temp_filename() as filename:

--- a/quodlibet/tests/test_formats__audio.py
+++ b/quodlibet/tests/test_formats__audio.py
@@ -411,13 +411,6 @@ class TAudioFile(TestCase):
         song["lyricist"] = u"Lyricist"
         self.assertTrue(isinstance(song.lyric_filename, fsnative))
 
-    def assert_paths_equal(self, a, b):
-        # pass custom error message to avoid truncation!
-        a2 = os.path.realpath(a).lower()
-        b2 = os.path.realpath(b).lower()
-        msg_fail = str("item1: %s !=\nitem2: %s" % (a2, b2))
-        self.assertEqual(a2, b2, msg_fail)
-
     def lyric_filename_search_test_song(self, pathfile):
         s = AudioFile()
         s.sanitize(pathfile)
@@ -443,7 +436,7 @@ class TAudioFile(TestCase):
             search = unquote(s.lyric_filename)
             os.remove(fp)
             os.rmdir(p)
-            self.assert_paths_equal(search, fp)
+            self.assertEqual(search, fp)
 
     def test_lyric_filename_search_builtin_default_local_path(self):
         """test built-in default local path"""
@@ -456,7 +449,10 @@ class TAudioFile(TestCase):
                 f.write(u"")
             search = s.lyric_filename
             os.remove(fp)
-            self.assert_paths_equal(search, fp)
+            if is_windows():
+                fp = fp.lower()  # account for 'os.path.normcase' santisatation
+                search = search.lower()  # compensate for the above
+            self.assertEqual(search, fp)
 
     def test_lyric_filename_search_file_not_found(self):
         """test default file not found fallback"""
@@ -468,7 +464,7 @@ class TAudioFile(TestCase):
             config.set("memory", "lyric_rootpaths", root)
             fp = os.path.join(root, s["artist"] + ".-." + s["title"])
             search = unquote(s.lyric_filename)
-            self.assert_paths_equal(search, fp)
+            self.assertEqual(search, fp)
         self.lyric_filename_search_clean_config()
 
     def test_lyric_filename_search_custom_path(self):
@@ -486,7 +482,7 @@ class TAudioFile(TestCase):
                 f.write(u"")
             search = s.lyric_filename
             os.remove(fp)
-            self.assert_paths_equal(search, fp)
+            self.assertEqual(search, fp)
         self.lyric_filename_search_clean_config()
 
     def test_lyric_filename_search_order_priority(self):
@@ -513,7 +509,7 @@ class TAudioFile(TestCase):
             os.remove(fp2)
             os.rmdir(p2)
             os.remove(fp)
-            self.assert_paths_equal(search, fp)
+            self.assertEqual(search, fp)
         self.lyric_filename_search_clean_config()
 
     def test_lyric_filename_search_modified_extension_fallback(self):
@@ -530,7 +526,7 @@ class TAudioFile(TestCase):
                 f.write(u"")
             search = s.lyric_filename
             os.remove(fp)
-            self.assert_paths_equal(search, fp)
+            self.assertEqual(search, fp)
         self.lyric_filename_search_clean_config()
 
     def test_lyric_filename_search_special_characters(self):
@@ -554,10 +550,15 @@ class TAudioFile(TestCase):
                     f.write(u"")
                 search = s.lyric_filename
                 os.remove(rpf.pathfile)
-                self.assert_paths_equal(search, rpf.pathfile)
+                fp = rpf.pathfile
+                if is_windows():
+                    # account for 'os.path.normcase' santisatation
+                    fp = fp.lower()
+                    search = search.lower() # compensate for the above
+                self.assertEqual(search, fp)
         self.lyric_filename_search_clean_config()
 
-    def test_lyric_filename_search_special_characters_accross_path(self):
+    def test_lyric_filename_search_special_characters_across_path(self):
         """test '<' and/or '>' in name across path separator (not parsed
         (transparent to test))"""
         with temp_filename() as filename:
@@ -595,7 +596,11 @@ class TAudioFile(TestCase):
             for p in rmdirs:
                 os.rmdir(p)
             # test whether the 'found' file is the test lyric file
-            self.assert_paths_equal(search, rpf.pathfile)
+            fp = rpf.pathfile
+            if is_windows():
+                fp = fp.lower()  # account for 'os.path.normcase' santisatation
+                search = search.lower()  # compensate for the above
+            self.assertEqual(search, fp)
         self.lyric_filename_search_clean_config()
 
     def test_lyrics_from_file(self):

--- a/quodlibet/tests/test_formats__audio.py
+++ b/quodlibet/tests/test_formats__audio.py
@@ -410,25 +410,31 @@ class TAudioFile(TestCase):
         song["lyricist"] = u"Lyricist"
         self.assertTrue(isinstance(song.lyric_filename, fsnative))
 
-    def test_lyric_filename_search(self):
+    def assert_paths_equal(self, a, b):
+        # pass custom error message to avoid truncation!
+        a2 = os.path.realpath(a).lower()
+        b2 = os.path.realpath(b).lower()
+        msg_fail = str("item1: %s !=\nitem2: %s" % (a2, b2))
+        self.assertEqual(a2, b2, msg_fail)
 
-        def assertEqual(a, b):
-            # pass custom error message to avoid truncation!
-            a2 = os.path.realpath(a).lower()
-            b2 = os.path.realpath(b).lower()
-            msg_fail = str("item1: %s !=\nitem2: %s" % (a2, b2))
-            self.assertEqual(a2, b2, msg_fail)
+    def lyric_filename_search_test_song(self, pathfile):
+        s = AudioFile()
+        s.sanitize(pathfile)
+        s['artist'] = "SpongeBob SquarePants"
+        s['title'] = "Theme Tune"
+        return s
 
+    def lyric_filename_search_clean_config(self):
+        """reset config to ensure other tests aren't affected"""
+        config.remove_option("memory", "lyric_rootpaths")
+        config.remove_option("memory", "lyric_filenames")
+
+    def test_lyric_filename_search_builtin_default(self):
+        """test built-in default"""
         with temp_filename() as filename:
-            s = AudioFile()
-            s.sanitize(filename)
-
-            artist = s['artist'] = "SpongeBob SquarePants"
-            title = s['title'] = "Theme Tune"
-
-            # test built-in default
+            s = self.lyric_filename_search_test_song(filename)
             root = os.path.join(get_home_dir(), ".lyrics")
-            fp = os.path.join(root, artist, title + ".lyric")
+            fp = os.path.join(root, s["artist"], s["title"] + ".lyric")
             p = os.path.dirname(fp)
             mkdir(p)
             with io.open(fp, "w", encoding='utf-8') as f:
@@ -436,44 +442,69 @@ class TAudioFile(TestCase):
             search = unquote(s.lyric_filename)
             os.remove(fp)
             os.rmdir(p)
-            assertEqual(search, fp)
+            self.assert_paths_equal(search, fp)
 
-            # test built-in default local path
+    def test_lyric_filename_search_builtin_default_local_path(self):
+        """test built-in default local path"""
+        with temp_filename() as filename:
+            s = self.lyric_filename_search_test_song(filename)
             root = os.path.dirname(filename)
-            fp = os.path.join(root, artist + " - " + title + ".lyric")
+            fp = os.path.join(root, s["artist"] + " - " +
+                                    s["title"] + ".lyric")
             with io.open(fp, "w", encoding='utf-8') as f:
                 f.write(u"")
             search = s.lyric_filename
             os.remove(fp)
-            assertEqual(search, fp)
+            self.assert_paths_equal(search, fp)
 
-            # custom lyrics file location / naming
+    def test_lyric_filename_search_file_not_found(self):
+        """test default file not found fallback"""
+        with temp_filename() as filename:
+            s = self.lyric_filename_search_test_song(filename)
+            config.set("memory", "lyric_filenames",
+                           "<artist>.-.<title>,<artist> - <title>.lyrics_mod")
+            root = os.path.dirname(filename)
+            config.set("memory", "lyric_rootpaths", root)
+            fp = os.path.join(root, s["artist"] + ".-." + s["title"])
+            search = unquote(s.lyric_filename)
+            self.assert_paths_equal(search, fp)
+        self.lyric_filename_search_clean_config()
+
+    def test_lyric_filename_search_custom_path(self):
+        """test custom lyrics file location / naming"""
+        with temp_filename() as filename:
+            s = self.lyric_filename_search_test_song(filename)
             config.set("memory", "lyric_filenames",
                            "<artist>.-.<title>,<artist> - <title>.lyrics_mod")
             root = os.path.dirname(filename)
             config.set("memory", "lyric_rootpaths", root)
 
-            # test custom default (fnf fallback!)
-            fp = os.path.join(root, artist + ".-." + title)
-            search = unquote(s.lyric_filename)
-            assertEqual(search, fp)
-
-            # test user defined
-            fp = os.path.join(root, artist + " - " + title + ".lyric")
+            fp = os.path.join(root, s["artist"] + " - " +
+                                    s["title"] + ".lyric")
             with io.open(fp, "w", encoding='utf-8') as f:
                 f.write(u"")
             search = s.lyric_filename
             os.remove(fp)
-            assertEqual(search, fp)
+            self.assert_paths_equal(search, fp)
+        self.lyric_filename_search_clean_config()
 
-            # test order priority
+    def test_lyric_filename_search_order_priority(self):
+        """test custom lyrics order priority"""
+        with temp_filename() as filename:
+            s = self.lyric_filename_search_test_song(filename)
+            config.set("memory", "lyric_filenames",
+                           "<artist>.-.<title>,<artist> - <title>.lyrics_mod")
+            root = os.path.dirname(filename)
+            config.set("memory", "lyric_rootpaths", root)
             root2 = os.path.join(get_home_dir(), ".lyrics") # built-in default
-            fp2 = os.path.join(root2, artist + " - " + title + ".lyric")
+            fp2 = os.path.join(root2, s["artist"] + " - " +
+                                      s["title"] + ".lyric")
             p2 = os.path.dirname(fp2)
             mkdir(p2)
             with io.open(fp2, "w", encoding='utf-8') as f:
                 f.write(u"")
-            fp = os.path.join(root, artist + " - " + title + ".lyric")
+            fp = os.path.join(root, s["artist"] + " - " +
+                                    s["title"] + ".lyric")
             with io.open(fp, "w", encoding='utf-8') as f:
                 f.write(u"")
             mkdir(p2)
@@ -481,27 +512,38 @@ class TAudioFile(TestCase):
             os.remove(fp2)
             os.rmdir(p2)
             os.remove(fp)
-            assertEqual(search, fp)
+            self.assert_paths_equal(search, fp)
+        self.lyric_filename_search_clean_config()
 
-            # test modified extension fallback search
-            fp = os.path.join(root, artist + " - " + title + ".txt")
+    def test_lyric_filename_search_modified_extension_fallback(self):
+        """test modified extension fallback search"""
+        with temp_filename() as filename:
+            s = self.lyric_filename_search_test_song(filename)
+            config.set("memory", "lyric_filenames",
+                           "<artist>.-.<title>,<artist> - <title>.lyrics_mod")
+            root = os.path.dirname(filename)
+            config.set("memory", "lyric_rootpaths", root)
+
+            fp = os.path.join(root, s["artist"] + " - " + s["title"] + ".txt")
             with io.open(fp, "w", encoding='utf-8') as f:
                 f.write(u"")
             search = s.lyric_filename
             os.remove(fp)
-            assertEqual(search, fp)
+            self.assert_paths_equal(search, fp)
+        self.lyric_filename_search_clean_config()
 
-            # reset to pickup default (no <attr>) templates
-            config.remove_option("memory", "lyric_filenames")
+    def test_lyric_filename_search_special_characters(self):
+        """test '<' and/or '>' in name (not parsed (transparent to test))"""
+        with temp_filename() as filename:
+            s = self.lyric_filename_search_test_song(filename)
+            root = os.path.dirname(filename)
 
-            # test '<' and/or '>' in name
-            # (not parsed (transparent to test))
             path_variants = \
                 ['<oldskool>'] if (os.name == "nt") \
                                else ['\<artist\>', '\<artist>', '<artist\>']
             for path_variant in path_variants:
                 s['artist'] = path_variant + " SpongeBob SquarePants"
-                parts = [root, s['artist'] + " - " + s['title'] + ".lyric"]
+                parts = [root, s["artist"] + " - " + s["title"] + ".lyric"]
                 rpf = RootPathFile(root, os.path.sep.join(parts))
                 if not rpf.is_valid:
                     rpf = RootPathFile(rpf.root, rpf.pathfile_escaped)
@@ -511,13 +553,21 @@ class TAudioFile(TestCase):
                     f.write(u"")
                 search = s.lyric_filename
                 os.remove(rpf.pathfile)
-                assertEqual(search, rpf.pathfile)
+                self.assert_paths_equal(search, rpf.pathfile)
+        self.lyric_filename_search_clean_config()
+
+    def test_lyric_filename_search_special_characters_accross_path(self):
+        """test '<' and/or '>' in name across path separator (not parsed
+        (transparent to test))"""
+        with temp_filename() as filename:
+            s = self.lyric_filename_search_test_song(filename)
+            root = os.path.dirname(filename)
 
             # test '<' and '>' in name across path
             # (not parsed (transparent to test))
             s['artist'] = "a < b"
             s['title'] = "b > a"
-            parts = [root, s['artist'], s['title'] + ".lyric"]
+            parts = [root, s["artist"], s["title"] + ".lyric"]
             rpf = RootPathFile(root, os.path.sep.join(parts))
             rootp = root
             rmdirs = []
@@ -544,11 +594,8 @@ class TAudioFile(TestCase):
             for p in rmdirs:
                 os.rmdir(p)
             # test whether the 'found' file is the test lyric file
-            assertEqual(search, rpf.pathfile)
-
-        # reset config - other tests expect different defaults!
-        config.remove_option("memory", "lyric_rootpaths")
-        config.remove_option("memory", "lyric_filenames")
+            self.assert_paths_equal(search, rpf.pathfile)
+        self.lyric_filename_search_clean_config()
 
     def test_lyrics_from_file(self):
         with temp_filename() as filename:

--- a/quodlibet/tests/test_formats__audio.py
+++ b/quodlibet/tests/test_formats__audio.py
@@ -16,7 +16,7 @@ from quodlibet.formats import AudioFile, types as format_types, AudioFileError
 from quodlibet.formats._audio import NUMERIC_ZERO_DEFAULT
 from quodlibet.formats import decode_value, MusicFile, FILESYSTEM_TAGS
 from quodlibet.util.tags import _TAGS as TAGS
-from quodlibet.util.path import normalize_path, mkdir, get_home_dir
+from quodlibet.util.path import normalize_path, mkdir, get_home_dir, unquote
 
 from .helper import temp_filename
 
@@ -425,7 +425,7 @@ class TAudioFile(TestCase):
             mkdir(p)
             with io.open(fp, "w", encoding='utf-8') as f:
                 f.write(u"")
-            fp_searched = s.lyric_filename
+            fp_searched = unquote(s.lyric_filename)
             os.remove(fp)
             os.rmdir(p)
             self.failUnlessEqual(fp_searched, fp)
@@ -435,7 +435,7 @@ class TAudioFile(TestCase):
             fp = os.path.join(root, artist + " - " + title + ".lyric")
             with io.open(fp, "w", encoding='utf-8') as f:
                 f.write(u"")
-            fp_searched = s.lyric_filename
+            fp_searched = unquote(s.lyric_filename)
             os.remove(fp)
             self.failUnlessEqual(fp_searched, fp)
 
@@ -447,14 +447,14 @@ class TAudioFile(TestCase):
 
             # test custom default (fnf fallback!)
             fp = os.path.join(root, artist + ".-." + title)
-            fp_searched = s.lyric_filename
+            fp_searched = unquote(s.lyric_filename)
             self.failUnlessEqual(fp_searched, fp)
 
             # test user defined
             fp = os.path.join(root, artist + " - " + title + ".lyric")
             with io.open(fp, "w", encoding='utf-8') as f:
                 f.write(u"")
-            fp_searched = s.lyric_filename
+            fp_searched = unquote(s.lyric_filename)
             os.remove(fp)
             self.failUnlessEqual(fp_searched, fp)
 
@@ -469,7 +469,7 @@ class TAudioFile(TestCase):
             with io.open(fp, "w", encoding='utf-8') as f:
                 f.write(u"")
             mkdir(p2)
-            fp_searched = s.lyric_filename
+            fp_searched = unquote(s.lyric_filename)
             os.remove(fp2)
             os.rmdir(p2)
             os.remove(fp)
@@ -479,7 +479,7 @@ class TAudioFile(TestCase):
             fp = os.path.join(root, artist + " - " + title + ".txt")
             with io.open(fp, "w", encoding='utf-8') as f:
                 f.write(u"")
-            fp_searched = s.lyric_filename
+            fp_searched = unquote(s.lyric_filename)
             os.remove(fp)
             self.failUnlessEqual(fp_searched, fp)
 
@@ -493,7 +493,7 @@ class TAudioFile(TestCase):
                 fp = os.path.join(root, artist + " - " + title + ".lyric")
                 with io.open(fp, "w", encoding='utf-8') as f:
                     f.write(u"")
-                fp_searched = s.lyric_filename
+                fp_searched = unquote(s.lyric_filename)
                 os.remove(fp)
                 self.failUnlessEqual(fp_searched, fp)
 
@@ -506,7 +506,7 @@ class TAudioFile(TestCase):
             mkdir(p)
             with io.open(fp, "w", encoding='utf-8') as f:
                 f.write(u"")
-            fp_searched = s.lyric_filename
+            fp_searched = unquote(s.lyric_filename)
             os.remove(fp)
             os.rmdir(p)
             self.failUnlessEqual(fp_searched, fp)

--- a/quodlibet/tests/test_formats__audio.py
+++ b/quodlibet/tests/test_formats__audio.py
@@ -16,7 +16,7 @@ from quodlibet.formats import AudioFile, types as format_types, AudioFileError
 from quodlibet.formats._audio import NUMERIC_ZERO_DEFAULT
 from quodlibet.formats import decode_value, MusicFile, FILESYSTEM_TAGS
 from quodlibet.util.tags import _TAGS as TAGS
-from quodlibet.util.path import normalize_path, mkdir
+from quodlibet.util.path import normalize_path, mkdir, get_home_dir
 
 from .helper import temp_filename
 
@@ -408,6 +408,112 @@ class TAudioFile(TestCase):
         self.assertTrue(isinstance(song.lyric_filename, fsnative))
         song["lyricist"] = u"Lyricist"
         self.assertTrue(isinstance(song.lyric_filename, fsnative))
+
+    def test_lyric_filename_search(self):
+
+        with temp_filename() as filename:
+            s = AudioFile()
+            s.sanitize(filename)
+
+            artist = s['artist'] = "SpongeBob SquarePants"
+            title = s['title'] = "Theme Tune"
+
+            # test built-in default
+            root = os.path.join(get_home_dir(), ".lyrics")
+            fp = os.path.join(root, artist, title + ".lyric")
+            p = os.path.dirname(fp)
+            mkdir(p)
+            with io.open(fp, "w", encoding='utf-8') as f:
+                f.write(u"")
+            fp_searched = s.lyric_filename
+            os.remove(fp)
+            os.rmdir(p)
+            self.failUnlessEqual(fp_searched, fp)
+
+            # test built-in default local path
+            root = os.path.dirname(filename)
+            fp = os.path.join(root, artist + " - " + title + ".lyric")
+            with io.open(fp, "w", encoding='utf-8') as f:
+                f.write(u"")
+            fp_searched = s.lyric_filename
+            os.remove(fp)
+            self.failUnlessEqual(fp_searched, fp)
+
+            # custom lyrics file location / naming
+            config.set("memory", "lyric_filenames",
+                           "<artist>.-.<title>,<artist> - <title>.lyrics_mod")
+            root = os.path.dirname(filename)
+            config.set("memory", "lyric_rootpaths", root)
+
+            # test custom default (fnf fallback!)
+            fp = os.path.join(root, artist + ".-." + title)
+            fp_searched = s.lyric_filename
+            self.failUnlessEqual(fp_searched, fp)
+
+            # test user defined
+            fp = os.path.join(root, artist + " - " + title + ".lyric")
+            with io.open(fp, "w", encoding='utf-8') as f:
+                f.write(u"")
+            fp_searched = s.lyric_filename
+            os.remove(fp)
+            self.failUnlessEqual(fp_searched, fp)
+
+            # test order priority
+            root2 = os.path.join(get_home_dir(), ".lyrics") # built-in default
+            fp2 = os.path.join(root2, artist + " - " + title + ".lyric")
+            p2 = os.path.dirname(fp2)
+            mkdir(p2)
+            with io.open(fp2, "w", encoding='utf-8') as f:
+                f.write(u"")
+            fp = os.path.join(root, artist + " - " + title + ".lyric")
+            with io.open(fp, "w", encoding='utf-8') as f:
+                f.write(u"")
+            mkdir(p2)
+            fp_searched = s.lyric_filename
+            os.remove(fp2)
+            os.rmdir(p2)
+            os.remove(fp)
+            self.failUnlessEqual(fp_searched, fp)
+
+            # test modified extension fallback search
+            fp = os.path.join(root, artist + " - " + title + ".txt")
+            with io.open(fp, "w", encoding='utf-8') as f:
+                f.write(u"")
+            fp_searched = s.lyric_filename
+            os.remove(fp)
+            self.failUnlessEqual(fp_searched, fp)
+
+            # reset to pickup default (no <attr>) templates
+            config.remove_option("memory", "lyric_filenames")
+
+            # test '<' and/or '>' in name
+            # (not parsed (transparent to test))
+            for artist in ['\<artist\>', '\<artist>', '<artist\>']:
+                artist = s['artist'] = artist + " SpongeBob SquarePants"
+                fp = os.path.join(root, artist + " - " + title + ".lyric")
+                with io.open(fp, "w", encoding='utf-8') as f:
+                    f.write(u"")
+                fp_searched = s.lyric_filename
+                os.remove(fp)
+                self.failUnlessEqual(fp_searched, fp)
+
+            # test '<' and '>' in name across path
+            # (not parsed (transparent to test))
+            artist = s['artist'] = "a < b"
+            title = s['title'] = "b > a"
+            fp = os.path.join(root, artist, title + ".lyric")
+            p = os.path.dirname(fp)
+            mkdir(p)
+            with io.open(fp, "w", encoding='utf-8') as f:
+                f.write(u"")
+            fp_searched = s.lyric_filename
+            os.remove(fp)
+            os.rmdir(p)
+            self.failUnlessEqual(fp_searched, fp)
+
+        # reset config, other tests expect different defaults!
+        config.remove_option("memory", "lyric_rootpaths")
+        config.remove_option("memory", "lyric_filenames")
 
     def test_lyrics_from_file(self):
         with temp_filename() as filename:

--- a/quodlibet/tests/test_formats__audio.py
+++ b/quodlibet/tests/test_formats__audio.py
@@ -412,9 +412,11 @@ class TAudioFile(TestCase):
     def test_lyric_filename_search(self):
 
         def assertEqual(a, b):
-            # don't truncate the bloody error message..
-            msg_fail = str("item1: %s !=\nitem2: %s" % (a, b))
-            self.assertEqual(a, b, msg_fail)
+            # pass custom error message to avoid truncation!
+            a2 = a.lower()
+            b2 = b.lower()
+            msg_fail = str("item1: %s !=\nitem2: %s" % (a2, b2))
+            self.assertEqual(a2, b2, msg_fail)
 
         with temp_filename() as filename:
             s = AudioFile()

--- a/quodlibet/tests/test_formats__audio.py
+++ b/quodlibet/tests/test_formats__audio.py
@@ -16,7 +16,8 @@ from quodlibet.formats import AudioFile, types as format_types, AudioFileError
 from quodlibet.formats._audio import NUMERIC_ZERO_DEFAULT
 from quodlibet.formats import decode_value, MusicFile, FILESYSTEM_TAGS
 from quodlibet.util.tags import _TAGS as TAGS
-from quodlibet.util.path import normalize_path, mkdir, get_home_dir, unquote
+from quodlibet.util.path import normalize_path, mkdir, get_home_dir, unquote, \
+                                escape_filename, RootPathFile
 
 from .helper import temp_filename
 
@@ -432,19 +433,19 @@ class TAudioFile(TestCase):
             mkdir(p)
             with io.open(fp, "w", encoding='utf-8') as f:
                 f.write(u"")
-            fp_searched = unquote(s.lyric_filename)
+            search = unquote(s.lyric_filename)
             os.remove(fp)
             os.rmdir(p)
-            assertEqual(fp_searched, fp)
+            assertEqual(search, fp)
 
             # test built-in default local path
             root = os.path.dirname(filename)
             fp = os.path.join(root, artist + " - " + title + ".lyric")
             with io.open(fp, "w", encoding='utf-8') as f:
                 f.write(u"")
-            fp_searched = unquote(s.lyric_filename)
+            search = s.lyric_filename
             os.remove(fp)
-            assertEqual(fp_searched, fp)
+            assertEqual(search, fp)
 
             # custom lyrics file location / naming
             config.set("memory", "lyric_filenames",
@@ -454,16 +455,16 @@ class TAudioFile(TestCase):
 
             # test custom default (fnf fallback!)
             fp = os.path.join(root, artist + ".-." + title)
-            fp_searched = unquote(s.lyric_filename)
-            assertEqual(fp_searched, fp)
+            search = unquote(s.lyric_filename)
+            assertEqual(search, fp)
 
             # test user defined
             fp = os.path.join(root, artist + " - " + title + ".lyric")
             with io.open(fp, "w", encoding='utf-8') as f:
                 f.write(u"")
-            fp_searched = unquote(s.lyric_filename)
+            search = s.lyric_filename
             os.remove(fp)
-            assertEqual(fp_searched, fp)
+            assertEqual(search, fp)
 
             # test order priority
             root2 = os.path.join(get_home_dir(), ".lyrics") # built-in default
@@ -476,49 +477,76 @@ class TAudioFile(TestCase):
             with io.open(fp, "w", encoding='utf-8') as f:
                 f.write(u"")
             mkdir(p2)
-            fp_searched = unquote(s.lyric_filename)
+            search = s.lyric_filename
             os.remove(fp2)
             os.rmdir(p2)
             os.remove(fp)
-            assertEqual(fp_searched, fp)
+            assertEqual(search, fp)
 
             # test modified extension fallback search
             fp = os.path.join(root, artist + " - " + title + ".txt")
             with io.open(fp, "w", encoding='utf-8') as f:
                 f.write(u"")
-            fp_searched = unquote(s.lyric_filename)
+            search = s.lyric_filename
             os.remove(fp)
-            assertEqual(fp_searched, fp)
+            assertEqual(search, fp)
 
             # reset to pickup default (no <attr>) templates
             config.remove_option("memory", "lyric_filenames")
 
             # test '<' and/or '>' in name
             # (not parsed (transparent to test))
-            for artist in ['\<artist\>', '\<artist>', '<artist\>']:
-                artist = s['artist'] = artist + " SpongeBob SquarePants"
-                fp = os.path.join(root, artist + " - " + title + ".lyric")
-                with io.open(fp, "w", encoding='utf-8') as f:
+            path_variants = \
+                ['<oldskool>'] if (os.name == "nt") \
+                               else ['\<artist\>', '\<artist>', '<artist\>']
+            for path_variant in path_variants:
+                s['artist'] = path_variant + " SpongeBob SquarePants"
+                parts = [root, s['artist'] + " - " + s['title'] + ".lyric"]
+                rpf = RootPathFile(root, os.path.sep.join(parts))
+                if not rpf.is_valid:
+                    rpf = RootPathFile(rpf.root, rpf.pathfile_escaped)
+                self.assertTrue(rpf.is_valid,
+                                "even escaped target file is not valid")
+                with io.open(rpf.pathfile, "w", encoding='utf-8') as f:
                     f.write(u"")
-                fp_searched = unquote(s.lyric_filename)
-                os.remove(fp)
-                assertEqual(fp_searched, fp)
+                search = s.lyric_filename
+                os.remove(rpf.pathfile)
+                assertEqual(search, rpf.pathfile)
 
             # test '<' and '>' in name across path
             # (not parsed (transparent to test))
-            artist = s['artist'] = "a < b"
-            title = s['title'] = "b > a"
-            fp = os.path.join(root, artist, title + ".lyric")
-            p = os.path.dirname(fp)
-            mkdir(p)
-            with io.open(fp, "w", encoding='utf-8') as f:
-                f.write(u"")
-            fp_searched = unquote(s.lyric_filename)
-            os.remove(fp)
-            os.rmdir(p)
-            assertEqual(fp_searched, fp)
+            s['artist'] = "a < b"
+            s['title'] = "b > a"
+            parts = [root, s['artist'], s['title'] + ".lyric"]
+            rpf = RootPathFile(root, os.path.sep.join(parts))
+            rootp = root
+            rmdirs = []
+            # ensure valid dir existence
+            for p in rpf.end.split(os.path.sep)[:-1]:
+                rootp = os.path.sep.join([root, p])
+                if not RootPathFile(root, rootp).is_valid:
+                    rootp = os.path.sep.join([root, escape_filename(p)])
+                self.assertTrue(RootPathFile(root, rootp).is_valid,
+                                "even escaped target dir part is not valid!")
+                if not os.path.exists(rootp):
+                    mkdir(rootp)
+                    rmdirs.append(rootp)
 
-        # reset config, other tests expect different defaults!
+            if not rpf.is_valid:
+                rpf = RootPathFile(rpf.root, rpf.pathfile_escaped)
+
+            with io.open(rpf.pathfile, "w", encoding='utf-8') as f:
+                f.write(u"")
+            # search for lyric file
+            search = s.lyric_filename
+            # clean up test lyric file / path
+            os.remove(rpf.pathfile)
+            for p in rmdirs:
+                os.rmdir(p)
+            # test whether the 'found' file is the test lyric file
+            assertEqual(search, rpf.pathfile)
+
+        # reset config - other tests expect different defaults!
         config.remove_option("memory", "lyric_rootpaths")
         config.remove_option("memory", "lyric_filenames")
 

--- a/quodlibet/tests/test_formats__audio.py
+++ b/quodlibet/tests/test_formats__audio.py
@@ -414,8 +414,8 @@ class TAudioFile(TestCase):
 
         def assertEqual(a, b):
             # pass custom error message to avoid truncation!
-            a2 = a.lower()
-            b2 = b.lower()
+            a2 = os.path.realpath(a).lower()
+            b2 = os.path.realpath(b).lower()
             msg_fail = str("item1: %s !=\nitem2: %s" % (a2, b2))
             self.assertEqual(a2, b2, msg_fail)
 


### PR DESCRIPTION
Hi,

**Here I wanted lyric files sourced via other programs to be visible in the View Lyrics pane**

So specifically, before this commit I'd have to manually rename any lyric file I wanted to see in the ViewLyrics pane to the bespoke ViewLyrics format of '_~/.lyrics/<artist/lyricartist>/<title>.lyric_', and now I don't have to, and that convenience is why I would like this patch to go into Quod Libet.

To facilitate this the changes added are:.

> -search alternate extensions: 'lyrics', '', 'txt'
> -add another default 'root'/'\<artist\> - \<title\>/lyric search path
> -add local song path as another default search path
> -add support for lyrics filename configuration via two '[memory]'
> config variables: 'lyric_rootpaths' and 'lyric_filenames'. song
> variables can also be used in these comma delimited list values.

**config example:**
lyric_filenames = \<artist\>.-.\<title\>,\<artist\> - \<title\>.lyrics_mod
lyric_rootpaths = ~/music/lyrics

**debug example:**
> D: 1.660: ViewLyrics.plugin_on_song_started: Looking for lyrics for ~/media/music/library/Dire Straits/Money for Nothing (1988)/09. Dire Straits - Private Investigations.mp3
> D: 1.660: MP3File.lyric_filename:
>     searching for lyrics in:
>     ~/media/music/lyrics/\<artist\>.-.\<title\>
>     ~/media/music/lyrics/\<artist\> - \<title\>.lyrics_mod
>     ~/media/music/lyrics/Dire Straits/Private Investigations.lyric
>     ~/media/music/lyrics/Dire Straits - Private Investigations.lyric
>     ~/.lyrics/\<artist\>.-.\<title\>
>     ~/.lyrics/\<artist\> - \<title\>.lyrics_mod
>     ~/.lyrics/Dire Straits/Private Investigations.lyric
>     ~/.lyrics/Dire Straits - Private Investigations.lyric
>     ~/media/music/library/Dire Straits/Money for Nothing (1988)/\<artist\>.-.\<title\>
>     ~/media/music/library/Dire Straits/Money for Nothing (1988)/\<artist\> - \<title\>.lyrics_mod
>     ~/media/music/library/Dire Straits/Money for Nothing (1988)/Dire Straits/Private Investigations.lyric
>     ~/media/music/library/Dire Straits/Money for Nothing (1988)/Dire Straits - Private Investigations.lyric
> D: 1.661: MP3File.lyric_filename: extending search to extensions: ['lyric', 'lyrics', '', 'txt']
> D: 1.661: MP3File.__call__: Reading lyrics from ~/media/music/lyrics/Dire Straits - Private Investigations.txt
