### PR TITLE
#2499 − Add the missing support for the Gnome Multimedia Keys

### DIFF
--- a/quodlibet/quodlibet/mmkeys/__init__.py
+++ b/quodlibet/quodlibet/mmkeys/__init__.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 # Copyright 2014 Christoph Reiter
+#           2018 Ludovic Druette
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -64,6 +65,7 @@ class MMKeysHandler(object):
         self._backend = None
         self._window = app.window
         self._player = app.player
+        self._player_options = app.player_options
         self._app_name = app.name
 
     def start(self):
@@ -91,6 +93,7 @@ class MMKeysHandler(object):
         print_d("Event %r from %r" % (action, type(self._backend).__name__))
 
         player = self._player
+        player_options = self._player_options
         if action == MMKeysAction.PREV:
             player.previous(force=True)
         elif action == MMKeysAction.NEXT:
@@ -103,5 +106,9 @@ class MMKeysHandler(object):
             player.playpause()
         elif action == MMKeysAction.PAUSE:
             player.paused = True
+        elif action == MMKeysAction.REPEAT:
+            player_options.repeat = not player_options.repeat
+        elif action == MMKeysAction.SHUFFLE:
+            player_options.shuffle = not player_options.shuffle
         else:
             assert 0, "unhandled event"

--- a/quodlibet/quodlibet/mmkeys/__init__.py
+++ b/quodlibet/quodlibet/mmkeys/__init__.py
@@ -92,6 +92,13 @@ class MMKeysHandler(object):
     def _callback(self, action):
         print_d("Event %r from %r" % (action, type(self._backend).__name__))
 
+        def seek_relative(seconds):
+            current = player.get_position()
+            current += seconds * 1000
+            current = min(player.song("~#length") * 1000 - 1, current)
+            current = max(0, current)
+            player.seek(current)
+
         player = self._player
         player_options = self._player_options
         if action == MMKeysAction.PREV:
@@ -106,6 +113,12 @@ class MMKeysHandler(object):
             player.playpause()
         elif action == MMKeysAction.PAUSE:
             player.paused = True
+        elif action == MMKeysAction.FORWARD:
+            if player.song:
+                seek_relative(10)
+        elif action == MMKeysAction.REWIND:
+            if player.song:
+                seek_relative(-10)
         elif action == MMKeysAction.REPEAT:
             player_options.repeat = not player_options.repeat
         elif action == MMKeysAction.SHUFFLE:

--- a/quodlibet/quodlibet/mmkeys/_base.py
+++ b/quodlibet/quodlibet/mmkeys/_base.py
@@ -19,6 +19,8 @@ class MMKeysAction(object):
     PREV = "prev"
     NEXT = "next"
     PLAYPAUSE = "playpause"
+    FORWARD = "forward"
+    REWIND = "rewind"
     REPEAT = "repeat"
     SHUFFLE = "shuffle"
 

--- a/quodlibet/quodlibet/mmkeys/_base.py
+++ b/quodlibet/quodlibet/mmkeys/_base.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 # Copyright 2014 Christoph Reiter
+#           2018 Ludovic Druette
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -18,6 +19,8 @@ class MMKeysAction(object):
     PREV = "prev"
     NEXT = "next"
     PLAYPAUSE = "playpause"
+    REPEAT = "repeat"
+    SHUFFLE = "shuffle"
 
 
 class MMKeysBackend(object):

--- a/quodlibet/quodlibet/mmkeys/gnome.py
+++ b/quodlibet/quodlibet/mmkeys/gnome.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 # Copyright 2014 Christoph Reiter
+#           2018 Ludovic Druette
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -26,8 +27,10 @@ class GnomeBackend(MMKeysBackend):
         "Play": MMKeysAction.PLAYPAUSE,
         "Pause": MMKeysAction.PAUSE,
         "Stop": MMKeysAction.STOP,
+        "Repeat": MMKeysAction.REPEAT,
+        "Shuffle": MMKeysAction.SHUFFLE
     }
-    # TODO: Rewind, FastForward, Repeat, Shuffle
+    # TODO: Rewind, FastForward
 
     def __init__(self, name, callback):
         self.__interface = None

--- a/quodlibet/quodlibet/mmkeys/gnome.py
+++ b/quodlibet/quodlibet/mmkeys/gnome.py
@@ -27,10 +27,11 @@ class GnomeBackend(MMKeysBackend):
         "Play": MMKeysAction.PLAYPAUSE,
         "Pause": MMKeysAction.PAUSE,
         "Stop": MMKeysAction.STOP,
+        "FastForward": MMKeysAction.FORWARD,
+        "Rewind": MMKeysAction.REWIND,
         "Repeat": MMKeysAction.REPEAT,
         "Shuffle": MMKeysAction.SHUFFLE
     }
-    # TODO: Rewind, FastForward
 
     def __init__(self, name, callback):
         self.__interface = None

--- a/quodlibet/quodlibet/mmkeys/keybinder.py
+++ b/quodlibet/quodlibet/mmkeys/keybinder.py
@@ -32,6 +32,8 @@ class KeybinderBackend(MMKeysBackend):
         "XF86AudioNext": MMKeysAction.NEXT,
         "XF86AudioStop": MMKeysAction.STOP,
         "XF86AudioPlay": MMKeysAction.PLAYPAUSE,
+        "XF86AudioForward": MMKeysAction.FORWARD,
+        "XF86AudioRewind": MMKeysAction.REWIND,
         "XF86AudioRepeat": MMKeysAction.REPEAT,
         "XF86AudioRandomPlay": MMKeysAction.SHUFFLE
     }

--- a/quodlibet/quodlibet/mmkeys/keybinder.py
+++ b/quodlibet/quodlibet/mmkeys/keybinder.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 # Copyright 2014 Christoph Reiter
+#           2018 Ludovic Druette
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -31,6 +32,8 @@ class KeybinderBackend(MMKeysBackend):
         "XF86AudioNext": MMKeysAction.NEXT,
         "XF86AudioStop": MMKeysAction.STOP,
         "XF86AudioPlay": MMKeysAction.PLAYPAUSE,
+        "XF86AudioRepeat": MMKeysAction.REPEAT,
+        "XF86AudioRandomPlay": MMKeysAction.SHUFFLE
     }
 
     def __init__(self, name, callback):


### PR DESCRIPTION
## Features
These commits implement support of Repeat, Shuffle, Rewind and Forward mmkeys in GnomeBackend and KeybinderBackend according to issue #2499 (if this pull request is accepted the issue could be close).


## Tests
The callbacks are all ok and tested.

Using xdotool (as described in #2499) with KeybinderBackend, RandomPlay and Repeat are not catch.

I don't test the GnomeBackend, if there is any gnome user, feel free to try.