### PR TITLE
Port Screensaver Pause extension to GDBus

### DIFF
--- a/quodlibet/quodlibet/ext/events/screensaver.py
+++ b/quodlibet/quodlibet/ext/events/screensaver.py
@@ -13,7 +13,8 @@ if os.name == "nt" or sys.platform == "darwin":
     from quodlibet.plugins import PluginNotSupportedError
     raise PluginNotSupportedError
 
-import dbus
+from gi.repository import Gio
+from gi.repository import GLib
 
 from quodlibet import _
 from quodlibet import app
@@ -37,21 +38,22 @@ class ScreensaverPause(EventPlugin):
     __active = False
     __watch = None
 
-    def __screensaver_changed(self, active):
-        # Gnome-Shell fires ActiveChanged even if it doesn't change
-        # (aborted transition to lock screen), so handle that
+    def __on_signal(self, proxy, sender, signal, args):
+        if signal == 'ActiveChanged':
+            # Gnome-Shell fires ActiveChanged even if it doesn't change
+            # (aborted transition to lock screen), so handle that
+            active = args[0]
+            if active == self.__active:
+                return
+            self.__active = active
 
-        if active == self.__active:
-            return
-        self.__active = active
+            if active:
+                self.__was_paused = app.player.paused
+                app.player.paused = True
+            elif not self.__was_paused and not self.__ignore_next:
+                app.player.paused = False
 
-        if active:
-            self.__was_paused = app.player.paused
-            app.player.paused = True
-        elif not self.__was_paused and not self.__ignore_next:
-            app.player.paused = False
-
-        self.__ignore_next = False
+            self.__ignore_next = False
 
     def plugin_on_unpaused(self):
         # In case pause/unpause happens while the session is inactive
@@ -62,30 +64,31 @@ class ScreensaverPause(EventPlugin):
 
     def __remove_interface(self):
         if self.__interface:
-            self.__sig.remove()
+            self.__interface.disconnect(self.__sig)
             self.__interface = None
 
-    def __owner_changed(self, owner):
-        if not owner:
-            self.__remove_interface()
-        elif not self.__interface:
-            bus = dbus.SessionBus()
-            obj = bus.get_object(self.DBUS_NAME, self.DBUS_PATH)
-            iface = dbus.Interface(obj, self.DBUS_INTERFACE)
-            self.__sig = iface.connect_to_signal("ActiveChanged",
-                                                 self.__screensaver_changed)
+    def __owner_appeared(self, bus, name, owner):
+        if not self.__interface:
+            iface = Gio.DBusProxy.new_for_bus_sync(
+                Gio.BusType.SESSION, Gio.DBusProxyFlags.NONE, None,
+                self.DBUS_NAME, self.DBUS_PATH, self.DBUS_INTERFACE, None)
+            self.__sig = iface.connect('g-signal', self.__on_signal)
             self.__active = iface.GetActive()
             self.__interface = iface
 
+    def __owner_vanished(self, bus, owner):
+        self.__remove_interface()
+
     def enabled(self):
         try:
-            bus = dbus.SessionBus()
-            self.__watch = bus.watch_name_owner(self.DBUS_NAME,
-                                                self.__owner_changed)
-        except dbus.DBusException:
+            bus = Gio.bus_get_sync(Gio.BusType.SESSION, None)
+            self.__watch = Gio.bus_watch_name_on_connection(
+                bus, self.DBUS_NAME, Gio.BusNameWatcherFlags.NONE,
+                self.__owner_appeared, self.__owner_vanished)
+        except GLib.Error:
             pass
 
     def disabled(self):
         if self.__watch:
-            self.__watch.cancel()
+            Gio.bus_unwatch_name(self.__watch)
         self.__remove_interface()


### PR DESCRIPTION
According to https://www.freedesktop.org/wiki/Software/DBusBindings/ dbus-python is obsolete. This patch ports Screensaver Pause extension to recommended GDBus binding.