### PR TITLE
Scrolling the mouse wheel seeks waveform seekbar

### DIFF
--- a/quodlibet/quodlibet/ext/events/waveformseekbar.py
+++ b/quodlibet/quodlibet/ext/events/waveformseekbar.py
@@ -670,6 +670,7 @@ class WaveformSeekBarPlugin(EventPlugin):
             adjustment=Gtk.Adjustment(CONFIG.seek_amount,
                                       0, 60000, 1000, 1000, 0)
         )
+        seek_amount.set_numeric(True)
         seek_amount.connect("changed", seek_amount_changed)
         hbox.pack_start(seek_amount, True, True, 0)
         vbox.pack_start(hbox, True, True, 0)

--- a/quodlibet/quodlibet/ext/events/waveformseekbar.py
+++ b/quodlibet/quodlibet/ext/events/waveformseekbar.py
@@ -310,7 +310,8 @@ class WaveformScale(Gtk.EventBox):
         self.mouse_position = -1
         self._last_mouse_position = -1
         self.connect('scroll-event', self.do_scroll_event)
-        self.add_events(Gdk.EventMask.POINTER_MOTION_MASK | Gdk.EventMask.SCROLL_MASK)
+        self.add_events(Gdk.EventMask.POINTER_MOTION_MASK |
+                        Gdk.EventMask.SCROLL_MASK)
 
         self._seeking = False
 
@@ -661,7 +662,9 @@ class WaveformSeekBarPlugin(EventPlugin):
 
         hbox = Gtk.HBox(spacing=6)
         hbox.set_border_width(6)
-        label = Gtk.Label(label=_("Seek amount when scrolling (milliseconds):"))
+        label = Gtk.Label(label=_(
+            "Seek amount when scrolling (milliseconds):"
+        ))
         hbox.pack_start(label, False, True, 0)
         seek_amount = Gtk.SpinButton(
             adjustment=Gtk.Adjustment(CONFIG.seek_amount,

--- a/quodlibet/quodlibet/ext/events/waveformseekbar.py
+++ b/quodlibet/quodlibet/ext/events/waveformseekbar.py
@@ -308,7 +308,8 @@ class WaveformScale(Gtk.EventBox):
 
         self.mouse_position = -1
         self._last_mouse_position = -1
-        self.add_events(Gdk.EventMask.POINTER_MOTION_MASK)
+        self.connect('scroll-event', self.do_scroll_event)
+        self.add_events(Gdk.EventMask.POINTER_MOTION_MASK | Gdk.EventMask.SCROLL_MASK)
 
         self._seeking = False
 
@@ -534,6 +535,15 @@ class WaveformScale(Gtk.EventBox):
             self.queue_draw()
             return True
 
+    def do_scroll_event(self, event, extra=None):
+        if extra is not None:
+            # Each scroll gives 2 callbacks, one with an extra arg
+            return
+        if event.direction == Gdk.ScrollDirection.UP:
+            self._player.seek(self._player.get_position() + 5000)
+        elif event.direction == Gdk.ScrollDirection.DOWN:
+            self._player.seek(self._player.get_position() - 5000)
+
     def set_position(self, position):
         self.position = position
 
@@ -556,6 +566,7 @@ class Config(object):
     remaining_color = ConfProp(_config, "remaining_color", "")
     show_current_pos = BoolConfProp(_config, "show_current_pos", False)
     max_data_points = IntConfProp(_config, "max_data_points", 3000)
+
 
 CONFIG = Config()
 

--- a/quodlibet/quodlibet/ext/events/waveformseekbar.py
+++ b/quodlibet/quodlibet/ext/events/waveformseekbar.py
@@ -540,9 +540,9 @@ class WaveformScale(Gtk.EventBox):
             # Each scroll gives 2 callbacks, one with an extra arg
             return
         if event.direction == Gdk.ScrollDirection.UP:
-            self._player.seek(self._player.get_position() + 5000)
+            self._player.seek(self._player.get_position() + CONFIG.seek_amount)
         elif event.direction == Gdk.ScrollDirection.DOWN:
-            self._player.seek(self._player.get_position() - 5000)
+            self._player.seek(self._player.get_position() - CONFIG.seek_amount)
 
     def set_position(self, position):
         self.position = position
@@ -565,6 +565,7 @@ class Config(object):
     hover_color = ConfProp(_config, "hover_color", "")
     remaining_color = ConfProp(_config, "remaining_color", "")
     show_current_pos = BoolConfProp(_config, "show_current_pos", False)
+    seek_amount = IntConfProp(_config, "seek_amount", 5000)
     max_data_points = IntConfProp(_config, "max_data_points", 3000)
 
 
@@ -622,6 +623,10 @@ class WaveformSeekBarPlugin(EventPlugin):
 
         def on_show_pos_toggled(button, *args):
             CONFIG.show_current_pos = button.get_active()
+
+        def seek_amount_changed(spinbox):
+            CONFIG.seek_amount = spinbox.get_value_as_int()
+
         vbox = Gtk.VBox(spacing=6)
 
         def create_color(label_text, color, callback):
@@ -652,5 +657,17 @@ class WaveformSeekBarPlugin(EventPlugin):
         show_current_pos.set_active(CONFIG.show_current_pos)
         show_current_pos.connect("toggled", on_show_pos_toggled)
         vbox.pack_start(show_current_pos, True, True, 0)
+
+        hbox = Gtk.HBox(spacing=6)
+        hbox.set_border_width(6)
+        label = Gtk.Label(label=_("Seek amount when scrolling (milliseconds):"))
+        hbox.pack_start(label, False, True, 0)
+        seek_amount = Gtk.SpinButton(
+            adjustment=Gtk.Adjustment(CONFIG.seek_amount,
+                                      0, 60000, 1000, 1000, 0)
+        )
+        seek_amount.connect("changed", seek_amount_changed)
+        hbox.pack_start(seek_amount, True, True, 0)
+        vbox.pack_start(hbox, True, True, 0)
 
         return vbox

--- a/quodlibet/quodlibet/ext/events/waveformseekbar.py
+++ b/quodlibet/quodlibet/ext/events/waveformseekbar.py
@@ -4,6 +4,7 @@
 #           2017 Didier Villevalois
 #           2017 Muges
 #           2017 Eyenseo
+#           2018 Blimmo
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/quodlibet/quodlibet/ext/events/waveformseekbar.py
+++ b/quodlibet/quodlibet/ext/events/waveformseekbar.py
@@ -309,7 +309,6 @@ class WaveformScale(Gtk.EventBox):
 
         self.mouse_position = -1
         self._last_mouse_position = -1
-        self.connect('scroll-event', self.do_scroll_event)
         self.add_events(Gdk.EventMask.POINTER_MOTION_MASK |
                         Gdk.EventMask.SCROLL_MASK)
 
@@ -537,10 +536,7 @@ class WaveformScale(Gtk.EventBox):
             self.queue_draw()
             return True
 
-    def do_scroll_event(self, event, extra=None):
-        if extra is not None:
-            # Each scroll gives 2 callbacks, one with an extra arg
-            return
+    def do_scroll_event(self, event):
         if event.direction == Gdk.ScrollDirection.UP:
             self._player.seek(self._player.get_position() + CONFIG.seek_amount)
         elif event.direction == Gdk.ScrollDirection.DOWN:


### PR DESCRIPTION
Similar functionality to that available with the alternative seekbar.

I considered making the seek amount setting in seconds instead of milliseconds because I couldn't think of a use case for millisecond accuracy and I felt it would be clearer. I settled on milliseconds since that is the precision it can offer. If people think seconds would be better I can switch to that fairly easily.

~~The workaround for the double calls of the scroll callback was the best I could come up with. Getting my callback called with 2 different numbers of arguments baffled me. Is this a bug with PyGObject?~~