### PR TITLE
Prompt on extending a playlist with another DND'ed playlist

### DIFF
--- a/quodlibet/browsers/playlists/main.py
+++ b/quodlibet/browsers/playlists/main.py
@@ -39,7 +39,9 @@ from quodlibet.util import connect_obj
 from quodlibet.util.collection import Playlist
 from quodlibet.util.dprint import print_d, print_w
 from quodlibet.util.urllib import urlopen
-from .util import parse_m3u, parse_pls, confirm_remove_playlist_dialog_invoke, _name_for
+from .util import parse_m3u, parse_pls, _name_for, \
+    confirm_remove_playlist_dialog_invoke, \
+    confirm_dnd_playlist_dialog_invoke
 
 DND_QL, DND_URI_LIST, DND_MOZ_URL = range(3)
 
@@ -376,6 +378,24 @@ class PlaylistsBrowser(Browser, DisplayPatternMixin):
         playlist = model[path][0]
         return playlist
 
+    def _add_drag_data_tracks_to_playlist(self, target_playlist, songs):
+        """helper-function to facilitate unit-tests without fiddling with views"""
+        # Accidentally extending through DnD'ing a playlist can be a fairly
+        # large operation, so prompt the user before proceeding.
+        # See issue #2367
+        playlist_name = target_playlist.name
+        response = confirm_dnd_playlist_dialog_invoke(
+            self, songs, playlist_name, self.Confirmer)
+        if response:
+            target_playlist.extend(songs)
+            self.changed(target_playlist)
+            was_modified = True
+        else:
+            print_d("DnD-extension of playlist cancelled through prompt")
+            was_modified = False
+
+        return was_modified
+
     def __drag_data_received(self, view, ctx, x, y, sel, tid, etime):
         # TreeModelSort doesn't support GtkTreeDragDestDrop.
         view.emit_stop_by_name('drag-data-received')
@@ -383,22 +403,38 @@ class PlaylistsBrowser(Browser, DisplayPatternMixin):
         if tid == DND_QL:
             filenames = qltk.selection_get_filenames(sel)
             songs = list(filter(None, [self.songs_lib.get(f) for f in filenames]))
+            # Used in conjunction with the prompt for DnD to decide whether to
+            # perform various updates/refreshes.
+            was_modified = True
             if not songs:
                 Gtk.drag_finish(ctx, False, False, etime)
                 return
+
             try:
                 path, pos = view.get_dest_row_at_pos(x, y)
             except TypeError:
+                # e.g. the target is the empty area after the list of playlists?
+                # TODO: Maybe prompt for this too? Though getting a new playlist is
+                # less intrusive than modifying an existing playlist.
+                # XXX: There does not seem to be an empty area anymore (changed
+                # by one of these pull-requests: #3751 #3974 or the newish browser
+                # code?).
                 playlist = self.pl_lib.create_from_songs(songs)
                 GLib.idle_add(self._select_playlist, playlist)
+                # self.changed()
             else:
                 playlist = model[path][0]
-                playlist.extend(songs)
+                # Call a helper-function that adds the tracks to the playlist if the
+                # user accepts the prompt.
+                was_modified = self._add_drag_data_tracks_to_playlist(
+                    playlist, songs
+                )
+
             # self.changed(playlist)
             Gtk.drag_finish(ctx, True, False, etime)
             # Cause a refresh to the dragged-to playlist if it is selected
             # so that the dragged (duplicate) track(s) appears
-            if playlist is self._selected_playlist():
+            if playlist is self._selected_playlist() and was_modified:
                 model, plist_iter = self.__selected_playlists()
                 songlist = qltk.get_top_parent(self).songlist
                 self.activate(resort=not songlist.is_sorted())

--- a/quodlibet/browsers/playlists/util.py
+++ b/quodlibet/browsers/playlists/util.py
@@ -8,7 +8,7 @@
 
 import os
 
-from quodlibet import _, print_w
+from quodlibet import _, print_w, ngettext
 from quodlibet import formats
 from quodlibet.qltk import Icons
 from quodlibet.qltk.getstring import GetStringDialog
@@ -39,6 +39,27 @@ def confirm_remove_playlist_dialog_invoke(
     ok_icon = Icons.EDIT_DELETE
 
     dialog = Confirmer(parent, title, description, ok_text, ok_icon)
+    prompt = dialog.run()
+    response = (prompt == Confirmer.RESPONSE_INVOKE)
+    return response
+
+
+def confirm_dnd_playlist_dialog_invoke(
+    parent, songs, target_playlist_name, Confirmer=ConfirmationPrompt):
+    """see confirm_remove_playlist_dialog_invoke above, except for
+       the action of attempting to extend a playlist with a second
+       dragged and dropped playlist.
+    """
+    title = ngettext(
+        "Extend \"{pl_name}\" with {num} additional track?",
+        "Extend \"{pl_name}\" with {num} additional tracks?",
+        len(songs),
+    ).format(pl_name=target_playlist_name, num=len(songs))
+
+    description = ""
+    ok_text = _("_Add Tracks")
+
+    dialog = Confirmer(parent, title, description, ok_text)
     prompt = dialog.run()
     response = (prompt == Confirmer.RESPONSE_INVOKE)
     return response

--- a/tests/test_browsers_playlists.py
+++ b/tests/test_browsers_playlists.py
@@ -310,6 +310,42 @@ class TPlaylistsBrowser(TestCase):
         qltk.selection_set_songs(sel, [song])
         b._drag_data_get(None, None, sel, DND_QL, None)
 
+    def test_playlist_drag_data_extend_accept(self):
+        b = self.bar
+        song1 = AudioFile()
+        song2 = AudioFile()
+        song3 = AudioFile()
+        song1["~filename"] = fsnative(u"foo1")
+        song2["~filename"] = fsnative(u"foo2")
+        song3["~filename"] = fsnative(u"foo3")
+        sel = MockSelData()
+        qltk.selection_set_songs(sel, [song1, song2, song3])
+        filenames = qltk.selection_get_filenames(sel)
+
+        first_pl = b.playlists()[0]
+        original_length = len(first_pl)
+        # This is usually called by __drag_data_received, but that is heavily
+        # dependent on gtk-views, so is more conveniently called manually.
+        b._add_drag_data_tracks_to_playlist(first_pl, filenames)
+        self.failUnlessEqual(len(first_pl), original_length + 3)
+
+    def test_playlist_drag_data_extend_decline(self):
+        b = self.bar_decline
+        song1 = AudioFile()
+        song2 = AudioFile()
+        song3 = AudioFile()
+        song1["~filename"] = fsnative(u"foo1")
+        song2["~filename"] = fsnative(u"foo2")
+        song3["~filename"] = fsnative(u"foo3")
+        sel = MockSelData()
+        qltk.selection_set_songs(sel, [song1, song2, song3])
+        filenames = qltk.selection_get_filenames(sel)
+
+        first_pl = b.playlists()[0]
+        original_length = len(first_pl)
+        b._add_drag_data_tracks_to_playlist(first_pl, filenames)
+        self.failUnlessEqual(len(first_pl), original_length)
+
     def test_songs_deletion(self):
         b = self.bar
         self._fake_browser_pack(b)


### PR DESCRIPTION
initial attempt to fix #2367 
and in line with a few other commits/PRs regarding prompts for actions that are annoying to do on accident (see e.g #2453 )

A few issues with this:

* I dislike that I handled it by simply not calling qltk.selection_set_songs(sel, songs) if the prompt failed, which to my surprise was enough to not (visibly at least) have any tracks be removed/changes occur. This feels like a dodgy way to do it to me though so I might have overlooked something here... 
* _drag_data_get was the only place I found that gets called when a playlist is dragged onto another playlist, that is not also being called on any DND action whatsoever (like when tracks are getting dragged onto a playlist). Prompting in the latter case would in my opinion be annoying as dragging tracks onto a playlist is way more common than dragging a playlist onto another playlist.
* To add to the above, I did not find a way to differentiate between a dragged playlist and dragged tracks in the first method I looked into (__drag_data_received, I think it was?) 
* I found no way of getting the name of the target playlist (that tracks are being added to), in the current version of this commit it is simply referred to as "target_playlist"
* test case monkeypatches the run method of the prompt in a similar way to #2675

otherwise it seems to work from the testing I have done, but are there better ways to achieve this?