### PR TITLE
Prompt for playlist song removals

### DIFF
--- a/quodlibet/browsers/playlists/main.py
+++ b/quodlibet/browsers/playlists/main.py
@@ -39,7 +39,9 @@ from quodlibet.util import connect_obj
 from quodlibet.util.collection import Playlist
 from quodlibet.util.dprint import print_d, print_w
 from quodlibet.util.urllib import urlopen
-from .util import parse_m3u, parse_pls, confirm_remove_playlist_dialog_invoke, _name_for
+from .util import parse_m3u, parse_pls, _name_for, \
+    confirm_remove_playlist_dialog_invoke, \
+    confirm_remove_playlist_tracks_dialog_invoke
 
 DND_QL, DND_URI_LIST, DND_MOZ_URL = range(3)
 
@@ -352,6 +354,15 @@ class PlaylistsBrowser(Browser, DisplayPatternMixin):
             if not removals:
                 print_w("No songs selected to remove")
                 return
+
+            parent = self
+            songset = {removals[key] for key in removals}
+            response = confirm_remove_playlist_tracks_dialog_invoke(
+                parent, songset, self.Confirmer)
+            if not response:
+                print_d("Removal of track(s) from playlist stopped via prompt")
+                return
+
             if self._query is None or not self.get_filter_text():
                 # Calling playlist.remove_songs(songs) won't remove the
                 # right ones if there are duplicates

--- a/quodlibet/browsers/playlists/util.py
+++ b/quodlibet/browsers/playlists/util.py
@@ -8,7 +8,7 @@
 
 import os
 
-from quodlibet import _, print_w
+from quodlibet import _, print_w, ngettext
 from quodlibet import formats
 from quodlibet.qltk import Icons
 from quodlibet.qltk.getstring import GetStringDialog
@@ -39,6 +39,30 @@ def confirm_remove_playlist_dialog_invoke(
     ok_icon = Icons.EDIT_DELETE
 
     dialog = Confirmer(parent, title, description, ok_text, ok_icon)
+    prompt = dialog.run()
+    response = (prompt == Confirmer.RESPONSE_INVOKE)
+    return response
+
+
+def confirm_remove_playlist_tracks_dialog_invoke(
+    parent, songs, Confirmer=ConfirmationPrompt):
+    """Creates and invokes a confirmation dialog that asks the user whether or not
+       to go forth with the removal of the selected track(s) from the playlist.
+    """
+    songs = set(songs)
+    if not songs:
+        return True
+
+    count = len(songs)
+    song = next(iter(songs))
+    title = ngettext(
+        'Remove track "{track_name}" from playlist?',
+        "Remove {count} tracks from playlist?",
+        len(songs)
+    ).format(track_name=song("title"), count=count)
+
+    ok_text = _("Remove from Playlist")
+    dialog = Confirmer(parent, title, "", ok_text)
     prompt = dialog.run()
     response = (prompt == Confirmer.RESPONSE_INVOKE)
     return response

--- a/tests/test_browsers_playlists.py
+++ b/tests/test_browsers_playlists.py
@@ -310,19 +310,34 @@ class TPlaylistsBrowser(TestCase):
         qltk.selection_set_songs(sel, [song])
         b._drag_data_get(None, None, sel, DND_QL, None)
 
-    def test_songs_deletion(self):
+    # deletion of playlist tracks
+    def test_playlist_track_removal_accept(self):
+        # Check: playlist should have the selected song removed (one fewer)
         b = self.bar
         self._fake_browser_pack(b)
         event = self.a_delete_event()
-        # This is selected in setUp()
         first_pl = b.playlists()[0]
         app.window.songlist.set_songs(first_pl)
-        app.window.songlist.select_by_func(lambda x: True,
-                                           scroll=False, one=True)
+        app.window.songlist.select_by_func(lambda x: True, scroll=False, one=True)
         original_length = len(first_pl)
+
         ret = b.key_pressed(event)
         self.failUnless(ret, msg="Didn't simulate a delete keypress")
         self.failUnlessEqual(len(first_pl), original_length - 1)
+
+    def test_playlist_track_removal_decline(self):
+        # Check: playlist should have the same number of songs
+        b = self.bar_decline
+        self._fake_browser_pack(b)
+        event = self.a_delete_event()
+        first_pl = b.playlists()[0]
+        app.window.songlist.set_songs(first_pl)
+        app.window.songlist.select_by_func(lambda x: True, scroll=False, one=True)
+        original_length = len(first_pl)
+
+        ret = b.key_pressed(event)
+        self.failUnless(ret, msg="Didn't simulate a delete keypress")
+        self.failUnlessEqual(len(first_pl), original_length)
 
     def test_playlist_deletion_ACCEPT(self):
         b = self.bar


### PR DESCRIPTION
As #2667 only accounts for removing from library, this attempt to implement a similar prompt for removing tracks from playlists. #2248

I really dislike the way I ended up passing a flag around in the removal functions/event handlers to account for the tests that use the same interface (and otherwise get stuck waiting for the prompt?)

It could maybe be done differently, though I can not think of a way myself.
playlists/collections seem to be fairly complex... 