### PR TITLE
Show spinner during browser switch (and set the cursor to a watch)

### DIFF
--- a/quodlibet/quodlibet/qltk/quodlibetwindow.py
+++ b/quodlibet/quodlibet/qltk/quodlibetwindow.py
@@ -1195,6 +1195,19 @@ class QuodLibetWindow(Window, PersistentWindowMixin, AppWindow):
                 self.remove_accel_group(self.browser.accelerators)
             container.destroy()
             self.browser.destroy()
+
+        spinner = Gtk.Spinner()
+        spinner.start()
+        spinner.show()
+        self.__browserbox.add(spinner)
+        window = self.get_window()
+        window.set_cursor(Gdk.Cursor.new(Gdk.CursorType.WATCH))
+
+        # Wait for the old browser to be destroyed before
+        # setting up the new one
+        while Gtk.events_pending():
+            Gtk.main_iteration()
+
         self.browser = Browser(library)
         self.browser.connect('songs-selected',
             self.__browser_cb, library, player)
@@ -1216,8 +1229,14 @@ class QuodLibetWindow(Window, PersistentWindowMixin, AppWindow):
 
         player.replaygain_profiles[1] = self.browser.replaygain_profiles
         player.reset_replaygain()
+
+        self.__browserbox.remove(spinner)
         self.__browserbox.add(container)
         container.show()
+
+        # Reset the cursor when the browser container is visible to the user
+        container.connect('draw', lambda w, cr: window.set_cursor(None))
+
         self._filter_menu.set_browser(self.browser)
         self.__hide_headers()
 


### PR DESCRIPTION
Related: #2111 

This makes it clear that the browser is loading when switching to browsers that take some time to load.

The spinner doesn't really spin though, since the gtk main loop is not run during the browser loading. I don't think this is so easy to fix, as the browser loading probably (?) can't be put in a separate thread. I don't consider this to be much of an issue though.

The waiting for the main loop also makes the set-browser test in `test_commands.py` generate a couple of these warnings:

```
 /usr/lib/python3.6/site-packages/gi/overrides/GObject.py:472: Warning: gsignal.c:2563: instance '0x563052220530' has no handler with id '3595'
```

Not sure why.