### PR TITLE
Equalizer enhancements to support backend Preamp and Preset

### DIFF
--- a/quodlibet/quodlibet/ext/events/equalizer.py
+++ b/quodlibet/quodlibet/ext/events/equalizer.py
@@ -93,6 +93,7 @@ def get_config():
     except (config.Error, ValueError):
         return []
 
+
 def get_config_preamp():
     try:
         eq_preamp_str = config.get('plugins', 'equalizer_level_preamp')

--- a/quodlibet/quodlibet/player/_base.py
+++ b/quodlibet/quodlibet/player/_base.py
@@ -8,6 +8,8 @@
 # the Free Software Foundation; either version 2 of the License, or
 # (at your option) any later version.
 
+import collections
+
 from gi.repository import GObject
 
 from quodlibet.formats import AudioFile
@@ -18,6 +20,19 @@ from quodlibet.compat import listfilter
 
 class Equalizer(object):
     _eq_values = []
+    _eq_preamp = 0.0
+
+    # This class is used to return information about an equalizer
+    # preset provided by the backend player
+    #
+    # NOTE: If the backend equalizer does not have a preamp,
+    #       any the 'preamp' field will be ignored.
+    EqualizerPreset = collections.namedtuple('EqualizerPreset', [
+        'name', 'values', 'preamp'])
+    EqualizerPreset.__doc__ += """: Equalizer Preset Definition"""
+    EqualizerPreset.name.__doc__ += """Equalizer Preset Name"""
+    EqualizerPreset.values.__doc__ += """List of preset band values"""
+    EqualizerPreset.preamp.__doc__ += """Preamp value (use 0.0 if no preamp)"""
 
     @property
     def eq_bands(self):
@@ -27,7 +42,9 @@ class Equalizer(object):
 
     @property
     def eq_values(self):
-        """The list of equalizer values, in the range (-24dB, 12dB)."""
+        """The list of equalizer values, in the range (-24dB, 12dB).
+
+        Override the available range using the eq_range() method."""
 
         return self._eq_values
 
@@ -40,6 +57,51 @@ class Equalizer(object):
         """Override to apply equalizer values"""
 
         pass
+
+    @property
+    def eq_has_preamp(self):
+        """If the equalizer has a preamp."""
+
+        return False
+
+    @property
+    def eq_preamp(self):
+        """The equalizer preamp value.
+
+        Only vaid if eq_has_preamp() == True"""
+
+        return self._eq_preamp
+
+    @eq_preamp.setter
+    def eq_preamp(self, value):
+        """Set the equalizer preamp value.
+
+        Only vaid if eq_has_preamp() == True"""
+
+        self._eq_preamp = value
+        self.update_eq_values()
+
+    @property
+    def eq_preamp_default(self):
+        """Default Preamp Value.
+        This is useful when a backend player should have a default preamp
+        value other than 0.0 for normal playback."""
+
+        return 0.0
+
+    @property
+    def eq_preset_list(self):
+        """List of presets provided by the equalizer.
+
+        This should be a list of EqualizerPreset objects!"""
+
+        return []
+
+    @property
+    def eq_range(self):
+        """Return the (min,max) equalizer range."""
+
+        return (-24, 12)
 
 
 class BasePlayer(GObject.GObject, Equalizer):


### PR DESCRIPTION
The VLC backend in pull request #2852 uses a preamp which is not a supported feature of the VLC Equalizer interface and plugin.  VLC also provides its own list of presets which are specifically designed for the VLC equalizer and thus improve sound quality.  Making these features available to Quod Libet improves playback sound quality.

This fixes FIXME comments in pull request #2852.

This pull request contains only the Equalizer interface updates and the Equalizer plugin updates necessary for supporting these features as the new VLC backend pull request (#2852) is not yet merged.  If the VLC backend is merged before this pull request, I can add in the VLC backend implementation of these equalizer settings.  Otherwise, a new pull request will be opened for the VLC backend updates for implementing the preamp and preset features.