### PR TITLE
Bug fix -- Right Click Menu Crash in Edit Tag Window

### DIFF
--- a/quodlibet/quodlibet/qltk/edittags.py
+++ b/quodlibet/quodlibet/qltk/edittags.py
@@ -628,8 +628,9 @@ class EditTags(Gtk.VBox):
                 else:
                     b.connect('activate', self.__menu_activate, view)
 
-                    if (not min(map(self.__songinfo.can_change, b.needs) +
-                                [1])
+                    if (not min(list(
+                                map(self.__songinfo.can_change, b.needs))
+                                + [1])
                             or comment.is_special()):
                         b.set_sensitive(False)
 


### PR DESCRIPTION
I fixed a crash that complained about adding a list and a map together. The following is the crash report I received:

```python 
TypeError: unsupported operand type(s) for +: 'map' and 'list'
------
Traceback (most recent call last):

  File "/usr/lib/python3/dist-packages/quodlibet/qltk/edittags.py", line 632, in __popup_menu
    [1])

TypeError: unsupported operand type(s) for +: 'map' and 'list'
```
Converting the map to a list allows the addition of these elements, but I'd like to hear if this is actually the desired behavior? Never-the-less, this PR solves the bug and seems to run well on my local repository. 

This is my first commit to this project, so hopefully it meets your standards. 