### PR TITLE
Add releases to appdata

### DIFF
--- a/quodlibet/data/exfalso.appdata.xml.in
+++ b/quodlibet/data/exfalso.appdata.xml.in
@@ -1,11 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2013 Christoph Reiter -->
 <application>
-    <id type="desktop">exfalso.desktop</id>
+    <id type="desktop-application">exfalso.desktop</id>
     <name>Ex Falso</name>
     <_summary>Edit tags in your audio files</_summary>
     <metadata_license>CC0</metadata_license>
     <project_license>GPL-2.0</project_license>
     <translation type="gettext">quodlibet</translation>
+    <launchable type="desktop-id">exfalso.desktop</launchable>
+    <provides>
+        <binary>exfalso</binary>
+    </provides>
+
     <description>
     <_p>
         Ex Falso is a tag editor with the same tag editing interface as
@@ -18,11 +24,16 @@
         SPC, MIDI.
     </_p>
     </description>
+
     <screenshots>
         <screenshot type="default">
             <image>https://quodlibet.readthedocs.org/en/latest/_images/exfalso.png</image>
         </screenshot>
     </screenshots>
+
     <url type="homepage">https://quodlibet.readthedocs.org</url>
-    <updatecontact>quod-libet-development@googlegroups.com</updatecontact>
+    <url type="bugtracker">https://quodlibet.readthedocs.io/en/latest/bugs_repo.html</url>
+    <url type="help">https://quodlibet.readthedocs.io/en/latest/guide/index.html</url>
+    <url type="translate">https://quodlibet.readthedocs.io/en/latest/translation/howto.html</url>
+    <update_contact>quod-libet-development@googlegroups.com</update_contact>
 </application>

--- a/quodlibet/data/exfalso.appdata.xml.in
+++ b/quodlibet/data/exfalso.appdata.xml.in
@@ -31,6 +31,14 @@
         </screenshot>
     </screenshots>
 
+    <releases>
+        <release version="4.0.2" date="2018-01-17"/>
+        <release version="4.0.1" date="2018-01-13"/>
+        <release version="4.0.0" date="2017-12-26"/>
+        <release version="3.9.1" date="2017-06-06"/>
+        <release version="3.9.0" date="2017-05-24"/>
+    </releases>
+
     <url type="homepage">https://quodlibet.readthedocs.org</url>
     <url type="bugtracker">https://quodlibet.readthedocs.io/en/latest/bugs_repo.html</url>
     <url type="help">https://quodlibet.readthedocs.io/en/latest/guide/index.html</url>

--- a/quodlibet/data/io.github.quodlibet.QuodLibet.appdata.xml.in
+++ b/quodlibet/data/io.github.quodlibet.QuodLibet.appdata.xml.in
@@ -1,14 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2013 Christoph Reiter -->
 <application>
-    <id type="desktop">io.github.quodlibet.QuodLibet.desktop</id>
+    <id type="desktop-application">io.github.quodlibet.QuodLibet.desktop</id>
     <name>Quod Libet</name>
     <_summary>Listen to, browse, or edit your audio collection</_summary>
     <metadata_license>CC0</metadata_license>
     <project_license>GPL-2.0</project_license>
     <translation type="gettext">quodlibet</translation>
+    <launchable type="desktop-id">io.github.quodlibet.QuodLibet.desktop</launchable>
     <provides>
         <id>quodlibet.desktop</id>
+        <binary>quodlibet</binary>
+        <binary>operon</binary>
     </provides>
+
     <description>
     <_p>
         Quod Libet is a music management program. It provides several
@@ -22,6 +27,7 @@
         SPC, MIDI.
     </_p>
     </description>
+
     <screenshots>
         <screenshot type="default">
             <image>https://quodlibet.readthedocs.org/en/latest/_images/paned1.png</image>
@@ -30,6 +36,10 @@
             <image>https://quodlibet.readthedocs.org/en/latest/_images/queue_2browsers1.png</image>
         </screenshot>
     </screenshots>
+
     <url type="homepage">https://quodlibet.readthedocs.org</url>
-    <updatecontact>quod-libet-development@googlegroups.com</updatecontact>
+    <url type="bugtracker">https://quodlibet.readthedocs.io/en/latest/bugs_repo.html</url>
+    <url type="help">https://quodlibet.readthedocs.io/en/latest/guide/index.html</url>
+    <url type="translate">https://quodlibet.readthedocs.io/en/latest/translation/howto.html</url>
+    <update_contact>quod-libet-development@googlegroups.com</update_contact>
 </application>

--- a/quodlibet/data/io.github.quodlibet.QuodLibet.appdata.xml.in
+++ b/quodlibet/data/io.github.quodlibet.QuodLibet.appdata.xml.in
@@ -37,6 +37,14 @@
         </screenshot>
     </screenshots>
 
+    <releases>
+        <release version="4.0.2" date="2018-01-17"/>
+        <release version="4.0.1" date="2018-01-13"/>
+        <release version="4.0.0" date="2017-12-26"/>
+        <release version="3.9.1" date="2017-06-06"/>
+        <release version="3.9.0" date="2017-05-24"/>
+    </releases>
+
     <url type="homepage">https://quodlibet.readthedocs.org</url>
     <url type="bugtracker">https://quodlibet.readthedocs.io/en/latest/bugs_repo.html</url>
     <url type="help">https://quodlibet.readthedocs.io/en/latest/guide/index.html</url>

--- a/quodlibet/gdist/appdata.py
+++ b/quodlibet/gdist/appdata.py
@@ -21,7 +21,7 @@
 # SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 """
-AppData Specification: http://people.freedesktop.org/~hughsient/appdata/
+AppData Specification: https://www.freedesktop.org/software/appstream/docs/
 """
 
 import os

--- a/quodlibet/tests/test_appdata_files.py
+++ b/quodlibet/tests/test_appdata_files.py
@@ -12,12 +12,27 @@ import subprocess
 from quodlibet.util.path import iscommand
 from quodlibet import util
 
-from tests import TestCase, mkstemp, skipUnless
+from tests import TestCase, mkstemp, skipUnless, skipIf
 
 
 QLDATA_DIR = os.path.join(os.path.dirname(util.get_module_dir()), "data")
 
 
+def get_appstream_util_version():
+    try:
+        data = subprocess.check_output(["appstream-util", "--version"])
+    except subprocess.CalledProcessError as e:
+        data = e.output or b""
+
+    text = data.decode("utf-8", "replace")
+    return tuple([int(p) for p in text.rsplit()[-1].split(".")])
+
+
+def is_too_old_appstream_util_version():
+    return get_appstream_util_version() < (0, 7, 0)
+
+
+@skipIf(is_too_old_appstream_util_version(), "appstream-util is too old")
 class _TAppDataFileMixin(object):
     PATH = None
 


### PR DESCRIPTION
[Another thing the Flathub requirements explicitly point out is releases](https://github.com/flathub/flathub/wiki/App-Requirements#appstream); probably because they're used for the version displayed on the website. So this is two more places that have to be updated on a release, which isn't ideal, but I didn't see any sort of maintainer script. The appdata releases could be generated from NEWS, I suppose, possibly including changelog entries.

I also added some other fields and fixed a few things `appstream-util validate-strict` was complaining about.

Semi-related: how does the release process work? Since there's now a separate release branch, would these changes not be in there or do you cherry-pick selectively? I'd love to have QL on Flathub for 4.1 but that would require these changes (probably).