### PR TITLE
Display cover art image with the correct size on multi-monitor setups

### DIFF
--- a/quodlibet/quodlibet/qltk/cover.py
+++ b/quodlibet/quodlibet/qltk/cover.py
@@ -42,11 +42,18 @@ class BigCenteredImage(qltk.Window):
             width = int(width / 1.1)
             height = int(height / 1.1)
         else:
-            win = Gdk.Window.at_pointer()
-            disp = Gdk.Display.get_default()
-            if win[0] and disp:
-                mon = disp.get_monitor_at_window(win[0])
-                rect = mon.get_workarea()
+            win = parent.get_window()
+            if win:
+                if qltk.gtk_version[:2] >= (3, 22):
+                    disp = Gdk.Display.get_default()
+                    mon = disp.get_monitor_at_window(win)
+                    rect = mon.get_geometry()
+                else:
+                    # The result should be the same as above, just using
+                    # deprecated methods instead
+                    screen = Gdk.Screen.get_default()
+                    mon_num = screen.get_monitor_at_window(win)
+                    rect = screen.get_monitor_geometry(mon_num)
                 width = int(rect.width / 1.8)
                 height = int(rect.height / 1.8)
             else:

--- a/quodlibet/quodlibet/qltk/cover.py
+++ b/quodlibet/quodlibet/qltk/cover.py
@@ -42,8 +42,16 @@ class BigCenteredImage(qltk.Window):
             width = int(width / 1.1)
             height = int(height / 1.1)
         else:
-            width = int(Gdk.Screen.width() / 1.8)
-            height = int(Gdk.Screen.height() / 1.8)
+            win = Gdk.Window.at_pointer()
+            disp = Gdk.Display.get_default()
+            if win[0] and disp:
+                mon = disp.get_monitor_at_window(win[0])
+                rect = mon.get_workarea()
+                width = int(rect.width / 1.8)
+                height = int(rect.height / 1.8)
+            else:
+                width = int(Gdk.Screen.width() / 1.8)
+                height = int(Gdk.Screen.height() / 1.8)
 
         self.set_position(Gtk.WindowPosition.CENTER_ON_PARENT)
 


### PR DESCRIPTION
When clicking on the cover art of the playing song, the image is enlarged and fills approximately half of the width and height of the monitor. This seems to be the intended behavior.

On multi-monitor setups, the image does not necessarily enlarge in the same way. I have multiple monitors with varying sizes and orientations, and the image always fills to the edge of the current monitor. The reason for this is that the dimensions of `Gdk.Screen` (which combines all monitors into one big (virtual) one) are used when scaling the image.

A better way is to use the current monitor as a base when calculating the desired width and height of the image, which is what this commit does.

Leaving the patch here in case someone wants to have a say in this.