### PR TITLE
Repeat and Shuffle also affect the Queue

### DIFF
--- a/quodlibet/quodlibet/qltk/playorder.py
+++ b/quodlibet/quodlibet/qltk/playorder.py
@@ -241,11 +241,12 @@ class PlayOrderWidget(Gtk.HBox):
         'changed': (GObject.SignalFlags.RUN_LAST, None, ()),
     }
 
-    def __init__(self, model, player):
+    def __init__(self, model, queue_model, player):
         super(PlayOrderWidget, self).__init__(spacing=6)
         self.order = None
         self.__inhibit = True
         self.__playlist = model
+        self.__queue = queue_model
         self.__player = player
 
         def create_shuffle(orders):
@@ -352,6 +353,9 @@ class PlayOrderWidget(Gtk.HBox):
         print_d("Updating %s order to %s"
                 % (type(self.__playlist).__name__, self.order))
         self.__playlist.order = self.order
+        print_d("Updating %s order to %s"
+                % (type(self.__queue).__name__, self.order))
+        self.__queue.order = self.order
         self.__player.replaygain_profiles[2] = shuffler.replaygain_profiles
         self.__player.reset_replaygain()
         if self.order != old_order:

--- a/quodlibet/quodlibet/qltk/quodlibetwindow.py
+++ b/quodlibet/quodlibet/qltk/quodlibetwindow.py
@@ -708,7 +708,9 @@ class QuodLibetWindow(Window, PersistentWindowMixin, AppWindow):
 
         main_box.pack_start(paned, True, True, 0)
 
-        play_order = PlayOrderWidget(self.songlist.model, player)
+        play_order = PlayOrderWidget(
+            self.songlist.model,
+            self.qexpander.queue.model, player)
         statusbox = StatusBarBox(play_order, self.qexpander)
         self.order = play_order
         self.statusbar = statusbox.statusbar

--- a/quodlibet/tests/test_qltk_playorder.py
+++ b/quodlibet/tests/test_qltk_playorder.py
@@ -22,7 +22,7 @@ class TPlayOrderWidget(TestCase):
         self.volume = 0
         self.replaygain_profiles = [None, None, None]
         self.reset_replaygain = lambda: None
-        self.po = PlayOrderWidget(self, self)
+        self.po = PlayOrderWidget(self, self, self)
 
     def tearDown(self):
         self.po.destroy()


### PR DESCRIPTION
Like the main song list does.

If Shuffle is enabled QL consumes the queue in
random order.

If Repeat and Keep Songs are enabled, the queue will loop.If Repeat is enabled, but Keep Songs is not, the queue is consumed as usual (or randomly if Shuffle is enabled).

If Ignore is checked, the queue is ignored so it's order doesn't really matter.

I don't think there is need to introduce any other UI element, I think this is a pretty good and intuitive behaviour. Let me know if I've missed some scenarios!

This PR should be the last step to have the queue behave like the "Now Playing" section of other media players.

There are 2 issues though:
* the Queue Only plugin may not work as intended
* there is also the Random checkbox in the queue's settings

Related issues: #2856 and #442 a bit