### PR TITLE
Port util.environment module to GDBus

### DIFF
--- a/quodlibet/quodlibet/util/environment.py
+++ b/quodlibet/quodlibet/util/environment.py
@@ -22,14 +22,20 @@ def _dbus_name_owned(name):
         return False
 
     try:
-        import dbus
+        from gi.repository import Gio
+        from gi.repository import GLib
     except ImportError:
         return False
 
     try:
-        bus = dbus.Bus(dbus.Bus.TYPE_SESSION)
-        return bus.name_has_owner(name)
-    except dbus.DBusException:
+        dbus = Gio.DBusProxy.new_for_bus_sync(Gio.BusType.SESSION,
+                                              Gio.DBusProxyFlags.NONE, None,
+                                              'org.freedesktop.DBus',
+                                              '/org/freedesktop/DBus',
+                                              'org.freedesktop.DBus',
+                                              None)
+        return dbus.NameHasOwner('(s)', name)
+    except GLib.Error:
         return False
 
 

--- a/quodlibet/quodlibet/util/environment.py
+++ b/quodlibet/quodlibet/util/environment.py
@@ -14,17 +14,14 @@ import os
 import sys
 import ctypes
 
+from gi.repository import Gio
+from gi.repository import GLib
+
 
 def _dbus_name_owned(name):
     """Returns True if the dbus name has an owner"""
 
     if not is_linux():
-        return False
-
-    try:
-        from gi.repository import Gio
-        from gi.repository import GLib
-    except ImportError:
         return False
 
     try:


### PR DESCRIPTION
According to https://www.freedesktop.org/wiki/Software/DBusBindings/ dbus-python is obsolete. This patch ports another QL module to recommended GDBus binding.