### PR TITLE
Closes #2928: Add an option to hide time labels

### DIFF
--- a/quodlibet/quodlibet/ext/events/waveformseekbar.py
+++ b/quodlibet/quodlibet/ext/events/waveformseekbar.py
@@ -4,6 +4,7 @@
 #           2017 Didier Villevalois
 #           2017 Muges
 #           2017 Eyenseo
+#           2018 Joschua Gandert
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -664,7 +665,6 @@ class WaveformSeekBarPlugin(EventPlugin):
         show_current_pos.set_active(CONFIG.show_current_pos)
         show_current_pos.connect("toggled", on_show_pos_toggled)
         vbox.pack_start(show_current_pos, True, True, 0)
-
 
         show_time_labels = Gtk.CheckButton(label=_("Show time labels"))
         show_time_labels.set_active(CONFIG.show_time_labels)


### PR DESCRIPTION
This is what it looks like when time labels are disabled (by default they are enabled currently): 

![ql-waveform](https://user-images.githubusercontent.com/3063858/43703750-15516b7e-995e-11e8-83e2-f36b5326aa83.png)

(I highly recommend Ghost if metal with tongue-in-cheek [not actual] satanic lyrics sounds good. =)