### PR TITLE
fix importexport plugin error

### DIFF
--- a/quodlibet/quodlibet/ext/songsmenu/importexport.py
+++ b/quodlibet/quodlibet/ext/songsmenu/importexport.py
@@ -98,6 +98,7 @@ def export_metadata(songs, target_path):
                     out.write(os.linesep.encode("utf-8"))
             out.write(os.linesep.encode("utf-8"))
 
+
 class Import(SongsMenuPlugin):
     PLUGIN_ID = "ImportMeta"
     PLUGIN_NAME = _("Import Metadata")

--- a/quodlibet/quodlibet/ext/songsmenu/importexport.py
+++ b/quodlibet/quodlibet/ext/songsmenu/importexport.py
@@ -96,7 +96,7 @@ def export_metadata(songs, target_path):
                     line = '%s=%s' % (key, val)
                     out.write(line.encode("utf-8"))
                     out.write(os.linesep.encode("utf-8"))
-
+            out.write(os.linesep.encode("utf-8"))
 
 class Import(SongsMenuPlugin):
     PLUGIN_ID = "ImportMeta"
@@ -156,7 +156,6 @@ class Import(SongsMenuPlugin):
                 index = len(metadata)
             else:
                 key, value = line[:-1].split('=', 1)
-                value = value.decode('utf-8')
                 try:
                     metadata[index][key].append(value)
                 except KeyError:


### PR DESCRIPTION
Python 3 port broke the importexport.py plugin.
Decode("utf-8") doesn't exist anymore (strings are already utf-8).
added a new line between songs in order to have the correct behaviour.