### PR TITLE
#2641 - fix for being unable to add feeds whose content-type is HTMLish

### DIFF
--- a/quodlibet/quodlibet/browsers/audiofeeds.py
+++ b/quodlibet/quodlibet/browsers/audiofeeds.py
@@ -50,6 +50,7 @@ class InvalidFeed(ValueError):
 
 
 class Feed(list):
+
     def __init__(self, uri):
         self.name = _("Unknown")
         self.uri = uri
@@ -232,7 +233,8 @@ class Feed(list):
             else:
                 print_d("Pre-check: %s returned %s with content type '%s'" %
                         (self.uri, status, content_type))
-                if content_type not in feedparser.ACCEPT_HEADER and content_type not in HTML_TYPES:
+                if (content_type not in feedparser.ACCEPT_HEADER and
+                    content_type not in HTML_TYPES):
                     print_w("Unusable content: %s. Perhaps %s is not a feed?" %
                             (content_type, self.uri))
                     return False
@@ -244,6 +246,7 @@ class Feed(list):
 
 
 class AddFeedDialog(GetStringDialog):
+
     def __init__(self, parent):
         super(AddFeedDialog, self).__init__(
             qltk.get_top_parent(parent), _("New Feed"),

--- a/quodlibet/quodlibet/browsers/audiofeeds.py
+++ b/quodlibet/quodlibet/browsers/audiofeeds.py
@@ -39,6 +39,7 @@ from quodlibet.util.picklehelper import pickle_load, pickle_dump, PickleError
 
 FEEDS = os.path.join(quodlibet.get_user_dir(), "feeds")
 DND_URI_LIST, DND_MOZ_URL = range(2)
+HTML_TYPES = ['text/html', 'application/xhtml+xml']
 
 # Migration path for pickle
 sys.modules["browsers.audiofeeds"] = sys.modules[__name__]
@@ -231,7 +232,7 @@ class Feed(list):
             else:
                 print_d("Pre-check: %s returned %s with content type '%s'" %
                         (self.uri, status, content_type))
-                if content_type not in feedparser.ACCEPT_HEADER:
+                if content_type not in feedparser.ACCEPT_HEADER and content_type not in HTML_TYPES:
                     print_w("Unusable content: %s. Perhaps %s is not a feed?" %
                             (content_type, self.uri))
                     return False

--- a/quodlibet/tests/test_browsers_audiofeeds.py
+++ b/quodlibet/tests/test_browsers_audiofeeds.py
@@ -61,3 +61,17 @@ class TFeed(TestCase):
 
     def tearDown(self):
         quodlibet.config.quit()
+
+class HtmlFeed(TestCase):
+
+    def setUp(self):
+        quodlibet.config.init()
+
+    def test_feed(self):
+        feed = Feed('http://cbsradionewsfeed.com/rss.php?id=149&ud=12')
+        result = feed.parse()
+        self.failUnless(result)
+        self.failUnless(feed[0].valid)
+
+    def tearDown(self):
+        quodlibet.config.quit()


### PR DESCRIPTION
Python's feedparser handles feeds that are HTMLish, that is, whose content type is text/html.
I have tested that after accepting these feeds, the podcast plays just like other feeds.