### PR TITLE
Add wildcard support to `albumart.filename` pref #374

### DIFF
--- a/quodlibet/quodlibet/qltk/prefs.py
+++ b/quodlibet/quodlibet/qltk/prefs.py
@@ -325,7 +325,8 @@ class PreferencesWindow(UniqueWindow):
 
             entry = UndoEntry()
             entry.set_tooltip_text(
-                    _("The album art image file to use when forced"))
+                    _("The album art image file to use when forced"
+                      " (supports wildcards)"))
             entry.set_text(config.get("albumart", "filename"))
             entry.connect('changed', self.__changed_text, 'filename')
             # Disable entry when not forcing

--- a/quodlibet/quodlibet/util/cover/built_in.py
+++ b/quodlibet/quodlibet/util/cover/built_in.py
@@ -7,6 +7,7 @@
 # the Free Software Foundation; either version 2 of the License, or
 # (at your option) any later version.
 
+import glob
 import os.path
 import re
 
@@ -95,8 +96,8 @@ class FilesystemCover(CoverSourcePlugin):
         # Issue 374: Specify artwork filename
         if config.getboolean("albumart", "force_filename"):
             path = os.path.join(base, config.get("albumart", "filename"))
-            if os.path.isfile(path):
-                images = [(100, path)]
+            for path in glob.glob(path):
+                images.append((100, os.path.join(base, path)))
         else:
             entries = []
             try:
@@ -149,8 +150,8 @@ class FilesystemCover(CoverSourcePlugin):
                     if sub is not None:
                         fn = os.path.join(sub, fn)
                     images.append((score, os.path.join(base, fn)))
-            images.sort(reverse=True)
 
+        images.sort(reverse=True)
         for score, path in images:
             # could be a directory
             if not os.path.isfile(path):

--- a/quodlibet/tests/test_util_cover.py
+++ b/quodlibet/tests/test_util_cover.py
@@ -11,6 +11,7 @@ import shutil
 
 from senf import fsnative
 
+from quodlibet import config
 from quodlibet.ext.covers.artwork_url import ArtworkUrlCover
 from quodlibet.formats import AudioFile
 from quodlibet.plugins import Plugin
@@ -34,8 +35,9 @@ bar_2_1 = AudioFile({
 class TCoverManager(TestCase):
 
     def setUp(self):
-        self.manager = CoverManager()
+        config.init()
 
+        self.manager = CoverManager()
         self.dir = mkdtemp()
         self.song = self.an_album_song()
 
@@ -53,6 +55,7 @@ class TCoverManager(TestCase):
 
     def tearDown(self):
         shutil.rmtree(self.dir)
+        config.quit()
 
     def _find_cover(self, song):
         return self.manager.get_cover(song)
@@ -85,6 +88,14 @@ class TCoverManager(TestCase):
         self.assertTrue(isinstance(self.song("album"), text_type))
         h = self._find_cover(self.song)
         self.assertEqual(normalize_path(h.name), normalize_path(f))
+
+    def test_glob(self):
+        config.set("albumart", "force_filename", str(True))
+        config.set("albumart", "filename", "foo.*")
+        for fn in ["foo.jpg", "foo.png"]:
+            f = self.add_file(fn)
+            assert path_equal(
+                os.path.abspath(self._find_cover(self.song).name), f)
 
     def test_intelligent(self):
         song = self.song


### PR DESCRIPTION
I updated the patch in #374 for current master. Can't tell who wrote the original from the issue history, but credit goes to them.