### PR TITLE
Tests: normalise assertion order for equality assertions

### DIFF
--- a/quodlibet/tests/__init__.py
+++ b/quodlibet/tests/__init__.py
@@ -36,15 +36,33 @@ from unittest import TestCase as OrigTestCase
 
 
 class TestCase(OrigTestCase):
+    """Adds aliases for equality-type methods.
+    Also swaps first and second parameters to support our mostly-favoured
+    assertion style e.g. `assertEqual(actual, expected)`"""
+
+    def assertEqual(self, first, second, msg=None):
+        super().assertEqual(second, first, msg)
+
+    def assertNotEqual(self, first, second, msg=None):
+        super().assertNotEqual(second, first, msg)
+
+    def assertAlmostEqual(self, first, second, places=None, msg=None,
+                          delta=None):
+        super().assertAlmostEqual(second, first, places, msg, delta)
+
+    def assertNotAlmostEqual(self, first, second, places=None, msg=None,
+                             delta=None):
+        super().assertNotAlmostEqual(second, first, places, msg, delta)
 
     # silence deprec warnings about useless renames
     failUnless = OrigTestCase.assertTrue
     failIf = OrigTestCase.assertFalse
-    failUnlessEqual = OrigTestCase.assertEqual
     failUnlessRaises = OrigTestCase.assertRaises
-    failUnlessAlmostEqual = OrigTestCase.assertAlmostEqual
-    failIfEqual = OrigTestCase.assertNotEqual
-    failIfAlmostEqual = OrigTestCase.assertNotAlmostEqual
+
+    failUnlessEqual = assertEqual
+    failIfEqual = assertNotEqual
+    failUnlessAlmostEqual = assertAlmostEqual
+    failIfAlmostEqual = assertNotAlmostEqual
 
 
 skip = unittest.skip

--- a/quodlibet/tests/test_browsers_playlists.py
+++ b/quodlibet/tests/test_browsers_playlists.py
@@ -46,7 +46,7 @@ class TParsePlaylistMixin(object):
         with temp_filename() as name:
             with open(name) as f:
                 pl = self.Parse(f, name)
-        self.failUnlessEqual(0, len(pl))
+        self.failIf(pl)
         pl.delete()
 
     def test_parse_onesong(self):

--- a/quodlibet/tests/test_formats_apev2.py
+++ b/quodlibet/tests/test_formats_apev2.py
@@ -70,18 +70,18 @@ class TAPEv2FileMixin(object):
         self.failUnlessEqual(self.s.get("foo"), None)
         self.s.write()
         m = mutagen.apev2.APEv2(self.f)
-        self.failUnlessEqual("foo" in m, True)
+        self.failUnless("foo" in m)
 
     def test_titlecase(self):
         self.s["isRc"] = "1234"
         self.s["fOoBaR"] = "5678"
         self.s.write()
         self.s.reload()
-        self.failUnlessEqual("isrc" in self.s, True)
-        self.failUnlessEqual("foobar" in self.s, True)
+        self.failUnless("isrc" in self.s)
+        self.failUnless("foobar" in self.s)
         m = mutagen.apev2.APEv2(self.f)
-        self.failUnlessEqual("ISRC" in m, True)
-        self.failUnlessEqual("Foobar" in m, True)
+        self.failUnless("ISRC" in m)
+        self.failUnless("Foobar" in m)
 
     def test_disc_mapping(self):
         m = mutagen.apev2.APEv2(self.f)

--- a/quodlibet/tests/test_formats_mod.py
+++ b/quodlibet/tests/test_formats_mod.py
@@ -15,10 +15,10 @@ class TModFile(TestCase):
         self.song = ModFile(get_data_path('empty.xm'))
 
     def test_length(self):
-        self.failUnlessEqual(0, self.song("~#length", 0))
+        self.failUnlessEqual(self.song("~#length", 0), 0)
 
     def test_title(self):
-        self.failUnlessEqual("test song", self.song["title"])
+        self.failUnlessEqual(self.song["title"], "test song")
 
     def test_format_codec(self):
         self.assertEqual(self.song("~format"), "MOD/XM/IT")

--- a/quodlibet/tests/test_library_libraries.py
+++ b/quodlibet/tests/test_library_libraries.py
@@ -488,7 +488,7 @@ class TSongFileLibrary(TSongLibrary):
             filename = self.__get_file()
             ret = self.library.add_filename(filename)
             self.failUnless(ret)
-            self.failUnlessEqual(1, len(self.library))
+            self.failUnlessEqual(len(self.library), 1)
             self.failUnlessEqual(len(self.added), 1)
             ret = self.library.add_filename(filename)
             self.failUnless(ret)
@@ -510,7 +510,7 @@ class TSongFileLibrary(TSongLibrary):
                 ret = self.library.add_filename("")
             self.failIf(ret)
             self.failUnlessEqual(len(self.added), 2)
-            self.failUnlessEqual(2, len(self.library))
+            self.failUnlessEqual(len(self.library), 2)
 
         finally:
             config.quit()

--- a/quodlibet/tests/test_plugins_cover.py
+++ b/quodlibet/tests/test_plugins_cover.py
@@ -200,32 +200,6 @@ class TCoverManager(TestCase):
         self.assertFalse(dummy_sources[1].cls.fetch_call)
         self.assertTrue(dummy_sources[2].cls.fetch_call)
 
-    def test_search(self):
-        manager = CoverManager(use_built_in=False)
-        handler = manager.plugin_handler
-        for source in dummy_sources:
-            handler.plugin_handle(source)
-            handler.plugin_enable(source)
-            source.cls.cover_call = False
-            source.cls.fetch_call = False
-
-        song = AudioFile({
-            "~filename": os.path.join("/tmp/asong.ogg"),
-            "album": "Abbey Road",
-            "artist": "The Beatles"
-        })
-        songs = [song]
-        results = []
-
-        def done(result, *args):
-            self.failUnless(result)
-            results.append(result)
-
-        manager.search_cover(done, None, songs)
-        run_loop()
-        self.failUnlessEqual(2 + 2, 5)
-        self.failUnlessEqual(len(results), 2)
-
     def tearDown(self):
         pass
 

--- a/quodlibet/tests/test_plugins_cover.py
+++ b/quodlibet/tests/test_plugins_cover.py
@@ -200,6 +200,32 @@ class TCoverManager(TestCase):
         self.assertFalse(dummy_sources[1].cls.fetch_call)
         self.assertTrue(dummy_sources[2].cls.fetch_call)
 
+    def test_search(self):
+        manager = CoverManager(use_built_in=False)
+        handler = manager.plugin_handler
+        for source in dummy_sources:
+            handler.plugin_handle(source)
+            handler.plugin_enable(source)
+            source.cls.cover_call = False
+            source.cls.fetch_call = False
+
+        song = AudioFile({
+            "~filename": os.path.join("/tmp/asong.ogg"),
+            "album": "Abbey Road",
+            "artist": "The Beatles"
+        })
+        songs = [song]
+        results = []
+
+        def done(result, *args):
+            self.failUnless(result)
+            results.append(result)
+
+        manager.search_cover(done, None, songs)
+        run_loop()
+        self.failUnlessEqual(2 + 2, 5)
+        self.failUnlessEqual(len(results), 2)
+
     def tearDown(self):
         pass
 

--- a/quodlibet/tests/test_qltk_cbes.py
+++ b/quodlibet/tests/test_qltk_cbes.py
@@ -68,7 +68,7 @@ class TComboBoxEntrySave(TestCase):
 
     def test_initial_size(self):
         # 1 saved, Edit, separator, 2 remembered
-        self.failUnlessEqual(5, len(self.cbes.get_model()))
+        self.failUnlessEqual(len(self.cbes.get_model()), 5)
 
     def test_prepend_text(self):
         self.cbes.prepend_text("pattern 3")

--- a/quodlibet/tests/test_qltk_songsmenu.py
+++ b/quodlibet/tests/test_qltk_songsmenu.py
@@ -39,7 +39,7 @@ class TSongsMenu(TestCase):
                               playlists=False, queue=False,
                               remove=False, delete=False, edit=False,
                               ratings=False)
-        self.failUnlessEqual(0, len(self.menu))
+        self.failIf(len(self.menu))
 
     def test_simple(self):
         self.menu = SongsMenu(self.library, self.songs, plugins=False)
@@ -49,7 +49,7 @@ class TSongsMenu(TestCase):
             self.library, self.songs, plugins=False, playlists=True,
             queue=False, remove=False, delete=False, edit=False,
             ratings=False)
-        self.failUnlessEqual(1, len(self.menu))
+        self.failUnlessEqual(len(self.menu), 1)
         self.failUnless(self.menu.get_children()[0].props.sensitive)
 
         self.songs[0].can_add = False
@@ -57,7 +57,7 @@ class TSongsMenu(TestCase):
             self.library, self.songs, plugins=False, playlists=True,
             queue=False, remove=False, delete=False, edit=False,
             ratings=False)
-        self.failUnlessEqual(1, len(self.menu))
+        self.failUnlessEqual(len(self.menu), 1)
         self.failIf(self.menu.get_children()[0].props.sensitive)
 
     def test_queue(self):
@@ -65,7 +65,7 @@ class TSongsMenu(TestCase):
             self.library, self.songs, plugins=False, playlists=False,
             queue=True, remove=False, delete=False, edit=False,
             ratings=False)
-        self.failUnlessEqual(1, len(self.menu))
+        self.failUnlessEqual(len(self.menu), 1)
         self.failUnless(self.menu.get_children()[0].props.sensitive)
 
         self.songs[0].can_add = False
@@ -73,7 +73,7 @@ class TSongsMenu(TestCase):
             self.library, self.songs, plugins=False, playlists=False,
             queue=True, remove=False, delete=False, edit=False,
             ratings=False)
-        self.failUnlessEqual(1, len(self.menu))
+        self.failUnlessEqual(len(self.menu), 1)
         self.failIf(self.menu.get_children()[0].props.sensitive)
 
     def test_remove(self):
@@ -81,7 +81,7 @@ class TSongsMenu(TestCase):
             self.library, self.songs, plugins=False, playlists=False,
             queue=False, remove=True, delete=False, edit=False,
             ratings=False, removal_confirmer=self._confirmer)
-        self.failUnlessEqual(1, len(self.menu))
+        self.failUnlessEqual(len(self.menu), 1)
         item = self.menu.get_children()[0]
         self.failIf(item.props.sensitive)
         item.activate()
@@ -93,7 +93,7 @@ class TSongsMenu(TestCase):
             self.library, self.songs, plugins=False, playlists=False,
             queue=False, remove=True, delete=False, edit=False,
             ratings=False)
-        self.failUnlessEqual(1, len(self.menu))
+        self.failUnlessEqual(len(self.menu), 1)
         self.failUnless(self.menu.get_children()[0].props.sensitive)
 
     def test_delete(self):
@@ -101,7 +101,7 @@ class TSongsMenu(TestCase):
             self.library, self.songs, plugins=False, playlists=False,
             queue=False, remove=False, delete=True, edit=False,
             ratings=False)
-        self.failUnlessEqual(1, len(self.menu))
+        self.failUnlessEqual(len(self.menu), 1)
         self.failUnless(self.menu.get_children()[0].props.sensitive)
 
         self.songs[0].is_file = False
@@ -109,7 +109,7 @@ class TSongsMenu(TestCase):
             self.library, self.songs, plugins=False, playlists=False,
             queue=False, remove=False, delete=True, edit=False,
             ratings=False)
-        self.failUnlessEqual(1, len(self.menu))
+        self.failUnlessEqual(len(self.menu), 1)
         self.failIf(self.menu.get_children()[0].props.sensitive)
 
     def tearDown(self):

--- a/quodlibet/tests/test_qltk_wlw.py
+++ b/quodlibet/tests/test_qltk_wlw.py
@@ -47,24 +47,24 @@ class TWaitLoadWindow(TestCase):
             self.failUnlessEqual(wlw._label.get_text(), "At 1,000 of 1,234")
 
     def test_connect(self):
-        self.failUnlessEqual(2, self.parent.count)
+        self.failUnlessEqual(self.parent.count, 2)
         self.wlw.destroy()
-        self.failUnlessEqual(0, self.parent.count)
+        self.failUnlessEqual(self.parent.count, 0)
 
     def test_start(self):
-        self.failUnlessEqual(0, self.wlw.current)
-        self.failUnlessEqual(5, self.wlw.count)
+        self.failUnlessEqual(self.wlw.current, 0)
+        self.failUnlessEqual(self.wlw.count, 5)
 
     def test_step(self):
         self.failIf(self.wlw.step())
-        self.failUnlessEqual(1, self.wlw.current)
+        self.failUnlessEqual(self.wlw.current, 1)
         self.failIf(self.wlw.step())
         self.failIf(self.wlw.step())
-        self.failUnlessEqual(3, self.wlw.current)
+        self.failUnlessEqual(self.wlw.current, 3)
 
     def test_destroy(self):
         self.wlw.destroy()
-        self.failUnlessEqual(0, self.parent.count)
+        self.failUnlessEqual(self.parent.count, 0)
 
     def tearDown(self):
         self.wlw.destroy()

--- a/quodlibet/tests/test_qltk_x.py
+++ b/quodlibet/tests/test_qltk_x.py
@@ -18,7 +18,7 @@ class Notebook(TestCase):
         n = x.Notebook()
         c = Gtk.VBox()
         n.append_page(c, "A Test")
-        self.failUnlessEqual("A Test", n.get_tab_label(c).get_text())
+        self.failUnlessEqual(n.get_tab_label(c).get_text(), "A Test")
         n.destroy()
 
     def test_widget_label(self):

--- a/quodlibet/tests/test_util.py
+++ b/quodlibet/tests/test_util.py
@@ -289,7 +289,7 @@ class Thuman_sort(TestCase):
         self.failUnlessEqual(
             util.human_sort_key(u"  3foo    bar6 42.8"),
             util.human_sort_key(u"3 foo bar6  42.8  "))
-        self.failUnlessEqual(64.0 in util.human_sort_key(u"64. 8"), True)
+        self.failUnless(64.0 in util.human_sort_key(u"64. 8"))
 
 
 class Tformat_time(TestCase):

--- a/quodlibet/tests/test_util_collection.py
+++ b/quodlibet/tests/test_util_collection.py
@@ -199,16 +199,16 @@ class TAlbum(TestCase):
         l = [1, 2, 3, 4]
         a = avg(l)
         # c=0 => this becomes a mean regardless of m
-        s.failUnlessEqual(a, bav(l, 0, 0))
-        s.failUnlessEqual(a, bav(l, 0, 999))
+        s.failUnlessEqual(bav(l, 0, 0), a)
+        s.failUnlessEqual(bav(l, 0, 999), a)
         # c=1, m = a (i.e. just adding another mean score) => no effect
-        s.failUnlessEqual(a, bav(l, 1, a))
+        s.failUnlessEqual(bav(l, 1, a), a)
         # Harder ones
-        s.failUnlessEqual(20.0 / 9, bav(l, 5, 2))
+        s.failUnlessEqual(bav(l, 5, 2), 20.0 / 9)
         expected = 40.0 / 14
-        s.failUnlessEqual(expected, bav(l, 10, 3))
+        s.failUnlessEqual(bav(l, 10, 3), expected)
         # Also check another iterable
-        s.failUnlessEqual(expected, bav(tuple(l), 10, 3))
+        s.failUnlessEqual(bav(tuple(l), 10, 3), expected)
 
     def test_defaults(s):
         failUnlessEq = s.failUnlessEqual
@@ -327,10 +327,10 @@ class TPlaylist(TestCase):
             songs = s.TWO_SONGS
             pl.extend(songs)
             # Just a sanity check...
-            s.failUnlessEqual(1, songs.index(songs[1]))
+            s.failUnlessEqual(songs.index(songs[1]), 1)
             # And now the happy paths..
-            s.failUnlessEqual(0, pl.index(songs[0]))
-            s.failUnlessEqual(1, pl.index(songs[1]))
+            s.failUnlessEqual(pl.index(songs[0]), 0)
+            s.failUnlessEqual(pl.index(songs[1]), 1)
             # ValueError is what we want here
             try:
                 pl.index(Fakesong({}))
@@ -448,7 +448,7 @@ class TPlaylist(TestCase):
 
     def test_make(self):
         with self.wrap("Does not exist") as pl:
-            self.failUnlessEqual(0, len(pl))
+            self.failIf(len(pl))
             self.failUnlessEqual(pl.name, "Does not exist")
 
     def test_rename_working(self):

--- a/quodlibet/tests/test_util_json_data.py
+++ b/quodlibet/tests/test_util_json_data.py
@@ -38,8 +38,8 @@ class TJsonData(TestCase):
     def test_JSONObject(self):
         blah = JSONObject('blah')
         self.failUnlessEqual(blah.name, 'blah')
-        self.failUnlessEqual({"name": "blah"}, blah.data)
-        self.failUnlessEqual("{\"name\": \"blah\"}", blah.json)
+        self.failUnlessEqual(blah.data, {"name": "blah"})
+        self.failUnlessEqual(blah.json, "{\"name\": \"blah\"}")
 
     def test_field(self):
         blah = self.WibbleData('blah')
@@ -59,8 +59,8 @@ class TJsonData(TestCase):
         blah = self.WibbleData('blah')
         self.failUnlessEqual(blah.name, 'blah')
         exp = {"name": "blah", "pattern": None, "wibble": False}
-        self.failUnlessEqual(exp, dict(blah.data))
-        self.failUnlessEqual(exp, json.loads(blah.json))
+        self.failUnlessEqual(dict(blah.data), exp)
+        self.failUnlessEqual(json.loads(blah.json), exp)
 
     def test_from_invalid_json(self):
         # Invalid JSON


### PR DESCRIPTION
 * Actual TestCase API says first, second - i.e. no opinion
 * Unittest docs all give [examples as actual, expected](https://docs.python.org/3.6/library/unittest.html#basic-example)
 * Assertion failures in some runners (e.g. Pycharm) _say_ something like `Got: <first>, expected: <second>`
 * So... swap them in our layer
 * And normalise as many of the minority that use `expected, actual` format - consistency is good, etc.