### PR TITLE
Fix searching with non-standard columns

### DIFF
--- a/quodlibet/quodlibet/browsers/albums/main.py
+++ b/quodlibet/quodlibet/browsers/albums/main.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Copyright 2004-2007 Joe Wreschnig, Michael Urman, Iñigo Serna
 #           2009-2010 Steven Robertson
-#           2012-2017 Nick Boultbee
+#           2012-2018 Nick Boultbee
 #           2009-2014 Christoph Reiter
 #
 # This program is free software; you can redistribute it and/or modify
@@ -509,8 +509,7 @@ class AlbumList(Browser, util.InstanceTracker, VisibleUpdate,
 
         self.accelerators = Gtk.AccelGroup()
         search = SearchBarBox(completion=AlbumTagCompletion(),
-                              accel_group=self.accelerators,
-                              star=self.STAR)
+                              accel_group=self.accelerators)
         search.connect('query-changed', self.__update_filter)
         connect_obj(search, 'focus-out', lambda w: w.grab_focus(), view)
         self.__search = search
@@ -592,7 +591,7 @@ class AlbumList(Browser, util.InstanceTracker, VisibleUpdate,
         model = self.view.get_model()
 
         self.__filter = None
-        query = self.__search.query
+        query = self.__search.get_query()
         if not query.matches_all:
             self.__filter = query.search
         self.__bg_filter = background_filter()

--- a/quodlibet/quodlibet/browsers/collection/main.py
+++ b/quodlibet/quodlibet/browsers/collection/main.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Copyright 2010, 2012-2014 Christoph Reiter
 #                      2017 Uriel Zajaczkovski
-#                      2017 Nick Boultbee
+#                 2017-2018 Nick Boultbee
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -232,10 +232,8 @@ class CollectionBrowser(Browser, util.InstanceTracker):
         prefs.connect('clicked', lambda *x: Preferences(self))
 
         self.accelerators = Gtk.AccelGroup()
-        tags = self.__model.tags + ["album"]
         search = SearchBarBox(completion=AlbumTagCompletion(),
-                              accel_group=self.accelerators,
-                              star=tags)
+                              accel_group=self.accelerators)
         search.connect('query-changed', self.__update_filter)
         connect_obj(search, 'focus-out', lambda w: w.grab_focus(), view)
         self.__search = search
@@ -293,7 +291,8 @@ class CollectionBrowser(Browser, util.InstanceTracker):
 
     def __update_filter(self, entry, text):
         self.__filter = None
-        query = self.__search.query
+        star = self.__model.tags + ["album"]
+        query = self.__search.get_query(star)
         if not query.matches_all:
             self.__filter = query.search
         self.__bg_filter = background_filter()

--- a/quodlibet/quodlibet/browsers/covergrid/main.py
+++ b/quodlibet/quodlibet/browsers/covergrid/main.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Copyright 2004-2007 Joe Wreschnig, Michael Urman, Iñigo Serna
 #           2009-2010 Steven Robertson
-#           2012-2017 Nick Boultbee
+#           2012-2018 Nick Boultbee
 #           2009-2014 Christoph Reiter
 #
 # This program is free software; you can redistribute it and/or modify
@@ -316,8 +316,7 @@ class CoverGrid(Browser, util.InstanceTracker, VisibleUpdate,
 
         self.accelerators = Gtk.AccelGroup()
         search = SearchBarBox(completion=AlbumTagCompletion(),
-                              accel_group=self.accelerators,
-                              star=self.STAR)
+                              accel_group=self.accelerators)
         search.connect('query-changed', self.__update_filter)
         connect_obj(search, 'focus-out', lambda w: w.grab_focus(), view)
         self.__search = search
@@ -402,7 +401,7 @@ class CoverGrid(Browser, util.InstanceTracker, VisibleUpdate,
         model = self.view.get_model()
 
         self.__filter = None
-        query = self.__search.query
+        query = self.__search.get_query(self.STAR)
         if not query.matches_all:
             self.__filter = query.search
         self.__bg_filter = background_filter()

--- a/quodlibet/quodlibet/browsers/iradio.py
+++ b/quodlibet/quodlibet/browsers/iradio.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Copyright 2011 Joe Wreschnig, Christoph Reiter
-#           2016 Nick Boultbee
+#      2013-2018 Nick Boultbee
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -540,8 +540,7 @@ class InternetRadio(Browser, util.InstanceTracker):
         completion = LibraryTagCompletion(self.__stations)
         self.accelerators = Gtk.AccelGroup()
         self.__searchbar = search = SearchBarBox(completion=completion,
-                                                 accel_group=self.accelerators,
-                                                 star=self.STAR)
+                                                 accel_group=self.accelerators)
         search.connect('query-changed', self.__filter_changed)
 
         menu = Gtk.Menu()

--- a/quodlibet/quodlibet/browsers/paned/main.py
+++ b/quodlibet/quodlibet/browsers/paned/main.py
@@ -2,7 +2,7 @@
 # Copyright 2004-2008 Joe Wreschnig, Michael Urman, Iñigo Serna
 #           2009,2010 Steven Robertson
 #           2009-2013 Christoph Reiter
-#           2011-2017 Nick Boultbee
+#           2011-2018 Nick Boultbee
 #                2017 Fredrik Strupe
 #
 # This program is free software; you can redistribute it and/or modify
@@ -18,7 +18,6 @@ from quodlibet import util
 from quodlibet import _
 from quodlibet.browsers import Browser
 from quodlibet.formats import PEOPLE
-from quodlibet.query import Query
 from quodlibet.qltk.songlist import SongList
 from quodlibet.qltk.completion import LibraryTagCompletion
 from quodlibet.qltk.searchbar import SearchBarBox
@@ -183,8 +182,7 @@ class PanedBrowser(Browser, util.InstanceTracker):
     def activate(self):
         star = dict.fromkeys(SongList.star)
         star.update(self.__star)
-        # TODO: get query from SearchBarBox (but with dynamic star)
-        query = Query(self._get_text(), star.keys())
+        query = self._sb_box.get_query(star.keys())
         if query.is_parsable:
             self._filter = query.search
             songs = list(filter(self._filter, self._library))

--- a/quodlibet/quodlibet/browsers/playlists/main.py
+++ b/quodlibet/quodlibet/browsers/playlists/main.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Copyright 2005 Joe Wreschnig
-#    2012 - 2017 Nick Boultbee
+#    2012 - 2018 Nick Boultbee
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -186,7 +186,7 @@ class PlaylistsBrowser(Browser, DisplayPatternMixin):
 
     @property
     def _query(self):
-        return self._sb_box.query
+        return self._sb_box.get_query(SongList.star)
 
     def __destroy(self, *args):
         del self._sb_box
@@ -200,7 +200,7 @@ class PlaylistsBrowser(Browser, DisplayPatternMixin):
         self.accelerators = Gtk.AccelGroup()
         completion = LibraryTagCompletion(library.librarian)
         sbb = SearchBarBox(completion=completion,
-                           accel_group=self.accelerators, star=SongList.star)
+                           accel_group=self.accelerators)
         sbb.connect('query-changed', self.__text_parse)
         sbb.connect('focus-out', self.__focus)
         return sbb
@@ -489,7 +489,7 @@ class PlaylistsBrowser(Browser, DisplayPatternMixin):
 
     def activate(self, widget=None, resort=True):
         songs = self._get_playlist_songs()
-        query = self._sb_box.query
+        query = self._sb_box.get_query(SongList.star)
         if query and query.is_parsable:
             songs = query.filter(songs)
         GLib.idle_add(self.songs_selected, songs, resort)

--- a/quodlibet/quodlibet/browsers/search.py
+++ b/quodlibet/quodlibet/browsers/search.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2004-2017 Joe Wreschnig, Michael Urman, Iñigo Serna,
+# Copyright 2004-2018 Joe Wreschnig, Michael Urman, Iñigo Serna,
 #                     Christoph Reiter, Steven Robertson, Nick Boultbee
 #
 # This program is free software; you can redistribute it and/or modify
@@ -17,6 +17,7 @@ from quodlibet.qltk.ccb import ConfigCheckMenuItem
 from quodlibet.qltk.completion import LibraryTagCompletion
 from quodlibet.qltk.menubutton import MenuButton
 from quodlibet.qltk.searchbar import LimitSearchBarBox
+from quodlibet.qltk.songlist import SongList
 from quodlibet.qltk.x import Align, SymbolicIconImage
 from quodlibet.qltk import Icons
 
@@ -99,7 +100,7 @@ class SearchBar(Browser):
         qltk.get_top_parent(widget).songlist.grab_focus()
 
     def _get_songs(self):
-        self._query = self._sb_box.query
+        self._query = self._sb_box.get_query(SongList.star)
         return self._query.filter(self._library) if self._query else None
 
     def activate(self):

--- a/quodlibet/quodlibet/qltk/searchbar.py
+++ b/quodlibet/quodlibet/qltk/searchbar.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Copyright 2010-2011 Christoph Reiter, Steven Robertson
-#           2016-2017 Nick Boultbee
+#           2016-2018 Nick Boultbee
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -64,7 +64,7 @@ class SearchBarBox(Gtk.HBox):
             entry.set_completion(completion)
 
         self._star = star
-        self.query = None
+        self._query = None
         self.__sig = combo.connect('text-changed', self.__text_changed)
 
         entry.connect('clear', self.__filter_changed)
@@ -104,12 +104,18 @@ class SearchBarBox(Gtk.HBox):
 
     def _update_query_from(self, text):
         # TODO: remove tight coupling to Query
-        self.query = Query(text, star=self._star)
+        self._query = Query(text, star=self._star)
 
     def get_text(self):
         """Get the active text as unicode"""
 
         return self.__entry.get_text()
+
+    def get_query(self, star=None):
+        if star and star != self._star:
+            self._star = star
+            self._update_query_from(self.get_text())
+        return self._query
 
     def changed(self):
         """Triggers a filter-changed signal if the current text
@@ -149,7 +155,7 @@ class SearchBarBox(Gtk.HBox):
             return
 
         text = self.get_text().strip()
-        if text and self.query.is_parsable:
+        if text and self._query.is_parsable:
             # Adding the active text to the model triggers a changed signal
             # (get_active is no longer -1), so inhibit
             self.__inhibit()
@@ -161,7 +167,7 @@ class SearchBarBox(Gtk.HBox):
         self.__deferred_changed.abort()
         text = self.get_text()
         self._update_query_from(text)
-        if self.query.is_parsable:
+        if self._query.is_parsable:
             GLib.idle_add(self.emit, 'query-changed', text)
             self.__save_search(args[0:1], args[1:])
 

--- a/quodlibet/quodlibet/query/_query.py
+++ b/quodlibet/quodlibet/query/_query.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Copyright 2004-2005 Joe Wreschnig, Michael Urman
-#           2015-2017 Nick Boultbee,
+#           2015-2018 Nick Boultbee,
 #                2016 Ryan Dellenbaugh
 #
 # This program is free software; you can redistribute it and/or modify
@@ -37,9 +37,6 @@ class Query(Node):
 
     string = None
     """The original string which was used to create this query"""
-
-    stars = None
-    """List of default tags used"""
 
     def __init__(self, string, star=None):
         """Parses the query string and returns a match object.
@@ -143,6 +140,10 @@ class Query(Node):
 
     def __neg__(self):
         return self._match.__neg__()
+
+    def __eq__(self, other):
+        return (self.string == other.string and self.star == other.star and
+                self.type == other.type)
 
     @classmethod
     def validator(cls, string):

--- a/quodlibet/tests/test_browsers_search.py
+++ b/quodlibet/tests/test_browsers_search.py
@@ -15,6 +15,7 @@ import quodlibet.config
 from quodlibet.browsers.search import SearchBar
 from quodlibet.formats import AudioFile
 from quodlibet.library import SongLibrary, SongLibrarian
+from quodlibet.qltk.songlist import SongList
 
 # Don't sort yet, album_key makes it complicated...
 SONGS = [AudioFile({
@@ -113,6 +114,23 @@ class TSearchBar(TestCase):
         self.expected = sorted([SONGS[0]] + SONGS[2:])
         self.bar.filter("~#length", [0])
         self._do()
+
+    def test_search_text_artist(self):
+        self.bar._set_text("boris")
+        self.expected = [SONGS[2]]
+        self.bar._sb_box.changed()
+        self._do()
+
+    def test_search_text_custom_star(self):
+        old = SongList.star
+        SongList.star = ["artist", "labelid"]
+        self.bar._set_text("65432-1")
+        self.expected = [SONGS[3]]
+        self.bar._sb_box.changed()
+        try:
+            self._do()
+        finally:
+            SongList.star = old
 
     def test_saverestore(self):
         self.bar.filter_text("title = %s" % SONGS[0]["title"])

--- a/quodlibet/tests/test_qltk_searchbar.py
+++ b/quodlibet/tests/test_qltk_searchbar.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+
+from quodlibet.qltk.searchbar import SearchBarBox
+from quodlibet.query import Query
+
+from . import TestCase
+
+
+class TSearchBarBox(TestCase):
+
+    def test_get_query(self):
+        sbb = SearchBarBox()
+        self.failIf(sbb.get_query(None))
+        a_star = ["artist", "date", "custom"]
+        sbb.set_text("foobar")
+        expected = Query("foobar", star=a_star)
+        self.failUnlessEqual(sbb.get_query(a_star), expected)
+
+    def test_get_query_override_star(self):
+        sbb = SearchBarBox(star=["initial"])
+        text = "foobar"
+        sbb.set_text(text)
+        self.failUnlessEqual(sbb.get_query(), Query(text, star=["initial"]))
+        another_star = ["another", "star"]
+        self.failUnlessEqual(sbb.get_query(star=another_star),
+                             Query(text, star=another_star))


### PR DESCRIPTION
 * Remove specification of `star` from browser construction (though
 it remains optional)
 * instead pass it in at query time
 * ...converting the `query` property to `get_query(star=None)` -
 thanks to @lazka for this idea. If not supplied it will used the
 most recent value for star.
 * This also solves a longstanding TODO with the Paned browser - you
 should now be able to search in any columns
 * Add basic star tests for `SearchBarBox`
 * Add some basic tests for text-based searching within Search Browsers

Fixes #2688