### PR TITLE
searchbar: Don't save query on filter changes

### DIFF
--- a/quodlibet/quodlibet/qltk/searchbar.py
+++ b/quodlibet/quodlibet/qltk/searchbar.py
@@ -72,6 +72,7 @@ class SearchBarBox(Gtk.HBox):
         entry.connect('backspace', self.__text_changed)
         entry.connect('populate-popup', self.__menu)
         entry.connect('activate', self.__filter_changed)
+        entry.connect('activate', self.__save_search)
         entry.connect('focus-out-event', self.__save_search)
         entry.connect('key-press-event', self.__key_pressed)
 
@@ -168,7 +169,7 @@ class SearchBarBox(Gtk.HBox):
             self.__uninhibit()
 
     def __key_pressed(self, entry, event):
-        if (is_accel(event, "<Primary>Return") or
+        if (is_accel(event, '<Primary>Return') or
                 is_accel(event, '<Primary>KP_Enter')):
             # Save query on Primary+Return accel, even though the focus is kept
             self.__save_search(entry)

--- a/quodlibet/quodlibet/qltk/searchbar.py
+++ b/quodlibet/quodlibet/qltk/searchbar.py
@@ -19,6 +19,7 @@ from quodlibet.query import Query
 from quodlibet.qltk.cbes import ComboBoxEntrySave
 from quodlibet.qltk.ccb import ConfigCheckMenuItem
 from quodlibet.qltk.x import SeparatorMenuItem
+from quodlibet.qltk import is_accel
 from quodlibet.util import limit_songs, DeferredSignal
 
 
@@ -56,8 +57,6 @@ class SearchBarBox(Gtk.HBox):
 
         self.__deferred_changed = DeferredSignal(
             self.__filter_changed, timeout=timeout, owner=self)
-        self.__deferred_save_search = DeferredSignal(
-            self.__save_search, timeout=1000, owner=self)
 
         self.__combo = combo
         entry = combo.get_child()
@@ -74,6 +73,7 @@ class SearchBarBox(Gtk.HBox):
         entry.connect('populate-popup', self.__menu)
         entry.connect('activate', self.__filter_changed)
         entry.connect('focus-out-event', self.__save_search)
+        entry.connect('key-press-event', self.__key_pressed)
 
         entry.set_placeholder_text(_("Search"))
         entry.set_tooltip_text(_("Search your library, "
@@ -167,16 +167,19 @@ class SearchBarBox(Gtk.HBox):
             self.__combo.write()
             self.__uninhibit()
 
+    def __key_pressed(self, entry, event):
+        if (is_accel(event, "<Primary>Return") or
+                is_accel(event, '<Primary>KP_Enter')):
+            # Save query on Primary+Return accel, even though the focus is kept
+            self.__save_search(entry)
+        return False
+
     def __filter_changed(self, *args):
         self.__deferred_changed.abort()
         text = self.get_text()
         self._update_query_from(text)
         if self._query.is_parsable:
             GLib.idle_add(self.emit, 'query-changed', text)
-            # Abort to reset timeout
-            self.__deferred_save_search.abort()
-            # Don't save the query immediately after filtering
-            self.__deferred_save_search(args[0:1], args[1:])
 
     def __text_changed(self, *args):
         if not self.__entry.is_sensitive():


### PR DESCRIPTION
But rather on Return and - for eager searching - focus-out and Primary+Return accel.