### PR TITLE
ext/website_search: Don't utf-8 encode tag values

### DIFF
--- a/quodlibet/quodlibet/ext/songsmenu/website_search.py
+++ b/quodlibet/quodlibet/ext/songsmenu/website_search.py
@@ -14,7 +14,7 @@ from gi.repository import Gtk
 import quodlibet
 from quodlibet import _
 from quodlibet import qltk
-from quodlibet.compat import quote_plus, text_type
+from quodlibet.compat import quote_plus
 from quodlibet.formats import AudioFile
 from quodlibet.pattern import Pattern
 from quodlibet.plugins.songsmenu import SongsMenuPlugin
@@ -151,12 +151,11 @@ def website_for(pat: Pattern, song: AudioFile) -> Optional[str]:
         vals = song.comma(k)
         if vals:
             try:
-                encoded = text_type(vals).encode('utf-8')
                 # Escaping ~filename stops ~dirname ~basename etc working
                 # But not escaping means ? % & will cause problems.
                 # Who knows what user wants to do with /, seems better raw.
-                subs[k] = (encoded if k in ['website', '~filename']
-                           else quote_plus(encoded))
+                subs[k] = (vals if k in ['website', '~filename']
+                           else quote_plus(vals))
             except KeyError:
                 print_d("Problem with %s tag values: %r" % (k, vals))
     return pat.format(subs) or None

--- a/quodlibet/tests/plugin/test_website_search.py
+++ b/quodlibet/tests/plugin/test_website_search.py
@@ -12,7 +12,8 @@ from tests.plugin import PluginTestCase
 from quodlibet import config
 
 A_SONG = AudioFile({'title': 'foo', 'artist': 'barman',
-                    '~filename': '/tmp/dir/barman - foo.mp3'})
+                    '~filename': '/tmp/dir/barman - foo.mp3',
+                    'website': 'https://example.com'})
 
 
 class TWebsiteSearch(PluginTestCase):
@@ -37,6 +38,12 @@ class TWebsiteSearch(PluginTestCase):
         url = self.mod.website_for(pat, song)
         # This is probably what the user wanted, ish
         assert url == "https://example.com//tmp/dir"
+
+    def test_website_for_website(self):
+        song = AudioFile(A_SONG)
+        pat = Pattern("<website>")
+        url = self.mod.website_for(pat, song)
+        assert url == "https://example.com"
 
     def tearDown(self):
         config.quit()


### PR DESCRIPTION
Proposed fix for #2896