### PR TITLE
fix bug with relative file names in enqueue and enqueue-files

### DIFF
--- a/quodlibet/quodlibet/cli.py
+++ b/quodlibet/quodlibet/cli.py
@@ -13,6 +13,7 @@ from senf import fsn2text, uri2fsn
 from quodlibet import C_, _
 from quodlibet.util.dprint import print_, print_e
 from quodlibet.remote import Remote, RemoteError
+from quodlibet.util.string import split_escape, join_escape
 
 
 def exit_(status=None, notify_startup=False):
@@ -221,9 +222,21 @@ def process_arguments(argv):
                 filename = uri2fsn(arg)
             except ValueError:
                 filename = arg
+            if os.path.isfile(filename):
+                filename = os.path.abspath(util.path.expanduser(filename))
             queue(command, filename)
         elif command == "enqueue-files":
-            queue(command, arg)
+            args = []
+            for param in split_escape(arg, ","):
+                try:
+                    filename = uri2fsn(param)
+                except ValueError:
+                    filename = param
+                    if os.path.isfile(filename):
+                        filename = util.path.expanduser(filename)
+                        filename = os.path.abspath(filename)
+                args.append(filename)
+            queue(command, join_escape(args, ","))
         elif command == "play-file":
             if uri_is_valid(arg) and arg.startswith("quodlibet://"):
                 # TODO: allow handling of URIs without --play-file

--- a/quodlibet/quodlibet/commands.py
+++ b/quodlibet/quodlibet/commands.py
@@ -389,7 +389,7 @@ def _enqueue_files(app, value):
         if song_path in library:
             songs.append(library[song_path])
         elif os.path.isfile(song_path):
-            songs.append(library.add_filename(os.path.realpath(value)))
+            songs.append(library.add_filename(os.path.realpath(song_path)))
     if songs:
         window.playlist.enqueue(songs)
 

--- a/quodlibet/tests/test_cli.py
+++ b/quodlibet/tests/test_cli.py
@@ -45,15 +45,17 @@ class Tcli(TestCase):
 
     def test_enqueue_notfile(self):
         tdir = tempfile.gettempdir()
-        (tfile, tpath) = tempfile.mkstemp(dir=tdir)
-        tname = os.path.basename(tpath)
-        os.remove(tpath)
+        # Can't get known non-file the correct way in some setups so fake it
+        # (nfile, npath) = tempfile.mkstemp(dir=tdir)
+        # nname = os.path.basename(npath)
+        # os.remove(npath)
+        nname = "THIS_IS_NOT_A_FILE"
         with working_directory(tdir):
             with capture_output():
                 self.assertEqual(
                     cli.process_arguments(["myprog", "--run",
-                                           "--enqueue", tname]),
-                    (['run'], [('enqueue', tname)]))
+                                           "--enqueue", nname]),
+                    (['run'], [('enqueue', nname)]))
 
     def test_enqueue_file(self):
         tdir = tempfile.gettempdir()
@@ -73,9 +75,11 @@ class Tcli(TestCase):
         tdir = tempfile.gettempdir()
         (tfile, tpath) = tempfile.mkstemp(dir=tdir)
         tname = os.path.basename(tpath)
-        (nfile, npath) = tempfile.mkstemp(dir=tdir)
-        nname = os.path.basename(npath)
-        os.remove(npath)
+        # Can't get known non-file the correct way in some setups so fake it
+        # (nfile, npath) = tempfile.mkstemp(dir=tdir)
+        # nname = os.path.basename(npath)
+        # os.remove(npath)
+        nname = "THIS_IS_NOT_A_FILE"
         try:
             with working_directory(tdir):
                 with capture_output():

--- a/quodlibet/tests/test_cli.py
+++ b/quodlibet/tests/test_cli.py
@@ -65,7 +65,7 @@ class Tcli(TestCase):
                     self.assertEqual(
                         cli.process_arguments(["myprog", "--run",
                                                "--enqueue", tname]),
-                        (['run'], [('enqueue', tdir + "/" + tname)]))
+                        (['run'], [('enqueue', tpath)]))
         finally:
             os.remove(tpath)
 

--- a/quodlibet/tests/test_cli.py
+++ b/quodlibet/tests/test_cli.py
@@ -67,7 +67,7 @@ class Tcli(TestCase):
                                                "--enqueue", tname]),
                         (['run'], [('enqueue', tpath)]))
         finally:
-            os.remove(tpath)
+            True # can't remove files in some test setups - os.remove(tpath)
 
     def test_enqueue_files(self):
         tdir = tempfile.gettempdir()
@@ -85,4 +85,4 @@ class Tcli(TestCase):
                                                nname + "," + tname]),
                         (['run'], [('enqueue-files', nname + "," + tpath)]))
         finally:
-            os.remove(tpath)
+            True # can't remove files in some test setups - os.remove(tpath)

--- a/quodlibet/tests/test_cli.py
+++ b/quodlibet/tests/test_cli.py
@@ -8,6 +8,7 @@
 
 from .helper import capture_output
 from quodlibet import cli
+from quodlibet.util.string import join_escape
 from tests import TestCase
 import os
 import tempfile
@@ -49,7 +50,7 @@ class Tcli(TestCase):
         # (nfile, npath) = tempfile.mkstemp(dir=tdir)
         # nname = os.path.basename(npath)
         # os.remove(npath)
-        nname = "THIS_IS_NOT_A_FILE"
+        nname = "NOT_A_FILE"
         with working_directory(tdir):
             with capture_output():
                 self.assertEqual(
@@ -79,7 +80,7 @@ class Tcli(TestCase):
         # (nfile, npath) = tempfile.mkstemp(dir=tdir)
         # nname = os.path.basename(npath)
         # os.remove(npath)
-        nname = "THIS_IS_NOT_A_FILE"
+        nname = "NOT_A_FILE"
         try:
             with working_directory(tdir):
                 with capture_output():
@@ -87,6 +88,7 @@ class Tcli(TestCase):
                         cli.process_arguments(["myprog", "--run",
                                                "--enqueue-files",
                                                nname + "," + tname]),
-                        (['run'], [('enqueue-files', nname + "," + tpath)]))
+                        (['run'], [('enqueue-files',
+                                    join_escape([nname, tpath], ","))]))
         finally:
             True # can't remove files in some test setups - os.remove(tpath)


### PR DESCRIPTION
Here are the changes to fix the bug with relative file names in the cli arguments enqueue and enqueue-files.  I've also figured out how to do some testing of the commands.