### PR TITLE
tests: capture exceptions that are not caught during the test execution an reraise them. Fixes #2705

### DIFF
--- a/quodlibet/tests/conftest.py
+++ b/quodlibet/tests/conftest.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018 Christoph Reiter
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+
+import sys
+
+import pytest
+
+
+@pytest.hookimpl(hookwrapper=True)
+def pytest_runtest_call(item):
+    """A pytest hook which takes over sys.excepthook and raises any uncaught
+    exception (with PyGObject this happesn often when we get called from C,
+    like any signal handler, vfuncs tc)
+    """
+
+    assert sys.excepthook is sys.__excepthook__
+
+    exceptions = []
+
+    def on_hook(type_, value, tback):
+        exceptions.append((type_, value, tback))
+
+    sys.excepthook = on_hook
+    try:
+        yield
+    finally:
+        sys.excepthook = sys.__excepthook__
+        if exceptions:
+            tp, value, tb = exceptions[0]
+            raise tp(value).with_traceback(tb)

--- a/quodlibet/tests/test_browsers_playlists.py
+++ b/quodlibet/tests/test_browsers_playlists.py
@@ -29,7 +29,7 @@ from quodlibet.formats import AudioFile
 from quodlibet.util.path import mkdir
 from quodlibet.library.librarians import SongLibrarian
 from quodlibet.library.libraries import FileLibrary
-from tests.test_browsers_search import SONGS, TSearchBar
+from tests.test_browsers_search import SONGS
 
 
 class ConfigSetupMixin(object):
@@ -161,7 +161,7 @@ class TPlaylistIntegration(TestCase):
         self.assertFalse(len(pl))
 
 
-class TPlaylistsBrowser(TSearchBar):
+class TPlaylistsBrowser(TestCase):
     Bar = PlaylistsBrowser
 
     ANOTHER_SONG = AudioFile({
@@ -211,6 +211,17 @@ class TPlaylistsBrowser(TSearchBar):
         shutil.rmtree(PLAYLISTS)
         PlaylistsBrowser.deinit(self.lib)
         destroy_fake_app()
+
+    def _expected(self, bar, songs, sort):
+        songs.sort()
+        if self.expected is not None:
+            self.failUnlessEqual(self.expected, songs)
+        self.success = True
+
+    def _do(self):
+        while Gtk.events_pending():
+            Gtk.main_iteration()
+        self.failUnless(self.success or self.expected is None)
 
     def test_saverestore(self):
         # Flush previous signals, etc. Hmm.


### PR DESCRIPTION
Exceptions raised during signals don't bubble to the test caller, instead they
get pushed into sys.excepthook which by default prints them.

This adds a pytest plugin which wraps each test (I think..) collects uncaught exceptions
and reraises them at the end.

This uncovers a few bugs, so this makes the tests fail atm.