### PR TITLE
Port GNOME Search Provider extension to GDBus

### DIFF
--- a/quodlibet/quodlibet/ext/events/searchprovider.py
+++ b/quodlibet/quodlibet/ext/events/searchprovider.py
@@ -27,8 +27,8 @@ if os.name == "nt" or sys.platform == "darwin":
     from quodlibet.plugins import PluginNotSupportedError
     raise PluginNotSupportedError
 
-import dbus
-import dbus.service
+from gi.repository import GLib
+from gi.repository import Gio
 
 from quodlibet import _
 from quodlibet import app
@@ -113,17 +113,95 @@ def get_songs_for_ids(library, ids):
     return songs
 
 
-class SearchProvider(dbus.service.Object):
+class SearchProvider:
+    """
+    <!DOCTYPE node PUBLIC
+     '-//freedesktop//DTD D-BUS Object Introspection 1.0//EN'
+     'http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd'>
+    <node name="/io/github/quodlibet/QuodLibet/SearchProvider">
+      <interface name="org.freedesktop.DBus.Introspectable">
+        <method name="Introspect">
+          <arg direction="out" type="s" />
+        </method>
+      </interface>
+      <interface name="org.gnome.Shell.SearchProvider2">
+        <method name="GetInitialResultSet">
+          <arg direction="in"  type="as" name="terms" />
+          <arg direction="out" type="as" />
+        </method>
+        <method name="GetSubsearchResultSet">
+          <arg direction="in"  type="as" name="previous_results" />
+          <arg direction="in"  type="as" name="terms" />
+          <arg direction="out" type="as" />
+        </method>
+        <method name="GetResultMetas">
+          <arg direction="in"  type="as" name="identifiers" />
+          <arg direction="out" type="aa{sv}" />
+        </method>
+        <method name="ActivateResult">
+          <arg direction="in"  type="s" name="identifier" />
+          <arg direction="in"  type="as" name="terms" />
+          <arg direction="in"  type="u" name="timestamp" />
+        </method>
+        <method name="LaunchSearch">
+          <arg direction="in"  type="as" name="terms" />
+          <arg direction="in"  type="u" name="timestamp" />
+        </method>
+      </interface>
+    </node>
+    """
+
     PATH = "/io/github/quodlibet/QuodLibet/SearchProvider"
     BUS_NAME = "io.github.quodlibet.QuodLibet.SearchProvider"
     IFACE = "org.gnome.Shell.SearchProvider2"
 
     def __init__(self):
-        bus = dbus.SessionBus()
-        name = dbus.service.BusName(self.BUS_NAME, bus)
-        super(SearchProvider, self).__init__(name, self.PATH)
+        self._own_id = Gio.bus_own_name(Gio.BusType.SESSION, self.BUS_NAME,
+                                        Gio.BusNameOwnerFlags.NONE,
+                                        self.on_bus_acquired, None,
+                                        self.on_name_lost)
+        self._registered_ids = []
+        self._method_outargs = {}
 
-    @dbus.service.method(IFACE, in_signature="as", out_signature="as")
+    def on_bus_acquired(self, connection, name):
+        info = Gio.DBusNodeInfo.new_for_xml(self.__doc__)
+        for interface in info.interfaces:
+            for method in interface.methods:
+                self._method_outargs[method.name] = '({})'.format(
+                    ''.join([arg.signature for arg in method.out_args]))
+
+            _id = connection.register_object(
+                object_path=self.PATH,
+                interface_info=interface,
+                method_call_closure=self.on_method_call)
+            self._registered_ids.append(_id)
+
+    def on_name_lost(self, connection, name):
+        for _id in self._registered_ids:
+            connection.unregister_object(_id)
+
+    def remove_from_connection(self):
+        if self._own_id is not None:
+            Gio.bus_unown_name(self._own_id)
+            self._own_id = None
+
+    def on_method_call(self, connection, sender, object_path, interface_name,
+                       method_name, parameters, invocation):
+        args = list(parameters.unpack())
+        result = getattr(self, method_name)(*args)
+        if not isinstance(result, tuple):
+            result = (result,)
+
+        out_args = self._method_outargs[method_name]
+        if out_args != '()':
+            variant = GLib.Variant(out_args, result)
+            invocation.return_value(variant)
+        else:
+            invocation.return_value(None)
+
+    def Introspect(self):
+        return self.__doc__
+
     def GetInitialResultSet(self, terms):
         if terms:
             query = Query("")
@@ -136,7 +214,6 @@ class SearchProvider(dbus.service.Object):
         ids = [get_song_id(s) for s in songs]
         return ids
 
-    @dbus.service.method(IFACE, in_signature="asas", out_signature="as")
     def GetSubsearchResultSet(self, previous_results, terms):
         query = Query("")
         for term in terms:
@@ -146,25 +223,23 @@ class SearchProvider(dbus.service.Object):
         ids = [get_song_id(s) for s in songs if query.search(s)]
         return ids
 
-    @dbus.service.method(IFACE, in_signature="as",
-                         out_signature="aa{sv}")
     def GetResultMetas(self, identifiers):
         metas = []
         for song in get_songs_for_ids(app.library, identifiers):
             name = song("title")
             description = song("~artist~title")
             song_id = get_song_id(song)
-            meta = dbus.Dictionary({
-                "name": dbus_unicode_validate(name),
-                "id": song_id,
-                "description": dbus_unicode_validate(description),
-                "gicon": ENTRY_ICON,
-            }, signature="ss")
+            meta = {
+                "name": GLib.Variant('s', dbus_unicode_validate(name)),
+                "id": GLib.Variant('s', song_id),
+                "description": GLib.Variant(
+                    's', dbus_unicode_validate(description)),
+                "gicon": GLib.Variant('s', ENTRY_ICON)
+            }
             metas.append(meta)
 
         return metas
 
-    @dbus.service.method(IFACE, in_signature="sasu")
     def ActivateResult(self, identifier, terms, timestamp):
         songs = get_songs_for_ids(app.library, [identifier])
         if not songs:
@@ -173,7 +248,6 @@ class SearchProvider(dbus.service.Object):
         if app.player.go_to(songs[0], True):
             app.player.paused = False
 
-    @dbus.service.method(IFACE, in_signature="asu")
     def LaunchSearch(self, terms, timestamp):
         try:
             app.window.browser.filter_text(" ".join(terms))


### PR DESCRIPTION
According to https://www.freedesktop.org/wiki/Software/DBusBindings/ dbus-python is obsolete. This patch ports GNOME Search Provider extension to recommended GDBus binding.