### PR TITLE
Queue stop once empty: do check at end of song instead

### DIFF
--- a/quodlibet/quodlibet/qltk/queue.py
+++ b/quodlibet/quodlibet/qltk/queue.py
@@ -130,7 +130,6 @@ class QueueExpander(Gtk.Expander):
 
         clear_item = MenuItem(_("_Clear Queue"), Icons.EDIT_CLEAR)
         menu.append(clear_item)
-        clear_item.connect("activate", self.__clear_queue)
 
         button = SmallMenuButton(
             SymbolicIconImage(Icons.EMBLEM_SYSTEM, Gtk.IconSize.MENU),
@@ -184,7 +183,7 @@ class QueueExpander(Gtk.Expander):
             state_icon, False)
 
         connect_destroy(
-            player, 'song-started', self.__update_queue_stop, self.queue.model)
+            player, 'song-ended', self.__update_queue_stop, self.queue.model)
 
         # to make the children clickable if mapped
         # ....no idea why, but works
@@ -223,14 +222,6 @@ class QueueExpander(Gtk.Expander):
         else:
             state_icon.stop()
 
-    def __clear_queue(self, activator):
-        self.model.clear()
-        stop_queue = config.getboolean("memory",
-                                       "queue_stop_once_empty",
-                                       False)
-        if stop_queue:
-            app.player_options.stop_after = True
-
     def __motion(self, wid, context, x, y, time):
         Gdk.drag_status(context, Gdk.DragAction.COPY, time)
         return True
@@ -260,12 +251,11 @@ class QueueExpander(Gtk.Expander):
         self.queue.model.order = (OrderShuffle() if is_shuffled
                                   else OrderInOrder())
 
-    def __update_queue_stop(self, player, song, model):
+    def __update_queue_stop(self, player, song, stopped, model):
         enabled = config.getboolean("memory", "queue_stop_once_empty", False)
         songs_left = len(model.get())
-        if enabled and songs_left == 1:
-            # Enable stop_after if this is the last song
-            app.player_options.stop_after = True
+        if enabled and songs_left == 0 and not stopped:
+            app.player.stop()
 
     def __expand(self, widget, prop, menu_button):
         expanded = self.get_expanded()


### PR DESCRIPTION
Stops playback directly when a song has ended and the queue is empty, as opposed to enabling the "Stop After Empty" setting when the last song has started.

See #2774 