### PR TITLE
Random album playback plugin - make it Python 3 compatible

### DIFF
--- a/quodlibet/quodlibet/ext/events/randomalbum.py
+++ b/quodlibet/quodlibet/ext/events/randomalbum.py
@@ -188,23 +188,27 @@ class RandomAlbum(EventPlugin):
                 # Select 3% of albums, or at least 3 albums
                 total = len(values)
                 nr_albums = min(total, max(int(0.03 * total), 3))
-                print_d("Choosing from %d library albums. Best:" % nr_albums)
+                print_d("Choosing from %d library albums:" % nr_albums)
                 chosen_albums = random.sample(values, nr_albums)
                 album_scores = self._score(chosen_albums)
-                for score, album in album_scores[-5:]:
-                    print_d("%0.1f scored by %s" % (score, album("album")))
                 # Find highest score value
                 max_score = max(album_scores, key=lambda t: t[0])[0]
+                print_d("Maximum score found: %0.1f" % max_score)
                 # Filter albums by highest score value
                 albums = [(sc, al)
                           for sc, al in album_scores
                           if sc == max_score]
+                print_d("Albums with maximum score:")
+                for score, album in album:
+                    print_d("  %s" % album("album"))
+                
                 # Pick random album from list of highest scored albums
                 album = random.choice(albums)[1]
             else:
                 album = random.choice(values)
 
             if album is not None:
+                print_d("Chosen album: %s" % album("album"))
                 self.schedule_change(album)
 
     def schedule_change(self, album):

--- a/quodlibet/quodlibet/ext/events/randomalbum.py
+++ b/quodlibet/quodlibet/ext/events/randomalbum.py
@@ -199,9 +199,9 @@ class RandomAlbum(EventPlugin):
                           for sc, al in album_scores
                           if sc == max_score]
                 print_d("Albums with maximum score:")
-                for score, album in album:
+                for score, album in albums:
                     print_d("  %s" % album("album"))
-                
+
                 # Pick random album from list of highest scored albums
                 album = random.choice(albums)[1]
             else:

--- a/quodlibet/quodlibet/ext/events/randomalbum.py
+++ b/quodlibet/quodlibet/ext/events/randomalbum.py
@@ -191,14 +191,16 @@ class RandomAlbum(EventPlugin):
                 print_d("Choosing from %d library albums. Best:" % nr_albums)
                 chosen_albums = random.sample(values, nr_albums)
                 album_scores = self._score(chosen_albums)
-                # Find highest score
+                for score, album in album_scores[-5:]:
+                    print_d("%0.1f scored by %s" % (score, album("album")))
+                # Find highest score value
                 max_score = max(album_scores, key=lambda t: t[0])[0]
-                # Filter albums by highest score
+                # Filter albums by highest score value
                 albums = [(sc, al)
                           for sc, al in album_scores
                           if sc == max_score]
-                # Pick random album from albums with max. score
-                album = random.choice(albums)
+                # Pick random album from list of highest scored albums
+                album = random.choice(albums)[1]
             else:
                 album = random.choice(values)
 

--- a/quodlibet/quodlibet/ext/events/randomalbum.py
+++ b/quodlibet/quodlibet/ext/events/randomalbum.py
@@ -140,7 +140,7 @@ class RandomAlbum(EventPlugin):
         return vbox
 
     def _score(self, albums):
-        """Score each album. Returns a list of (score, name) tuples."""
+        """Score each album. Returns a list of (score, album) tuples."""
 
         # Score the album based on its weighted rank ordering for each key
         # Rank ordering is more resistant to clustering than weighting
@@ -160,7 +160,7 @@ class RandomAlbum(EventPlugin):
                 rank = ranked[tag].index(album)
                 scores[album] += rank * self.weights[tag]
 
-        return [(score, name) for name, score in scores.items()]
+        return [(score, album) for album, score in scores.items()]
 
     def plugin_on_song_started(self, song):
         one_song = app.player_options.single
@@ -190,10 +190,15 @@ class RandomAlbum(EventPlugin):
                 nr_albums = min(total, max(int(0.03 * total), 3))
                 print_d("Choosing from %d library albums. Best:" % nr_albums)
                 chosen_albums = random.sample(values, nr_albums)
-                album_scores = sorted(self._score(chosen_albums))
-                for score, album in album_scores[-5:]:
-                    print_d("%0.1f scored by %s" % (score, album("album")))
-                album = max(album_scores)[1]
+                album_scores = self._score(chosen_albums)
+                # Find highest score
+                max_score = max(album_scores, key=lambda t: t[0])[0]
+                # Filter albums by highest score
+                albums = [(sc, al)
+                          for sc, al in album_scores
+                          if sc == max_score]
+                # Pick random album from albums with max. score
+                album = random.choice(albums)
             else:
                 album = random.choice(values)
 


### PR DESCRIPTION
When using the `Random album playback` plug-in on Linux Mint 19 with Python 3.6.5 I always get exception when QL switches the album. This was due to the line 193 in `quodlibet/ext/events/randomalbum.py`:
```python
                album_scores = sorted(self._score(chosen_albums))
```
The exception was cause by Python 3 not being able to sort class instances without a `__le__` method.

The original code sorted the albums and picked the maximum. I changed the code to find the maximum score, filter the albums by this maximum score and pick an album by random from the resulting list. This also solved the problem, that the original `randomalbum.py` always picked the last album (in alphabetical order), if more than one album has the maximum score.