### PR TITLE
Fix raising NotImplementedError

### DIFF
--- a/quodlibet/quodlibet/operon/base.py
+++ b/quodlibet/quodlibet/operon/base.py
@@ -85,7 +85,7 @@ class Command(object):
     def _execute(self, options, args):
         """Override to execute something"""
 
-        raise NotImplemented
+        raise NotImplementedError
 
     def print_help(self, file=None):
         """Print the help information about the comand"""

--- a/quodlibet/quodlibet/remote.py
+++ b/quodlibet/quodlibet/remote.py
@@ -32,7 +32,7 @@ class RemoteBase(object):
             cmd_registry (CommandRegistry)
         """
 
-        raise NotImplemented
+        raise NotImplementedError
 
     @classmethod
     def remote_exists(self):
@@ -42,7 +42,7 @@ class RemoteBase(object):
             bool
         """
 
-        raise NotImplemented
+        raise NotImplementedError
 
     @classmethod
     def send_message(cls, message):
@@ -58,7 +58,7 @@ class RemoteBase(object):
                 there was no response.
         """
 
-        raise NotImplemented
+        raise NotImplementedError
 
     def start(self):
         """Start the listener for other instances.
@@ -67,12 +67,12 @@ class RemoteBase(object):
             RemoteError: in case another instance is already listening.
         """
 
-        raise NotImplemented
+        raise NotImplementedError
 
     def stop(self):
         """Stop the listener for other instances"""
 
-        raise NotImplemented
+        raise NotImplementedError
 
 
 class QuodLibetWinRemote(RemoteBase):


### PR DESCRIPTION
`NotImplemented` is a sentinel object, not an exception type.
It was mistakenly used instead of `NotImplementedError`.