### PR TITLE
Add a show_files() function which allows opening the file browser and…

### DIFF
--- a/quodlibet/quodlibet/ext/songsmenu/browsefolders.py
+++ b/quodlibet/quodlibet/ext/songsmenu/browsefolders.py
@@ -7,13 +7,6 @@
 # the Free Software Foundation; either version 2 of the License, or
 # (at your option) any later version.
 
-import os
-import sys
-import subprocess
-
-from gi.repository import Gtk
-from senf import fsn2uri, fsnative
-
 from quodlibet.plugins.songshelpers import any_song, is_a_file
 
 try:
@@ -25,134 +18,22 @@ from quodlibet import _
 from quodlibet.plugins.songsmenu import SongsMenuPlugin
 from quodlibet.qltk.msg import ErrorMessage
 from quodlibet.qltk import Icons
+from quodlibet.qltk.showfiles import show_files
 from quodlibet.util.dprint import print_d
 
 
-class BrowseError(Exception):
-    pass
-
-
-def group_songs(songs):
-    """Groups a sequence of songs per dirname.
-
-    The value order is the same as with the passed in songs.
-    """
+def show_songs(songs):
+    """Returns False if showing any of them failed"""
 
     dirs = {}
     for s in songs:
-        dirs.setdefault(s("~dirname"), []).append(s)
-    return dirs
+        dirs.setdefault(s("~dirname"), []).append(s("~basename"))
 
-
-def get_startup_id():
-    from quodlibet import app
-    app_name = type(app.window).__name__
-    return "%s_TIME%d" % (app_name, Gtk.get_current_event_time())
-
-
-def browse_folders_fdo(songs):
-    # http://www.freedesktop.org/wiki/Specifications/file-manager-interface
-    FDO_PATH = "/org/freedesktop/FileManager1"
-    FDO_NAME = "org.freedesktop.FileManager1"
-    FDO_IFACE = "org.freedesktop.FileManager1"
-
-    if not dbus:
-        raise BrowseError("no dbus")
-
-    try:
-        bus = dbus.SessionBus()
-        bus_object = bus.get_object(FDO_NAME, FDO_PATH)
-        bus_iface = dbus.Interface(bus_object, dbus_interface=FDO_IFACE)
-
-        # open each folder and select the first file we have selected
-        for dirname, sub_songs in group_songs(songs).items():
-            bus_iface.ShowItems([sub_songs[0]("~uri")], get_startup_id())
-    except dbus.DBusException as e:
-        raise BrowseError(e)
-
-
-def browse_folders_thunar(songs, display=""):
-    # http://git.xfce.org/xfce/thunar/tree/thunar/thunar-dbus-service-infos.xml
-    XFCE_PATH = "/org/xfce/FileManager"
-    XFCE_NAME = "org.xfce.FileManager"
-    XFCE_IFACE = "org.xfce.FileManager"
-
-    if not dbus:
-        raise BrowseError("no dbus")
-
-    try:
-        bus = dbus.SessionBus()
-        bus_object = bus.get_object(XFCE_NAME, XFCE_PATH)
-        bus_iface = dbus.Interface(bus_object, dbus_interface=XFCE_IFACE)
-
-        # open each folder and select the first file we have selected
-        for dirname, sub_songs in group_songs(songs).items():
-            bus_iface.DisplayFolderAndSelect(
-                fsn2uri(dirname),
-                sub_songs[0]("~basename"),
-                display,
-                get_startup_id())
-    except dbus.DBusException as e:
-        raise BrowseError(e)
-
-
-def browse_folders_gnome_open(songs):
-    try:
-        for dir_ in group_songs(songs).keys():
-            if subprocess.call(["gnome-open", dir_]) != 0:
-                raise EnvironmentError("gnome-open error return status")
-    except EnvironmentError as e:
-        raise BrowseError(e)
-
-
-def browse_folders_xdg_open(songs):
-    try:
-        for dir_ in group_songs(songs).keys():
-            if subprocess.call(["xdg-open", dir_]) != 0:
-                raise EnvironmentError("xdg-open error return status")
-    except EnvironmentError as e:
-        raise BrowseError(e)
-
-
-def show_files_win32(path, files):
-    """Takes a path to a directory and a list of filenames in that directory
-    to display.
-
-    Returns True on success.
-    """
-
-    assert os.name == "nt"
-    assert isinstance(path, fsnative)
-    assert all(isinstance(f, fsnative) for f in files)
-
-    from quodlibet.util.windows import open_folder_and_select_items
-
-    try:
-        open_folder_and_select_items(path, files)
-    except WindowsError:
-        return False
+    for dirname, entries in sorted(dirs.items()):
+        status = show_files(dirname, entries)
+        if not status:
+            return False
     return True
-
-
-def browse_folders_win_explorer(songs):
-    if os.name != "nt":
-        raise BrowseError("windows only")
-
-    for path, sub_songs in group_songs(songs).items():
-        if not show_files_win32(path, [s("~basename") for s in sub_songs]):
-            raise BrowseError
-
-
-def browse_folders_finder(songs):
-    if sys.platform != "darwin":
-        raise BrowseError("OS X only")
-
-    try:
-        for dir_ in group_songs(songs).keys():
-            if subprocess.call(["open", "-R", dir_]) != 0:
-                raise EnvironmentError("open error return status")
-    except EnvironmentError as e:
-        raise BrowseError(e)
 
 
 class BrowseFolders(SongsMenuPlugin):
@@ -161,37 +42,13 @@ class BrowseFolders(SongsMenuPlugin):
     PLUGIN_DESC = _("Opens the songs' folders in a file manager.")
     PLUGIN_ICON = Icons.DOCUMENT_OPEN
 
-    _HANDLERS = [browse_folders_fdo, browse_folders_thunar,
-                 browse_folders_xdg_open, browse_folders_gnome_open,
-                 browse_folders_win_explorer, browse_folders_finder]
-
     def plugin_songs(self, songs):
         songs = [s for s in songs if s.is_file]
         print_d("Trying to browse folders...")
-        if not self._handle(songs):
+        if not show_songs(songs):
             ErrorMessage(self.plugin_window,
                          _("Unable to open folders"),
                          _("No program available to open folders.")).run()
 
     plugin_handles = any_song(is_a_file)
     """By default, any single song being a file is good enough"""
-
-    def _handle(self, songs):
-        """
-        Uses the first successful handler in callable list `_HANDLERS`
-        to handle `songs`
-        Returns False if none could be used
-        """
-
-        for handler in self._HANDLERS:
-            name = handler.__name__
-            try:
-                print_d("Trying %r..." % name)
-                handler(songs)
-            except BrowseError as e:
-                print_d("...failed: %r" % e)
-            else:
-                print_d("...success!")
-                return True
-        print_d("No handlers could be used.")
-        return False

--- a/quodlibet/quodlibet/qltk/__init__.py
+++ b/quodlibet/quodlibet/qltk/__init__.py
@@ -18,9 +18,9 @@ gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk
 from gi.repository import Gdk
 from gi.repository import GLib, GObject
-from senf import fsn2bytes, bytes2fsn
+from senf import fsn2bytes, bytes2fsn, uri2fsn
 
-from quodlibet.util import print_d, print_w
+from quodlibet.util import print_d, print_w, is_windows, is_osx
 from quodlibet.compat import urlparse
 
 
@@ -45,13 +45,27 @@ def show_uri(label, uri):
             return False
         else:
             return __show_quodlibet_uri(parsed)
+    elif parsed.scheme == "file" and (is_windows() or is_osx()):
+        # Gio on non-Linux can't handle file URIs for some reason,
+        # fall back to our own implementation for now
+        from quodlibet.qltk.showfiles import show_files
+
+        try:
+            filepath = uri2fsn(uri)
+        except ValueError:
+            return False
+        else:
+            return show_files(filepath, [])
     else:
         # Gtk.show_uri_on_window exists since 3.22
-        if hasattr(Gtk, "show_uri_on_window"):
-            from quodlibet.qltk import get_top_parent
-            return Gtk.show_uri_on_window(get_top_parent(label), uri, 0)
-        else:
-            return Gtk.show_uri(None, uri, 0)
+        try:
+            if hasattr(Gtk, "show_uri_on_window"):
+                from quodlibet.qltk import get_top_parent
+                return Gtk.show_uri_on_window(get_top_parent(label), uri, 0)
+            else:
+                return Gtk.show_uri(None, uri, 0)
+        except GLib.Error:
+            return False
 
 
 def __show_quodlibet_uri(uri):

--- a/quodlibet/quodlibet/qltk/showfiles.py
+++ b/quodlibet/quodlibet/qltk/showfiles.py
@@ -1,0 +1,171 @@
+# -*- coding: utf-8 -*-
+# Copyright 2012,2016 Nick Boultbee
+#           2012,2014,2018 Christoph Reiter
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+
+"""Show directories and files in the default system file browser"""
+
+import os
+import subprocess
+
+from gi.repository import Gtk
+from senf import fsn2uri, fsnative
+
+try:
+    import dbus
+except ImportError:
+    dbus = None
+
+from quodlibet.util import is_windows, is_osx
+
+
+def show_files(dirname, entries=[]):
+    """Shows the directory in the default file browser and if passed
+    a list of directory entries will highlight those.
+
+    Depending on the system/platform this might highlight all files passed,
+    or only one of them, or none at all.
+
+    Args:
+        dirname (fsnative): Path to the directory
+        entries (List[fsnative]): List of (relative) filenames in the directory
+        entries (List[fsnative]): List of (relative) filenames in the directory
+    Returns:
+        bool: if the action was successful or not
+    """
+
+    assert isinstance(dirname, fsnative)
+    assert all(isinstance(e, fsnative) and os.path.basename(e) == e
+               for e in entries)
+
+    dirname = os.path.abspath(dirname)
+
+    if is_windows():
+        implementations = [_show_files_win32]
+    elif is_osx():
+        implementations = [_show_files_finder]
+    else:
+        implementations = [
+            _show_files_fdo,
+            _show_files_thunar,
+            _show_files_xdg_open,
+            _show_files_gnome_open,
+        ]
+
+    for impl in implementations:
+        try:
+            impl(dirname, entries)
+        except BrowseError:
+            continue
+        else:
+            return True
+    return False
+
+
+class BrowseError(Exception):
+    pass
+
+
+def _get_startup_id():
+    from quodlibet import app
+    app_name = type(app.window).__name__
+    return "%s_TIME%d" % (app_name, Gtk.get_current_event_time())
+
+
+def _show_files_fdo(dirname, entries):
+    # http://www.freedesktop.org/wiki/Specifications/file-manager-interface
+    FDO_PATH = "/org/freedesktop/FileManager1"
+    FDO_NAME = "org.freedesktop.FileManager1"
+    FDO_IFACE = "org.freedesktop.FileManager1"
+
+    if not dbus:
+        raise BrowseError("no dbus")
+
+    try:
+        bus = dbus.SessionBus()
+        bus_object = bus.get_object(FDO_NAME, FDO_PATH)
+        bus_iface = dbus.Interface(bus_object, dbus_interface=FDO_IFACE)
+
+        if not entries:
+            bus_iface.ShowFolders(fsn2uri(dirname), _get_startup_id())
+        else:
+            item_uri = fsn2uri(os.path.join(dirname, entries[0]))
+            bus_iface.ShowItems([item_uri])
+    except dbus.DBusException as e:
+        raise BrowseError(e)
+
+
+def _show_files_thunar(dirname, entries):
+    # http://git.xfce.org/xfce/thunar/tree/thunar/thunar-dbus-service-infos.xml
+    XFCE_PATH = "/org/xfce/FileManager"
+    XFCE_NAME = "org.xfce.FileManager"
+    XFCE_IFACE = "org.xfce.FileManager"
+
+    if not dbus:
+        raise BrowseError("no dbus")
+
+    try:
+        bus = dbus.SessionBus()
+        bus_object = bus.get_object(XFCE_NAME, XFCE_PATH)
+        bus_iface = dbus.Interface(bus_object, dbus_interface=XFCE_IFACE)
+
+        if not entries:
+            bus_iface.DisplayFolder(fsn2uri(dirname), "", _get_startup_id())
+        else:
+            item_name = os.path.join(dirname, entries[0])
+            bus_iface.DisplayFolderAndSelect(
+                fsn2uri(dirname), item_name, "", _get_startup_id())
+    except dbus.DBusException as e:
+        raise BrowseError(e)
+
+
+def _show_files_gnome_open(dirname, *args):
+    try:
+        if subprocess.call(["gnome-open", dirname]) != 0:
+            raise EnvironmentError("gnome-open error return status")
+    except EnvironmentError as e:
+        raise BrowseError(e)
+
+
+def _show_files_xdg_open(dirname, *args):
+    try:
+        if subprocess.call(["xdg-open", dirname]) != 0:
+            raise EnvironmentError("xdg-open error return status")
+    except EnvironmentError as e:
+        raise BrowseError(e)
+
+
+def _show_files_win32(dirname, entries):
+    if not is_windows():
+        raise BrowseError("windows only")
+
+    if not entries:
+        # open_folder_and_select_items will open the parent if no items
+        # are passed, so execute explorer directly for that case
+        try:
+            if subprocess.call(["explorer", dirname]) != 0:
+                raise EnvironmentError("explorer error return status")
+        except EnvironmentError as e:
+            raise BrowseError(e)
+    else:
+        from quodlibet.util.windows import open_folder_and_select_items
+
+        try:
+            open_folder_and_select_items(dirname, [])
+        except WindowsError as e:
+            raise BrowseError(e)
+
+
+def _show_files_finder(dirname, *args):
+    if not is_osx():
+        raise BrowseError("OS X only")
+
+    try:
+        if subprocess.call(["open", "-R", dirname]) != 0:
+            raise EnvironmentError("open error return status")
+    except EnvironmentError as e:
+        raise BrowseError(e)


### PR DESCRIPTION
… selecting files.

This extracts the functionality already present in the browse folders plugin
and generalizes it a bit to work on filenames and handle the case
where only a directory is passed and no entries.

Make the browse folder plugin use that new API.

And use the new API in show_uri() under Windows/macOS. The show_uri() API
Gtk/Gio provides isn't working for file URIs there for some reason
(the new "app info" plugin uses it for opening the configuration directory)

Related issue: #1859