### PR TITLE
Bug Fix: Cannot re-order playlist songs with DnD 

### DIFF
--- a/quodlibet/quodlibet/qltk/songlist.py
+++ b/quodlibet/quodlibet/qltk/songlist.py
@@ -3,6 +3,7 @@
 #           2012 Christoph Reiter
 #           2014 Jan Path
 #      2011-2017 Nick Boultbee
+#           2018 David Morris
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -260,7 +261,17 @@ class SongListDnDMixin(object):
                 return
 
             qltk.selection_set_songs(sel, songs)
-            if ctx.get_actions() & Gdk.DragAction.MOVE:
+
+            # DEM 2018/05/25: The below check is a deliberate repitition of
+            # code in the drag-motion signal handler.  In MacOS/Quartz, the
+            # context action is not propogated between event handlers for
+            # drag-motion and drag-data-get using "ctx.get_actions()".  It is
+            # unclear if this is a bug or expected behavior.  Regardless, the
+            # context widget information is the same so identical behavior can
+            # be achieved by simply using the same widget check as in the move
+            # action.
+            if Gtk.drag_get_source_widget(ctx) == self and \
+                    not self.__force_copy:
                 self.__drag_iters = list(map(model.get_iter, paths))
             else:
                 self.__drag_iters = []


### PR DESCRIPTION
This is a bug fix for Issue #2595, "Cannot re-order playlist songs with DnD".  See comments in the code and the issue for full details.

This fix should work on all operating systems, however it has so far only been tested on MacOS as I lack an ability to test on Linux and Windows at this time.