### PR TITLE
Independent cover size for Album List and Cover Grid browser

### DIFF
--- a/quodlibet/quodlibet/browsers/albums/models.py
+++ b/quodlibet/quodlibet/browsers/albums/models.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 # Copyright 2013 Christoph Reiter
+#           2018 Uriel Zajaczkovski
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -28,6 +29,13 @@ class AlbumItem(object):
             size = 48
         return size
 
+    @property
+    def COVER_SIZE_GRID(self):
+        size = config.getint("browsers", "cover_size_grid")
+        if size <= 0:
+            size = 96
+        return size
+
     def scan_cover(self, force=False, scale_factor=1,
             callback=None, cancel=None):
         if (self.scanned and not force) or not self.album or \
@@ -40,6 +48,21 @@ class AlbumItem(object):
             callback()
 
         s = self.COVER_SIZE * scale_factor
+        app.cover_manager.get_pixbuf_many_async(
+            self.album.songs, s, s, cancel, set_cover_cb)
+
+    def scan_cover_grid(self, force=False, scale_factor=1,
+            callback=None, cancel=None):
+        if (self.scanned and not force) or not self.album or \
+                not self.album.songs:
+            return
+        self.scanned = True
+
+        def set_cover_cb(pixbuf):
+            self.cover = pixbuf
+            callback()
+
+        s = self.COVER_SIZE_GRID * scale_factor
         app.cover_manager.get_pixbuf_many_async(
             self.album.songs, s, s, cancel, set_cover_cb)
 

--- a/quodlibet/quodlibet/browsers/covergrid/main.py
+++ b/quodlibet/quodlibet/browsers/covergrid/main.py
@@ -47,8 +47,10 @@ from quodlibet.qltk.cover import get_no_cover_pixbuf
 from quodlibet.qltk.image import add_border_widget, get_surface_for_pixbuf
 from quodlibet.qltk import popup_menu_at_widget
 
+
 def get_cover_size_grid():
     return AlbumItem(None).COVER_SIZE_GRID
+
 
 class PreferencesButton(PreferencesButton):
     def __init__(self, browser, model):
@@ -132,7 +134,6 @@ class CoverGrid(Browser, util.InstanceTracker, VisibleUpdate,
     keys = ["CoverGrid"]
     priority = 4
 
-
     def pack(self, songpane):
         container = self.songcontainer
         container.pack1(self, True, False)
@@ -171,7 +172,8 @@ class CoverGrid(Browser, util.InstanceTracker, VisibleUpdate,
     def update_mag(klass):
         mag = config.getfloat("browsers", "covergrid_magnification", 3.)
         for covergrid in klass.instances():
-            covergrid.__cover.set_property('width', get_cover_size_grid() * mag + 8)
+            covergrid.__cover.set_property('width',
+                get_cover_size_grid() * mag + 8)
             covergrid.__cover.set_property('height',
                 get_cover_size_grid() * mag + 8)
             covergrid.view.set_item_width(get_cover_size_grid() * mag + 8)
@@ -377,7 +379,6 @@ class CoverGrid(Browser, util.InstanceTracker, VisibleUpdate,
         iter_ = sort_model.convert_iter_to_child_iter(iter_)
         tref = Gtk.TreeRowReference.new(model, model.get_path(iter_))
         mag = config.getfloat("browsers", "covergrid_magnification", 3.)
-
 
         def callback():
             path = tref.get_path()

--- a/quodlibet/quodlibet/browsers/covergrid/main.py
+++ b/quodlibet/quodlibet/browsers/covergrid/main.py
@@ -3,6 +3,7 @@
 #           2009-2010 Steven Robertson
 #           2012-2018 Nick Boultbee
 #           2009-2014 Christoph Reiter
+#           2018      Uriel Zajaczkovski
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -17,9 +18,9 @@ from gi.repository import Gtk, Pango, Gdk, Gio
 
 from .prefs import Preferences, DEFAULT_PATTERN_TEXT
 from quodlibet.browsers.albums.models import (AlbumModel,
-    AlbumFilterModel, AlbumSortModel)
-from quodlibet.browsers.albums.main import (get_cover_size,
-    AlbumTagCompletion, PreferencesButton, VisibleUpdate)
+    AlbumFilterModel, AlbumSortModel, AlbumItem)
+from quodlibet.browsers.albums.main import (AlbumTagCompletion,
+    PreferencesButton, VisibleUpdate)
 
 import quodlibet
 from quodlibet import app
@@ -46,6 +47,8 @@ from quodlibet.qltk.cover import get_no_cover_pixbuf
 from quodlibet.qltk.image import add_border_widget, get_surface_for_pixbuf
 from quodlibet.qltk import popup_menu_at_widget
 
+def get_cover_size_grid():
+    return AlbumItem(None).COVER_SIZE_GRID
 
 class PreferencesButton(PreferencesButton):
     def __init__(self, browser, model):
@@ -129,6 +132,7 @@ class CoverGrid(Browser, util.InstanceTracker, VisibleUpdate,
     keys = ["CoverGrid"]
     priority = 4
 
+
     def pack(self, songpane):
         container = self.songcontainer
         container.pack1(self, True, False)
@@ -167,10 +171,10 @@ class CoverGrid(Browser, util.InstanceTracker, VisibleUpdate,
     def update_mag(klass):
         mag = config.getfloat("browsers", "covergrid_magnification", 3.)
         for covergrid in klass.instances():
-            covergrid.__cover.set_property('width', get_cover_size() * mag + 8)
+            covergrid.__cover.set_property('width', get_cover_size_grid() * mag + 8)
             covergrid.__cover.set_property('height',
-                get_cover_size() * mag + 8)
-            covergrid.view.set_item_width(get_cover_size() * mag + 8)
+                get_cover_size_grid() * mag + 8)
+            covergrid.view.set_item_width(get_cover_size_grid() * mag + 8)
             covergrid.view.queue_resize()
             covergrid.redraw()
 
@@ -200,7 +204,7 @@ class CoverGrid(Browser, util.InstanceTracker, VisibleUpdate,
 
         mag = config.getfloat("browsers", "covergrid_magnification", 3.)
 
-        cover_size = get_cover_size()
+        cover_size = get_cover_size_grid()
         scale_factor = self.get_scale_factor() * mag
         pb = get_no_cover_pixbuf(cover_size, cover_size, scale_factor)
         return get_surface_for_pixbuf(self, pb)
@@ -224,7 +228,7 @@ class CoverGrid(Browser, util.InstanceTracker, VisibleUpdate,
         model_sort = AlbumSortModel(model=self.__model)
         model_filter = AlbumFilterModel(child_model=model_sort)
         self.view = view = IconView(model_filter)
-        #view.set_item_width(get_cover_size() + 12)
+        #view.set_item_width(get_cover_size_grid() + 12)
         self.view.set_row_spacing(config.getint("browsers", "row_spacing", 6))
         self.view.set_column_spacing(config.getint("browsers",
             "column_spacing", 6))
@@ -239,11 +243,11 @@ class CoverGrid(Browser, util.InstanceTracker, VisibleUpdate,
 
         mag = config.getfloat("browsers", "covergrid_magnification", 3.)
 
-        self.view.set_item_width(get_cover_size() * mag + 8)
+        self.view.set_item_width(get_cover_size_grid() * mag + 8)
 
         self.__cover = render = Gtk.CellRendererPixbuf()
-        render.set_property('width', get_cover_size() * mag + 8)
-        render.set_property('height', get_cover_size() * mag + 8)
+        render.set_property('width', get_cover_size_grid() * mag + 8)
+        render.set_property('height', get_cover_size_grid() * mag + 8)
         view.pack_start(render, False)
 
         def cell_data_pb(view, cell, model, iter_, no_cover):
@@ -374,6 +378,7 @@ class CoverGrid(Browser, util.InstanceTracker, VisibleUpdate,
         tref = Gtk.TreeRowReference.new(model, model.get_path(iter_))
         mag = config.getfloat("browsers", "covergrid_magnification", 3.)
 
+
         def callback():
             path = tref.get_path()
             if path is not None:
@@ -383,7 +388,7 @@ class CoverGrid(Browser, util.InstanceTracker, VisibleUpdate,
 
         item = model.get_value(iter_)
         scale_factor = self.get_scale_factor() * mag
-        item.scan_cover(scale_factor=scale_factor,
+        item.scan_cover_grid(scale_factor=scale_factor,
                         callback=callback,
                         cancel=self._cover_cancel)
 

--- a/quodlibet/quodlibet/config.py
+++ b/quodlibet/quodlibet/config.py
@@ -2,6 +2,7 @@
 # Copyright 2004-2008 Joe Wreschnig
 #           2009-2017 Nick Boultbee
 #           2011-2014 Christoph Reiter
+#           2018      Uriel Zajaczkovski
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -147,6 +148,9 @@ INITIAL = {
 
         # max cover height/width, <= 0 is default
         "cover_size": "-1",
+
+        # max cover height/width, <= 0 is default
+        "cover_size_grid": "-1",
 
         # Show the limit widgets for SearchBar
         "search_limit": "false",

--- a/quodlibet/quodlibet/ext/events/advanced_preferences.py
+++ b/quodlibet/quodlibet/ext/events/advanced_preferences.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # Copyright 2015 Christoph Reiter
 #        2016-17 Nick Boultbee
+#        2018    Uriel Zajaczkovski
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -129,9 +130,16 @@ class AdvancedPreferences(EventPlugin):
         rows.append(
             int_config(
                 "browsers", "cover_size",
-                "Album cover size:",
-                ("Size of the album cover images in the album list browser "
+                "Album List browser cover size:",
+                ("Size of the album cover images in the Album List browser "
                  "(restart required)")))
+
+        rows.append(
+            int_config(
+                "browsers", "cover_size_grid",
+                "Cover Grid browser cover size:",
+                ("Size of the album cover images in the Cover Grid browser "
+                "(restart required)")))
 
         rows.append(
             boolean_config(


### PR DESCRIPTION
This PR allows to have independent values for the covers displayed in the Album List and Cover Grid browsers. The default value for the Cover Grid is set to 96, however users can set their preferred sized via the Advanced Preferences plugin.