### PR TITLE
Docs: fix command argument format

### DIFF
--- a/quodlibet/data/quodlibet.1
+++ b/quodlibet/data/quodlibet.1
@@ -49,13 +49,11 @@ documentation is available at
 .SH OPTIONS
 .INDENT 0.0
 .TP
-.B \-\-enqueue filename|query
+.BI \-\-enqueue \ <filename|query>
 Enqueue a filename or query results
 .TP
-.B \-\-filter tag=value
+.BI \-\-filter \ <tag=value>
 Filter on a tag value
-.UNINDENT
-.INDENT 0.0
 .TP
 .B \-\-focus
 Focus the running player
@@ -115,44 +113,32 @@ Filter on a random value
 .TP
 .B \-\-refresh
 Refresh and rescan library
-.UNINDENT
-.INDENT 0.0
 .TP
-.B \-\-repeat=off|on|t
+.BI \-\-repeat\fB= <off|on|t>
 Turn repeat off, on, or toggle
 .TP
-.B \-\-repeat\-type=current|all|one|off
+.BI \-\-repeat\-type\fB= <current|all|one|off>
 Repeat the currently playing song, the current list, stop after
 one song, or turn repeat off
 .TP
-.B \-\-seek=[+|\-][HH:]MM:SS
+.BI \-\-seek\fB= <[+|\-][HH:]MM:SS>
 Seek within the playing song
-.UNINDENT
-.INDENT 0.0
 .TP
 .BI \-\-set\-browser\fB= BrowserName
 Set the current browser
-.UNINDENT
-.INDENT 0.0
 .TP
-.B \-\-set\-rating=0.0..1.0
+.BI \-\-set\-rating\fB= <0.0..1.0>
 Rate the playing song
-.UNINDENT
-.INDENT 0.0
 .TP
 .B \-\-show\-window
 Show main window
-.UNINDENT
-.INDENT 0.0
 .TP
-.B \-\-shuffle=off|on|t
+.BI \-\-shuffle\fB= <off|on|t>
 Turn shuffle off, on, or toggle
 .TP
-.B \-\-shuffle\-type=random|weighted|off
+.BI \-\-shuffle\-type\fB= <random|weighted|off>
 Set the shuffle type to be random, to prefer higher rated songs,
 or turn shuffle off
-.UNINDENT
-.INDENT 0.0
 .TP
 .B \-\-start\-hidden
 Don\(aqt show any windows on start
@@ -162,26 +148,20 @@ Begin playing immediately
 .TP
 .B \-\-status
 Print playing status
-.UNINDENT
-.INDENT 0.0
 .TP
-.B \-\-stop\-after=0|1|t
+.BI \-\-stop\-after\fB= <0|1|t>
 Stop after the playing song
-.UNINDENT
-.INDENT 0.0
 .TP
 .B \-\-toggle\-window
 Toggle main window visibility
 .TP
 .B \-\-unfilter
 Remove active browser filters
-.UNINDENT
-.INDENT 0.0
 .TP
-.B \-\-unqueue=filename|query
+.BI \-\-unqueue\fB= <filename|query>
 Unqueue a file or query
 .TP
-.B \-\-volume=(+|\-|)0..100
+.BI \-\-volume\fB= <(+\e|\-\e|)0..100>
 Set the volume
 .UNINDENT
 .SH ALBUM COVERS

--- a/quodlibet/docs/guide/commands/quodlibet.rst
+++ b/quodlibet/docs/guide/commands/quodlibet.rst
@@ -29,10 +29,10 @@ https://quodlibet.readthedocs.io/en/latest/guide/index.html.
 OPTIONS
 =======
 
---enqueue filename|query
+--enqueue <filename|query>
     Enqueue a filename or query results
 
---filter tag=value
+--filter <tag=value>
     Filter on a tag value
 
 --focus
@@ -94,29 +94,29 @@ OPTIONS
 --refresh
     Refresh and rescan library
 
---repeat=off|on|t
+--repeat=<off|on|t>
     Turn repeat off, on, or toggle
 
---repeat-type=current|all|one|off
+--repeat-type=<current|all|one|off>
     Repeat the currently playing song, the current list, stop after
     one song, or turn repeat off
 
---seek=[+|-][HH:]MM:SS
+--seek=<[+|-][HH:]MM:SS>
     Seek within the playing song
 
 --set-browser=BrowserName
     Set the current browser
 
---set-rating=0.0..1.0
+--set-rating=<0.0..1.0>
     Rate the playing song
 
 --show-window
     Show main window
 
---shuffle=off|on|t
+--shuffle=<off|on|t>
     Turn shuffle off, on, or toggle
 
---shuffle-type=random|weighted|off
+--shuffle-type=<random|weighted|off>
     Set the shuffle type to be random, to prefer higher rated songs,
     or turn shuffle off
 
@@ -129,7 +129,7 @@ OPTIONS
 --status
     Print playing status
 
---stop-after=0|1|t
+--stop-after=<0|1|t>
     Stop after the playing song
 
 --toggle-window
@@ -138,10 +138,10 @@ OPTIONS
 --unfilter
     Remove active browser filters
 
---unqueue=filename|query
+--unqueue=<filename|query>
     Unqueue a file or query
 
---volume=(+\|-\|)0..100
+--volume=<(+\|-\|)0..100>
     Set the volume
 
 ALBUM COVERS


### PR DESCRIPTION
Arguments with special characters (like = and |) must be put between angle brackets. This makes the webdoc render each command properly.

Now the commands are all in the same table at least, but the rendering is still not perfect, as every command longer than some fixed width gets it description inserted in the row below, with a single space as the first element for alignment.

This doesn't work well when the CSS styling visually separates the rows. I'm not sure if there's much we can do about this though.