### PR TITLE
Add cli options for setting repeat and shuffle type

### DIFF
--- a/quodlibet/data/quodlibet.1
+++ b/quodlibet/data/quodlibet.1
@@ -128,6 +128,10 @@ Refresh and rescan library
 .B \-\-repeat=off|on|t
 Turn repeat off, on, or toggle
 .TP
+.B \-\-repeat\-type=current|all|one
+Repeat the currently playing song, the current list, or stop after
+one song
+.TP
 .B \-\-seek=[+|\-][HH:]MM:SS
 Seek within the playing song
 .UNINDENT
@@ -145,6 +149,13 @@ Rate the playing song
 .TP
 .B \-\-show\-window
 Show main window
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-\-shuffle\-type=random|weighted
+Set the shuffle type to be random or to prefer higher rated songs
+.UNINDENT
+.INDENT 0.0
 .TP
 .B \-\-start\-hidden
 Don\(aqt show any windows on start

--- a/quodlibet/data/quodlibet.1
+++ b/quodlibet/data/quodlibet.1
@@ -128,9 +128,9 @@ Refresh and rescan library
 .B \-\-repeat=off|on|t
 Turn repeat off, on, or toggle
 .TP
-.B \-\-repeat\-type=current|all|one
-Repeat the currently playing song, the current list, or stop after
-one song
+.B \-\-repeat\-type=current|all|one|off
+Repeat the currently playing song, the current list, stop after
+one song, or turn repeat off
 .TP
 .B \-\-seek=[+|\-][HH:]MM:SS
 Seek within the playing song
@@ -152,8 +152,12 @@ Show main window
 .UNINDENT
 .INDENT 0.0
 .TP
-.B \-\-shuffle\-type=random|weighted
-Set the shuffle type to be random or to prefer higher rated songs
+.B \-\-shuffle=off|on|t
+Turn shuffle off, on, or toggle
+.TP
+.B \-\-shuffle\-type=random|weighted|off
+Set the shuffle type to be random, to prefer higher rated songs,
+or turn shuffle off
 .UNINDENT
 .INDENT 0.0
 .TP

--- a/quodlibet/docs/guide/commands/quodlibet.rst
+++ b/quodlibet/docs/guide/commands/quodlibet.rst
@@ -100,6 +100,10 @@ OPTIONS
 --repeat=off|on|t
     Turn repeat off, on, or toggle
 
+--repeat-type=current|all|one
+    Repeat the currently playing song, the current list, or stop after
+    one song
+
 --seek=[+|-][HH:]MM:SS
     Seek within the playing song
 
@@ -111,6 +115,9 @@ OPTIONS
 
 --show-window
     Show main window
+
+--shuffle-type=random|weighted
+    Set the shuffle type to be random or to prefer higher rated songs
 
 --start-hidden
     Don't show any windows on start

--- a/quodlibet/docs/guide/commands/quodlibet.rst
+++ b/quodlibet/docs/guide/commands/quodlibet.rst
@@ -100,9 +100,9 @@ OPTIONS
 --repeat=off|on|t
     Turn repeat off, on, or toggle
 
---repeat-type=current|all|one
-    Repeat the currently playing song, the current list, or stop after
-    one song
+--repeat-type=current|all|one|off
+    Repeat the currently playing song, the current list, stop after
+    one song, or turn repeat off
 
 --seek=[+|-][HH:]MM:SS
     Seek within the playing song
@@ -116,8 +116,12 @@ OPTIONS
 --show-window
     Show main window
 
---shuffle-type=random|weighted
-    Set the shuffle type to be random or to prefer higher rated songs
+--shuffle=off|on|t
+    Turn shuffle off, on, or toggle
+
+--shuffle-type=random|weighted|off
+    Set the shuffle type to be random, to prefer higher rated songs,
+    or turn shuffle off
 
 --start-hidden
     Don't show any windows on start

--- a/quodlibet/quodlibet/cli.py
+++ b/quodlibet/quodlibet/cli.py
@@ -79,7 +79,8 @@ def process_arguments(argv):
                 "focus", "quit", "unfilter", "refresh", "force-previous"]
     controls_opt = ["seek", "repeat", "query", "volume", "filter",
                     "set-rating", "set-browser", "open-browser", "shuffle",
-                    "song-list", "queue", "stop-after", "random"]
+                    "song-list", "queue", "stop-after", "random",
+                    "repeat-type", "shuffle-type"]
 
     options = util.OptionParser(
         "Quod Libet", const.VERSION,
@@ -120,8 +121,10 @@ def process_arguments(argv):
 
     for opt, help, arg in [
         ("seek", _("Seek within the playing song"), _("[+|-][HH:]MM:SS")),
-        ("shuffle", _("Set or toggle shuffle mode"), "[0|1|t"),
+        ("shuffle", _("Set or toggle shuffle mode"), "0|1|t"),
+        ("shuffle-type", _("Set shuffle mode type"), "random|weighted"),
         ("repeat", _("Turn repeat off, on, or toggle it"), "0|1|t"),
+        ("repeat-type", _("Set repeat mode type"), "current|all|one"),
         ("volume", _("Set the volume"), "(+|-|)0..100"),
         ("query", _("Search your audio library"), _("query")),
         ("play-file", _("Play a file"), C_("command", "filename")),
@@ -175,7 +178,9 @@ def process_arguments(argv):
 
     validators = {
         "shuffle": ["0", "1", "t", "on", "off", "toggle"].__contains__,
+        "shuffle-type": ["random", "weighted"].__contains__,
         "repeat": ["0", "1", "t", "on", "off", "toggle"].__contains__,
+        "repeat-type": ["current", "all", "one"].__contains__,
         "volume": is_vol,
         "seek": is_time,
         "set-rating": is_float,

--- a/quodlibet/quodlibet/cli.py
+++ b/quodlibet/quodlibet/cli.py
@@ -122,9 +122,9 @@ def process_arguments(argv):
     for opt, help, arg in [
         ("seek", _("Seek within the playing song"), _("[+|-][HH:]MM:SS")),
         ("shuffle", _("Set or toggle shuffle mode"), "0|1|t"),
-        ("shuffle-type", _("Set shuffle mode type"), "random|weighted"),
+        ("shuffle-type", _("Set shuffle mode type"), "random|weighted|off"),
         ("repeat", _("Turn repeat off, on, or toggle it"), "0|1|t"),
-        ("repeat-type", _("Set repeat mode type"), "current|all|one"),
+        ("repeat-type", _("Set repeat mode type"), "current|all|one|off"),
         ("volume", _("Set the volume"), "(+|-|)0..100"),
         ("query", _("Search your audio library"), _("query")),
         ("play-file", _("Play a file"), C_("command", "filename")),
@@ -178,9 +178,9 @@ def process_arguments(argv):
 
     validators = {
         "shuffle": ["0", "1", "t", "on", "off", "toggle"].__contains__,
-        "shuffle-type": ["random", "weighted"].__contains__,
+        "shuffle-type": ["random", "weighted", "off", "0"].__contains__,
         "repeat": ["0", "1", "t", "on", "off", "toggle"].__contains__,
-        "repeat-type": ["current", "all", "one"].__contains__,
+        "repeat-type": ["current", "all", "one", "off", "0"].__contains__,
         "volume": is_vol,
         "seek": is_time,
         "set-rating": is_float,

--- a/quodlibet/quodlibet/commands.py
+++ b/quodlibet/quodlibet/commands.py
@@ -217,10 +217,14 @@ def _shuffle(app, value):
 
 @registry.register("shuffle-type", args=1)
 def _shuffle_type(app, value):
-    if value == "random":
-        app.window.order.shuffler = OrderShuffle
-    elif value == "weighted":
-        app.window.order.shuffler = OrderWeighted
+    if value in ["random", "weighted"]:
+        app.player_options.shuffle = True
+        if value == "random":
+            app.window.order.shuffler = OrderShuffle
+        elif value == "weighted":
+            app.window.order.shuffler = OrderWeighted
+    elif value in ["off", "0"]:
+        app.player_options.shuffle = False
 
 
 @registry.register("repeat", args=1)
@@ -237,12 +241,16 @@ def _repeat(app, value):
 
 @registry.register("repeat-type", args=1)
 def _repeat_type(app, value):
-    if value == "current":
-        app.window.order.repeater = RepeatSongForever
-    elif value == "all":
-        app.window.order.repeater = RepeatListForever
-    elif value == "one":
-        app.window.order.repeater = OneSong
+    if value in ["current", "all", "one"]:
+        app.player_options.repeat = True
+        if value == "current":
+            app.window.order.repeater = RepeatSongForever
+        elif value == "all":
+            app.window.order.repeater = RepeatListForever
+        elif value == "one":
+            app.window.order.repeater = OneSong
+    elif value in ["off", "0"]:
+        app.player_options.repeat = False
 
 
 @registry.register("seek", args=1)

--- a/quodlibet/quodlibet/commands.py
+++ b/quodlibet/quodlibet/commands.py
@@ -24,6 +24,10 @@ from quodlibet.qltk.browser import LibraryBrowser
 from quodlibet.qltk.properties import SongProperties
 from quodlibet.util.library import scan_library
 
+from quodlibet.order.repeat import RepeatListForever, RepeatSongForever, \
+        OneSong
+from quodlibet.order.reorder import OrderWeighted, OrderShuffle
+
 
 class CommandError(Exception):
     pass
@@ -211,6 +215,14 @@ def _shuffle(app, value):
         po.shuffle = not po.shuffle
 
 
+@registry.register("shuffle-type", args=1)
+def _shuffle_type(app, value):
+    if value == "random":
+        app.window.order.shuffler = OrderShuffle
+    elif value == "weighted":
+        app.window.order.shuffler = OrderWeighted
+
+
 @registry.register("repeat", args=1)
 def _repeat(app, value):
     po = app.player_options
@@ -221,6 +233,16 @@ def _repeat(app, value):
         po.repeat = True
     elif value in ["t", "toggle"]:
         po.repeat = not po.repeat
+
+
+@registry.register("repeat-type", args=1)
+def _repeat_type(app, value):
+    if value == "current":
+        app.window.order.repeater = RepeatSongForever
+    elif value == "all":
+        app.window.order.repeater = RepeatListForever
+    elif value == "one":
+        app.window.order.repeater = OneSong
 
 
 @registry.register("seek", args=1)

--- a/quodlibet/quodlibet/qltk/playorder.py
+++ b/quodlibet/quodlibet/qltk/playorder.py
@@ -191,6 +191,7 @@ class ToggledPlayOrderMenu(Gtk.Box):
         self.__current = value
         if not self.__inhibit:
             self.emit('changed', self.__current)
+        self.__rebuild_menu()
 
     def set_active_by_name(self, name):
         for cls in self.__orders:


### PR DESCRIPTION
Fixes #2785 

There are a few things to consider here, which I would like to have some input on:

- Should order plugins (like Reverse) also be adjustable via the command line? If so, what should happen if set while the plugin is not enabled?
- Should changing the mode type also turn on the mode? Worth mentioning since setting multiple options at once doesn't seem to work too well.
- This change appears to have some overlap with the '--order' option mentioned in the manpage, but that option doesn't seem to have been implemented... I'm also not sure if the format of the --order option maps too well against the GUI.