### PR TITLE
Fixed link to internal tags in Search guide

### DIFF
--- a/quodlibet/docs/guide/searching.rst
+++ b/quodlibet/docs/guide/searching.rst
@@ -60,7 +60,7 @@ In QL 3.9 onwards, you can also use `!=` to search for things not equal::
     genre != /.+ Jazz/
 
 
-You can also search :ref:internal tags <InternalTags>, e.g.
+You can also search :ref:`internal tags <InternalTags>`, e.g.
 
  * ``~format = Ogg Vorbis``
  * ``~dirname=Greatest Hits`` - search for all songs in Greatest Hits folders.


### PR DESCRIPTION
The link to [internal tags](http://quodlibet.readthedocs.io/en/latest/guide/tags/internal_tags.html) in [Searching Your Library](http://quodlibet.readthedocs.io/en/latest/guide/searching.html) missed the backticks to make it work.