### PR TITLE
console: Use plugin name instead of description as window title

### DIFF
--- a/quodlibet/quodlibet/ext/songsmenu/console.py
+++ b/quodlibet/quodlibet/ext/songsmenu/console.py
@@ -48,7 +48,7 @@ class PyConsole(SongsMenuPlugin):
         win = ConsoleWindow(create_console(songs), title=desc)
         win.set_icon_name(self.PLUGIN_ICON)
         win.set_title(_("{plugin_name} for {songs} ({app})").format(
-            plugin_name=self.PLUGIN_DESC.strip('.'), songs=desc, app=app.name))
+            plugin_name=self.PLUGIN_NAME, songs=desc, app=app.name))
         win.show_all()
 
 


### PR DESCRIPTION
Use plugin name instead of description as window title for Python Console plugin.

Currently the window title looks like this: "Interactive Python console. Opens a new window for 1 song (Quod Libet)". After the change it looks like "Python Console for 1 song (Quod Libet)".