### PR TITLE
Make queue able to keep songs after playing them

### DIFF
--- a/quodlibet/quodlibet/config.py
+++ b/quodlibet/quodlibet/config.py
@@ -75,6 +75,7 @@ INITIAL = {
         "queue_expanded": "false",
         "shufflequeue": "false",
         "queue_stop_at_end": "false",
+        "queue_keep_songs": "false",
         "queue_prioritize": "true",
 
         # <reversed?>tagname, song list sort

--- a/quodlibet/quodlibet/config.py
+++ b/quodlibet/quodlibet/config.py
@@ -76,7 +76,7 @@ INITIAL = {
         "shufflequeue": "false",
         "queue_stop_at_end": "false",
         "queue_keep_songs": "false",
-        "queue_prioritize": "true",
+        "queue_ignore": "false",
 
         # <reversed?>tagname, song list sort
         "sortby": "0album",

--- a/quodlibet/quodlibet/config.py
+++ b/quodlibet/quodlibet/config.py
@@ -74,7 +74,8 @@ INITIAL = {
         "queue": "false",
         "queue_expanded": "false",
         "shufflequeue": "false",
-        "queue_stop_once_empty": "false",
+        "queue_stop_at_end": "false",
+        "queue_prioritize": "true",
 
         # <reversed?>tagname, song list sort
         "sortby": "0album",

--- a/quodlibet/quodlibet/qltk/queue.py
+++ b/quodlibet/quodlibet/qltk/queue.py
@@ -130,16 +130,18 @@ class QueueExpander(Gtk.Expander):
             populate=True)
         menu.append(stop_checkbox)
 
+        queue_ignore_cb = ConfigCheckMenuItem(
+            _("Ignore"), "memory", "queue_ignore",
+            populate=True)
+        menu.append(queue_ignore_cb)
+
         keep_checkbox = ConfigCheckMenuItem(
             _("Keep Songs"), "memory", "queue_keep_songs",
             populate=True)
+        keep_checkbox.set_tooltip_text(
+            _("Keep songs in the queue after playing them"))
         keep_checkbox.connect("activate", self.__keep_songs_activated)
         menu.append(keep_checkbox)
-
-        self._prio_q_cb = ConfigCheckMenuItem(
-            _("Prioritize Queue"), "memory", "queue_prioritize",
-            populate=True)
-        menu.append(self._prio_q_cb)
 
         clear_item = MenuItem(_("_Clear Queue"), Icons.EDIT_CLEAR)
         menu.append(clear_item)
@@ -154,9 +156,6 @@ class QueueExpander(Gtk.Expander):
         button.set_no_show_all(True)
         menu.show_all()
         button.set_menu(menu)
-
-        keep_song = config.getboolean("memory", "queue_keep_songs", False)
-        self._prio_q_cb.set_sensitive(keep_song)
 
         outer.pack_start(button, False, False, 0)
 
@@ -251,9 +250,7 @@ class QueueExpander(Gtk.Expander):
         keep_song = config.getboolean("memory", "queue_keep_songs", False)
         if keep_song:
             self.queue.set_first_column_type(CurrentColumn)
-            self._prio_q_cb.set_sensitive(True)
         else:
-            self._prio_q_cb.set_sensitive(False)
             for col in self.queue.get_columns():
                 # Remove the CurrentColum if it exists
                 if isinstance(col, CurrentColumn):

--- a/quodlibet/quodlibet/qltk/quodlibetwindow.py
+++ b/quodlibet/quodlibet/qltk/quodlibetwindow.py
@@ -52,7 +52,7 @@ from quodlibet.qltk.songlist import SongList, get_columns, set_columns
 from quodlibet.qltk.songmodel import PlaylistMux
 from quodlibet.qltk.x import RVPaned, Align, ScrolledWindow, Action
 from quodlibet.qltk.x import ToggleAction, RadioAction, HighlightToggleButton
-from quodlibet.qltk.x import SeparatorMenuItem, MenuItem, CellRendererPixbuf
+from quodlibet.qltk.x import SeparatorMenuItem, MenuItem
 from quodlibet.qltk import Icons
 from quodlibet.qltk.about import AboutDialog
 from quodlibet.util import copool, connect_destroy, connect_after_destroy
@@ -61,7 +61,7 @@ from quodlibet.util import connect_obj, print_d
 from quodlibet.util.library import background_filter, scan_library
 from quodlibet.util.path import uri_is_valid
 from quodlibet.qltk.window import PersistentWindowMixin, Window, on_first_map
-from quodlibet.qltk.songlistcolumns import SongListColumn
+from quodlibet.qltk.songlistcolumns import CurrentColumn
 
 
 class PlayerOptions(GObject.Object):
@@ -217,53 +217,6 @@ class DockMenu(Gtk.Menu):
 
     def _on_pause(self, item, player):
         player.paused = True
-
-
-class CurrentColumn(SongListColumn):
-    """Displays the current song indicator, either a play or pause icon."""
-
-    def __init__(self):
-        super(CurrentColumn, self).__init__("~current")
-        self._render = CellRendererPixbuf()
-        self.pack_start(self._render, True)
-        self._render.set_property('xalign', 0.5)
-
-        self.set_fixed_width(24)
-        self.set_expand(False)
-        self.set_cell_data_func(self._render, self._cdf)
-
-    def _format_title(self, tag):
-        return u""
-
-    def _cdf(self, column, cell, model, iter_, user_data):
-        PLAY = "media-playback-start"
-        PAUSE = "media-playback-pause"
-        STOP = "media-playback-stop"
-        ERROR = "dialog-error"
-
-        row = model[iter_]
-
-        if row.path == model.current_path:
-            player = app.player
-            if player.error:
-                name = ERROR
-            elif model.sourced:
-                name = [PLAY, PAUSE][player.paused]
-            else:
-                name = STOP
-        else:
-            name = None
-
-        if not self._needs_update(name):
-            return
-
-        if name is not None:
-            gicon = Gio.ThemedIcon.new_from_names(
-                [name + "-symbolic", name])
-        else:
-            gicon = None
-
-        cell.set_property('gicon', gicon)
 
 
 class MainSongList(SongList):

--- a/quodlibet/quodlibet/qltk/songmodel.py
+++ b/quodlibet/quodlibet/qltk/songmodel.py
@@ -61,10 +61,11 @@ class PlaylistMux(object):
     def next(self):
         """Switch to the next song"""
 
-        keep_song = config.getboolean("memory", "queue_keep_songs", False)
-        q_prio = config.getboolean("memory", "queue_prioritize", False)
+        keep_songs = config.getboolean("memory", "queue_keep_songs", False)
+        q_ignore = config.getboolean("memory", "queue_ignore", False)
 
-        if self.q.is_empty() or (keep_song and not q_prio and self.pl.sourced):
+        if (self.q.is_empty()
+                or (q_ignore and not (keep_songs and self.q.sourced))):
             self.pl.next()
         else:
             self.q.next()
@@ -73,10 +74,11 @@ class PlaylistMux(object):
     def next_ended(self):
         """Switch to the next song (action comes from the user)"""
 
-        keep_song = config.getboolean("memory", "queue_keep_songs", False)
-        q_prio = config.getboolean("memory", "queue_prioritize", False)
+        keep_songs = config.getboolean("memory", "queue_keep_songs", False)
+        q_ignore = config.getboolean("memory", "queue_ignore", False)
 
-        if self.q.is_empty() or (keep_song and not q_prio and self.pl.sourced):
+        if (self.q.is_empty()
+                or (q_ignore and not (keep_songs and self.q.sourced))):
             self.pl.next_ended()
         else:
             self.q.next_ended()
@@ -85,13 +87,13 @@ class PlaylistMux(object):
     def previous(self):
         """Go to the previous song"""
 
-        keep_song = config.getboolean("memory", "queue_keep_songs", False)
-        q_prio = config.getboolean("memory", "queue_prioritize", False)
+        keep_songs = config.getboolean("memory", "queue_keep_songs", False)
+        q_ignore = config.getboolean("memory", "queue_ignore", False)
 
-        if keep_song and (q_prio or self.q.sourced):
-            self.q.previous()
-        else:
+        if q_ignore or self.pl.sourced or not keep_songs:
             self.pl.previous()
+        else:
+            self.q.previous()
         self._check_sourced()
 
     def go_to(self, song, explicit=False, source=None):


### PR DESCRIPTION
This PR adds a new checkbox to the queue preferences - "Keep Songs".

When enabled, the queue will get a "CurrentColumn" and act more like the main song list. Songs can be added to the queue as normal, but they will be kept in the queue when playing them.

When "Keep Songs" is enabled, it's also possible to enable the "Prioritize Queue" checkbox. If the user selects a song in the main song list with this option enabled, then the player will switch to the queue after the song is done playing. This is the same as how the queue works now.

If "Prioritize Queue" is disabled, then the player will not switch to queue automatically (but rather play the next song in the main song list), and the user will have to click on a song in the queue to begin playing from it again. This makes it possible to occasionally ignore the queue without having to clear it.

It is quite rough around the edges, and some feedback would be very appreciated.

Some things to consider:
- There may be a better wording for the feature than "Keep Songs".
- The "Prioritize Queue" checkbox is not very pretty wrt. how it's disabled when "Keep Songs" is not checked. It's not very clear that the two are connected.
- It could perhaps be useful to have the queue remember its location when switching to the main song list, such that the queue automatically continues where it left off when the main song list is done.

Related issues: #1890, #2856.