### PR TITLE
plugins: Make random album work on non-album browsers again

### DIFF
--- a/quodlibet/quodlibet/ext/events/randomalbum.py
+++ b/quodlibet/quodlibet/ext/events/randomalbum.py
@@ -17,6 +17,7 @@ from quodlibet import config
 from quodlibet.plugins.events import EventPlugin
 from quodlibet import util
 from quodlibet.util import print_d
+from quodlibet.browsers.playlists import PlaylistsBrowser
 try:
     from quodlibet.qltk import notif, Icons
 except Exception:
@@ -242,4 +243,5 @@ class RandomAlbum(EventPlugin):
             app.player.paused = True
 
     def disabled_for_browser(self, browser):
-        return not browser.can_filter_albums() or browser == "Playlists"
+        return (not browser.can_filter("album") or
+                isinstance(browser, PlaylistsBrowser))


### PR DESCRIPTION
Fixes #2809 

It seems like #2086 introduced this bug. `browser.can_filter("album")` was changed to `browser.can_filter_albums()`, which (albeit a bit confusingly) is more restrictive. Furthermore, the playlists browser check is categorically false, which is kind of overshadowed by the first check.

It's a simple fix that seems to have solved the issue, but it would be nice if someone could check over it to make sure I haven't overlooked anything.
