### PR TITLE
use "performance" role for bare performer tag

### DIFF
--- a/quodlibet/quodlibet/formats/_audio.py
+++ b/quodlibet/quodlibet/formats/_audio.py
@@ -510,10 +510,10 @@ class AudioFile(dict, ImageContainer):
 
         role_map = {}
         for key in role_tag_keys:
-            if key != role_tag:
-                role = key.rsplit(":", 1)[-1]
-                for name in self.list(key):
-                    role_map.setdefault(name, []).append(role)
+            role = (TAG_ROLES.get(role_tag, role_tag) if key == role_tag
+                    else key.split(":", 1)[-1])
+            for name in self.list(key):
+                role_map.setdefault(name, []).append(role)
 
         if sub_keys is None:
             names = self.list_unique(role_tag_keys)

--- a/quodlibet/quodlibet/util/tags.py
+++ b/quodlibet/quodlibet/util/tags.py
@@ -70,6 +70,16 @@ class TagName(object):
         return "%s(%r)" % (type(self).__name__, vars(self))
 
 
+def _get_role_map(tags):
+    roles = {}
+    for (name, tag) in iteritems(tags):
+        if tag.role:
+            roles[name] = tag.role
+            if tag.has_sort:
+                roles[name + "sort"] = tag.role
+    return roles
+
+
 T = TagName
 _TAGS = dict((t.name, t) for t in [
     T("album", "us", _("album"), _("albums")),
@@ -85,7 +95,7 @@ _TAGS = dict((t.name, t) for t in [
     T("date", "u", _("date")),
     T("description", "u", _("description")),
     T("genre", "u", _("genre"), _("genres")),
-    T("performer", "uisr", _("performer"), _("performers")),
+    T("performer", "uisr", _("performer"), _("performers"), _("performance")),
     T("grouping", "u", _("grouping")),
     T("language", "ui", _("language")),
     T("license", "u", _("license")),
@@ -205,7 +215,7 @@ USER_TAGS = _get_standard_tags(_TAGS, machine=False)
 e.g. album
 """
 
-TAG_ROLES = dict([(n, t.role) for (n, t) in iteritems(_TAGS) if t.role])
+TAG_ROLES = _get_role_map(_TAGS)
 """A mapping from tags to their translated role description.
 e.g. conductor -> conducting
 """

--- a/quodlibet/tests/test_formats__audio.py
+++ b/quodlibet/tests/test_formats__audio.py
@@ -447,7 +447,7 @@ class TAudioFile(TestCase):
                        ("performer", "C")])
         self.failUnlessEqual(set(q.list("~performers")), {"A", "B", "C"})
         self.failUnlessEqual(set(q.list("~performers:roles")),
-                             {"A (Vocals)", "B (Guitar)", "C"})
+                             {"A (Vocals)", "B (Guitar)", "C (Performance)"})
 
     def test_performers_multi_value(self):
         q = AudioFile([
@@ -461,12 +461,12 @@ class TAudioFile(TestCase):
 
         self.failUnlessEqual(
             set(q.list("~performer:roles")), {
-                    "A (Guitar, Vocals)",
-                    "C",
-                    "B (Guitar)",
+                    "A (Guitar, Performance, Vocals)",
+                    "C (Performance)",
+                    "B (Guitar, Performance)",
                     "X (Vocals)",
                     "Y (Guitar, Vocals)",
-                    "F",
+                    "F (Performance)",
                 })
 
     def test_people(self):
@@ -475,7 +475,7 @@ class TAudioFile(TestCase):
                        ("albumartist", "B"), ("artist", "C")])
         self.failUnlessEqual(q.list("~people"), ["C", "B", "A"])
         self.failUnlessEqual(q.list("~people:roles"),
-                         ["C", "B (Guitar)", "A (Arrangement, Vocals)"])
+            ["C (Performance)", "B (Guitar)", "A (Arrangement, Vocals)"])
 
     def test_people_mix(self):
         q = AudioFile([
@@ -486,7 +486,7 @@ class TAudioFile(TestCase):
         ])
         self.failUnlessEqual(q.list("~people"), ["A"])
         self.failUnlessEqual(q.list("~people:roles"),
-                             ["A (Arrangement, Arrangement, Foo)"])
+            ["A (Arrangement, Arrangement, Foo, Performance)"])
 
     def test_people_multi_value(self):
         q = AudioFile([
@@ -496,9 +496,9 @@ class TAudioFile(TestCase):
         ])
 
         self.failUnlessEqual(q.list("~people"), ["A", "Y", "X"])
-        self.failUnlessEqual(
-            q.list("~people:roles"),
-            ["A (Arrangement, Foo)", "Y", "X (Arrangement, Foo)"])
+        self.failUnlessEqual(q.list("~people:roles"),
+            ["A (Arrangement, Foo, Performance)", "Y (Performance)",
+             "X (Arrangement, Foo)"])
 
     def test_people_individuals(self):
         q = AudioFile({"artist": "A\nX", "albumartist": "Various Artists"})
@@ -524,7 +524,7 @@ class TAudioFile(TestCase):
         self.failUnlessEqual(q.list("~peoplesort"),
                              ["B, The", "C, The", "A, The"])
         self.failUnlessEqual(q.list("~peoplesort:roles"),
-                             ["B, The (Guitar)", "C, The", "A, The (Vocals)"])
+            ["B, The (Guitar)", "C, The (Performance)", "A, The (Vocals)"])
 
     def test_to_dump(self):
         dump = bar_1_1.to_dump()


### PR DESCRIPTION
Patterns like `people:roles` currently generate non-instrument role descriptions like Arrangement, Lyrics, etc. This patch gives bare (role-less) performer tags a similar "Performance" role description (e.g. `<people:roles>` would output `Foo (Performance)` for a song with the tag performer=Foo).