### PR TITLE
Port GNOME multimedia keys backend to GDBus

### DIFF
--- a/quodlibet/quodlibet/mmkeys/gnome.py
+++ b/quodlibet/quodlibet/mmkeys/gnome.py
@@ -124,7 +124,7 @@ class GnomeBackend(MMKeysBackend):
 
     def __on_signal(self, proxy, sender, signal, args):
         if signal == 'MediaPlayerKeyPressed':
-            application, action = args[:2]
+            application, action = tuple(args)[:2]
             self.__key_pressed(application, action)
 
     def __key_pressed(self, application, action):

--- a/quodlibet/quodlibet/mmkeys/gnome.py
+++ b/quodlibet/quodlibet/mmkeys/gnome.py
@@ -11,7 +11,7 @@ import time
 from gi.repository import GLib, Gio
 
 from ._base import MMKeysBackend, MMKeysAction
-from quodlibet.util.dbusutils import dbus_name_owned
+from quodlibet.util.environment import dbus_name_owned
 
 
 class GnomeBackend(MMKeysBackend):

--- a/quodlibet/quodlibet/util/dbusutils.py
+++ b/quodlibet/quodlibet/util/dbusutils.py
@@ -8,6 +8,8 @@
 
 import xml.etree.ElementTree as ET
 
+from gi.repository import GLib, Gio
+
 import dbus
 import dbus.service
 
@@ -335,3 +337,18 @@ class DBusProperty(object):
     @dbus.service.signal(IFACE, signature="sa{sv}as", rel_path_keyword="rel")
     def PropertiesChanged(self, interface, changed, invalidated, rel=""):
         pass
+
+
+def dbus_name_owned(name):
+    """Returns True if the dbus name has an owner"""
+    BUS_DAEMON_NAME = 'org.freedesktop.DBus'
+    BUS_DAEMON_PATH = '/org/freedesktop/DBus'
+    BUS_DAEMON_IFACE = 'org.freedesktop.DBus'
+
+    try:
+        bus = Gio.DBusProxy.new_for_bus_sync(
+            Gio.BusType.SESSION, Gio.DBusProxyFlags.NONE, None,
+            BUS_DAEMON_NAME, BUS_DAEMON_PATH, BUS_DAEMON_IFACE, None)
+        return bus.NameHasOwner('(s)', name)
+    except GLib.Error:
+        return False

--- a/quodlibet/quodlibet/util/dbusutils.py
+++ b/quodlibet/quodlibet/util/dbusutils.py
@@ -8,8 +8,6 @@
 
 import xml.etree.ElementTree as ET
 
-from gi.repository import GLib, Gio
-
 import dbus
 import dbus.service
 
@@ -337,18 +335,3 @@ class DBusProperty(object):
     @dbus.service.signal(IFACE, signature="sa{sv}as", rel_path_keyword="rel")
     def PropertiesChanged(self, interface, changed, invalidated, rel=""):
         pass
-
-
-def dbus_name_owned(name):
-    """Returns True if the dbus name has an owner"""
-    BUS_DAEMON_NAME = 'org.freedesktop.DBus'
-    BUS_DAEMON_PATH = '/org/freedesktop/DBus'
-    BUS_DAEMON_IFACE = 'org.freedesktop.DBus'
-
-    try:
-        bus = Gio.DBusProxy.new_for_bus_sync(
-            Gio.BusType.SESSION, Gio.DBusProxyFlags.NONE, None,
-            BUS_DAEMON_NAME, BUS_DAEMON_PATH, BUS_DAEMON_IFACE, None)
-        return bus.NameHasOwner('(s)', name)
-    except GLib.Error:
-        return False

--- a/quodlibet/quodlibet/util/environment.py
+++ b/quodlibet/quodlibet/util/environment.py
@@ -14,8 +14,7 @@ import os
 import sys
 import ctypes
 
-from gi.repository import Gio
-from gi.repository import GLib
+from quodlibet.util.dbusutils import dbus_name_owned
 
 
 def _dbus_name_owned(name):
@@ -24,16 +23,7 @@ def _dbus_name_owned(name):
     if not is_linux():
         return False
 
-    try:
-        dbus = Gio.DBusProxy.new_for_bus_sync(Gio.BusType.SESSION,
-                                              Gio.DBusProxyFlags.NONE, None,
-                                              'org.freedesktop.DBus',
-                                              '/org/freedesktop/DBus',
-                                              'org.freedesktop.DBus',
-                                              None)
-        return dbus.NameHasOwner('(s)', name)
-    except GLib.Error:
-        return False
+    return dbus_name_owned(name)
 
 
 def is_flatpak():

--- a/quodlibet/quodlibet/util/environment.py
+++ b/quodlibet/quodlibet/util/environment.py
@@ -14,7 +14,7 @@ import os
 import sys
 import ctypes
 
-from quodlibet.util.dbusutils import dbus_name_owned
+from gi.repository import GLib, Gio
 
 
 def _dbus_name_owned(name):
@@ -80,3 +80,19 @@ def is_osx():
     """If we are running under OS X"""
 
     return sys.platform == "darwin"
+
+
+def dbus_name_owned(name):
+    """Returns True if the dbus name has an owner"""
+
+    BUS_DAEMON_NAME = 'org.freedesktop.DBus'
+    BUS_DAEMON_PATH = '/org/freedesktop/DBus'
+    BUS_DAEMON_IFACE = 'org.freedesktop.DBus'
+
+    try:
+        bus = Gio.DBusProxy.new_for_bus_sync(
+            Gio.BusType.SESSION, Gio.DBusProxyFlags.NONE, None,
+            BUS_DAEMON_NAME, BUS_DAEMON_PATH, BUS_DAEMON_IFACE, None)
+        return bus.NameHasOwner('(s)', name)
+    except GLib.Error:
+        return False


### PR DESCRIPTION
According to https://www.freedesktop.org/wiki/Software/DBusBindings/ dbus-python is obsolete. This patch ports GNOME multimedia keys backend to recommended GDBus binding.
Also moved dbus_name_owned() utility function to dbusutils.py.