### PR TITLE
Port DBusHandler to GDBus

### DIFF
--- a/quodlibet/quodlibet/qltk/dbus_.py
+++ b/quodlibet/quodlibet/qltk/dbus_.py
@@ -8,9 +8,8 @@
 # the Free Software Foundation; either version 2 of the License, or
 # (at your option) any later version.
 
-import dbus
-import dbus.service
-from dbus import DBusException
+from gi.repository import GLib
+from gi.repository import Gio
 
 from quodlibet.util import dbusutils
 from quodlibet.query import Query
@@ -19,15 +18,65 @@ from quodlibet.formats import decode_value
 from quodlibet.compat import itervalues
 
 
-class DBusHandler(dbus.service.Object):
+class DBusHandler:
+    """
+    <!DOCTYPE node PUBLIC
+      "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
+      "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+    <node name="/net/sacredchao/QuodLibet">
+      <interface name="org.freedesktop.DBus.Introspectable">
+        <method name="Introspect">
+          <arg direction="out" type="s" />
+        </method>
+      </interface>
+      <interface name="net.sacredchao.QuodLibet">
+        <signal name="SongStarted">
+          <arg type="v" name="song" />
+        </signal>
+        <signal name="SongEnded">
+          <arg type="v" name="song" />
+          <arg type="v" name="skipped" />
+        </signal>
+        <signal name="Paused"></signal>
+        <signal name="Unpaused"></signal>
+        <method name="GetPosition">
+          <arg direction="out" type="u" />
+        </method>
+        <method name="IsPlaying">
+          <arg direction="out" type="b" />
+        </method>
+        <method name="CurrentSong">
+          <arg direction="out" type="a{ss}" />
+        </method>
+        <method name="Next"></method>
+        <method name="Previous"></method>
+        <method name="Pause"></method>
+        <method name="Play"></method>
+        <method name="PlayPause">
+          <arg direction="out" type="b" />
+        </method>
+        <method name="Query">
+          <arg direction="in"  type="s" name="text" />
+          <arg direction="out" type="aa{ss}" />
+        </method>
+      </interface>
+    </node>
+    """
+
+    BUS_NAME = 'net.sacredchao.QuodLibet'
+    PATH = '/net/sacredchao/QuodLibet'
+
     def __init__(self, player, library):
         try:
+            self._registered_ids = []
+            self._method_outargs = {}
             self.library = library
-            bus = dbus.SessionBus()
-            name = dbus.service.BusName('net.sacredchao.QuodLibet', bus=bus)
-            path = '/net/sacredchao/QuodLibet'
-            super(DBusHandler, self).__init__(name, path)
-        except DBusException:
+            self.conn = Gio.bus_get_sync(Gio.BusType.SESSION, None)
+            Gio.bus_own_name_on_connection(self.conn, self.BUS_NAME,
+                                           Gio.BusNameOwnerFlags.NONE,
+                                           None, self.__on_name_lost)
+            self.__register_ifaces()
+        except GLib.Error:
             pass
         else:
             player.connect('song-started', self.__song_started)
@@ -36,7 +85,39 @@ class DBusHandler(dbus.service.Object):
             player.connect('unpaused', lambda player: self.Unpaused())
             self._player = player
 
-    def __dict(self, song):
+    def __on_name_lost(self, connection, name):
+        for _id in self._registered_ids:
+            connection.unregister_object(_id)
+
+    def __register_ifaces(self):
+        info = Gio.DBusNodeInfo.new_for_xml(self.__doc__)
+        for interface in info.interfaces:
+            for method in interface.methods:
+                self._method_outargs[method.name] = '({})'.format(
+                    ''.join([arg.signature for arg in method.out_args]))
+
+            _id = self.conn.register_object(
+                object_path=self.PATH,
+                interface_info=interface,
+                method_call_closure=self.__on_method_call)
+            self._registered_ids.append(_id)
+
+    def __on_method_call(self, connection, sender, object_path, interface_name,
+                         method_name, parameters, invocation):
+        args = list(parameters.unpack())
+        result = getattr(self, method_name)(*args)
+        if not isinstance(result, tuple):
+            result = (result,)
+
+        out_args = self._method_outargs[method_name]
+        if out_args != '()':
+            variant = GLib.Variant(out_args, result)
+            invocation.return_value(variant)
+        else:
+            invocation.return_value(None)
+
+    @staticmethod
+    def __dict(song):
         dict = {}
         for key, value in (song or {}).items():
             value = decode_value(key, value)
@@ -55,56 +136,51 @@ class DBusHandler(dbus.service.Object):
             song = self.__dict(song)
             self.SongEnded(song, skipped)
 
-    @dbus.service.signal('net.sacredchao.QuodLibet')
+    def Introspect(self):
+        return self.__doc__
+
     def SongStarted(self, song):
-        pass
+        self.conn.emit_signal(None, self.PATH, 'net.sacredchao.QuodLibet',
+                              'SongStarted', GLib.Variant('(a{ss})', (song,)))
 
-    @dbus.service.signal('net.sacredchao.QuodLibet')
     def SongEnded(self, song, skipped):
-        pass
+        self.conn.emit_signal(None, self.PATH, 'net.sacredchao.QuodLibet',
+                              'SongEnded', GLib.Variant('(a{ss}b)',
+                                                        (song, skipped)))
 
-    @dbus.service.signal('net.sacredchao.QuodLibet')
     def Paused(self):
-        pass
+        self.conn.emit_signal(None, self.PATH, 'net.sacredchao.QuodLibet',
+                              'Paused', None)
 
-    @dbus.service.signal('net.sacredchao.QuodLibet')
     def Unpaused(self):
-        pass
+        self.conn.emit_signal(None, self.PATH, 'net.sacredchao.QuodLibet',
+                              'Unpaused', None)
 
-    @dbus.service.method('net.sacredchao.QuodLibet')
     def GetPosition(self):
         return self._player.get_position()
 
-    @dbus.service.method('net.sacredchao.QuodLibet')
     def IsPlaying(self):
         return not self._player.paused
 
-    @dbus.service.method('net.sacredchao.QuodLibet')
     def CurrentSong(self):
         return self.__dict(self._player.song)
 
-    @dbus.service.method('net.sacredchao.QuodLibet')
     def Next(self):
         self._player.next()
 
-    @dbus.service.method('net.sacredchao.QuodLibet')
     def Previous(self):
         self._player.previous()
 
-    @dbus.service.method('net.sacredchao.QuodLibet')
     def Pause(self):
         self._player.paused = True
 
-    @dbus.service.method('net.sacredchao.QuodLibet')
     def Play(self):
         self._player.play()
 
-    @dbus.service.method('net.sacredchao.QuodLibet')
     def PlayPause(self):
         self._player.playpause()
         return self._player.paused
 
-    @dbus.service.method('net.sacredchao.QuodLibet', in_signature='s')
     def Query(self, text):
         if text is not None:
             query = Query(text, star=SongList.star)


### PR DESCRIPTION
According to https://www.freedesktop.org/wiki/Software/DBusBindings/ dbus-python is obsolete. This patch ports DBusHandler server (net.sacredchao.QuodLibet) to recommended GDBus binding.