### PR TITLE
Big Album Cover View Now Updates on Song Change

### DIFF
--- a/quodlibet/quodlibet/qltk/cover.py
+++ b/quodlibet/quodlibet/qltk/cover.py
@@ -35,12 +35,55 @@ class BigCenteredImage(qltk.Window):
         parent = qltk.get_top_parent(parent)
         self.set_transient_for(parent)
 
+        self.set_position(Gtk.WindowPosition.CENTER_ON_PARENT)
+
+        #If image fails to set, abort construction.
+        if not self.set_image(fileobj, parent):
+            self.destroy()
+            return
+
+        event_box = Gtk.EventBox()
+        event_box.add(self.__image)
+
+        frame = Gtk.Frame()
+        frame.set_shadow_type(Gtk.ShadowType.OUT)
+        frame.add(event_box)
+
+        self.add(frame)
+
+        event_box.connect('button-press-event', self.__destroy)
+        event_box.connect('key-press-event', self.__destroy)
+
+        self.get_child().show_all()
+
+    def set_image(self, file, parent):
+        scale_factor = self.get_scale_factor()
+
+        (width, height) = self.__calculate_screen_width(parent)
+
+        pixbuf = None
+        try:
+            pixbuf = pixbuf_from_file(file, (width, height), scale_factor)
+        except GLib.GError:
+            return False
+
+        # failed to load, abort
+        if not pixbuf:
+            return False
+
+        self.__image = Gtk.Image()
+        self.__image.set_from_surface(get_surface_for_pixbuf(self, pixbuf))
+
+        return True
+
+    def __calculate_screen_width(self, parent):
         if qltk.is_wayland():
             # no screen size with wayland, the parent window is
             # the next best thing..
             width, height = parent.get_size()
             width = int(width / 1.1)
             height = int(height / 1.1)
+            return (width, height)
         else:
             win = parent.get_window()
             if win:
@@ -56,40 +99,11 @@ class BigCenteredImage(qltk.Window):
                     rect = screen.get_monitor_geometry(mon_num)
                 width = int(rect.width / 1.8)
                 height = int(rect.height / 1.8)
-            else:
-                width = int(Gdk.Screen.width() / 1.8)
-                height = int(Gdk.Screen.height() / 1.8)
+                return (width, height)
 
-        self.set_position(Gtk.WindowPosition.CENTER_ON_PARENT)
-
-        scale_factor = self.get_scale_factor()
-
-        pixbuf = None
-        try:
-            pixbuf = pixbuf_from_file(fileobj, (width, height), scale_factor)
-        except GLib.GError:
-            pass
-
-        # failed to load, abort
-        if not pixbuf:
-            self.destroy()
-            return
-
-        image = Gtk.Image()
-        image.set_from_surface(get_surface_for_pixbuf(self, pixbuf))
-
-        event_box = Gtk.EventBox()
-        event_box.add(image)
-
-        frame = Gtk.Frame()
-        frame.set_shadow_type(Gtk.ShadowType.OUT)
-        frame.add(event_box)
-
-        self.add(frame)
-
-        event_box.connect('button-press-event', self.__destroy)
-        event_box.connect('key-press-event', self.__destroy)
-        self.get_child().show_all()
+            width = int(Gdk.Screen.width() / 1.8)
+            height = int(Gdk.Screen.height() / 1.8)
+            return (width, height)
 
     def __destroy(self, *args):
         self.destroy()
@@ -241,7 +255,7 @@ class CoverImage(Gtk.EventBox):
         self.__cancellable = None
 
         self.add(ResizeImage(resize, size))
-        self.connect('button-press-event', self.__show_cover)
+        self.connect('button-press-event', self.__album_clicked)
         self.set_song(song)
         self.get_child().show_all()
 
@@ -264,14 +278,24 @@ class CoverImage(Gtk.EventBox):
                     try:
                         self.set_image(result)
                         self.emit('cover-visible', success)
+                        self.update_bci(result)
                         # If this widget is already 'destroyed', we will get
                         # following error.
                     except AttributeError:
                         pass
+                else:
+                    self.update_bci(None)
             app.cover_manager.acquire_cover(cb, cancellable, song)
 
     def refresh(self):
         self.set_song(self.__song)
+
+    def update_bci(self, albumfile):
+        #if there's a big image displaying, it should update.
+        if self.__current_bci is not None:
+            self.__current_bci.destroy()
+            if albumfile:
+                self.__show_cover(self.__song)
 
     def __nonzero__(self):
         return bool(self.__file)
@@ -279,26 +303,29 @@ class CoverImage(Gtk.EventBox):
     def __reset_bci(self, bci):
         self.__current_bci = None
 
-    def __show_cover(self, box, event):
-        """Show the cover as a detached BigCenteredImage.
-        If one is already showing, destroy it instead
-        If there is no image, run the AlbumArt plugin
-        """
-
+    def __album_clicked(self, box, event):
         song = self.__song
         if not song:
             return
 
         if event.button != Gdk.BUTTON_PRIMARY or \
                 event.type != Gdk.EventType.BUTTON_PRESS:
-            return
+            return False
 
+        return self.__show_cover(song)
+
+    def __show_cover(self, song):
+        """Show the cover as a detached BigCenteredImage.
+        If one is already showing, destroy it instead
+        If there is no image, run the AlbumArt plugin
+        """
         if not self.__file and song.is_file:
             from quodlibet.qltk.songsmenu import SongsMenu
             from quodlibet import app
 
             SongsMenu.plugins.handle(ALBUM_ART_PLUGIN_ID, app.library,
                                      qltk.get_top_parent(self), [song])
+
             return True
 
         if self.__current_bci is not None:


### PR DESCRIPTION
The big album cover view used to stay on the same image regardless of what song was currently playing. Now, when the album widget changes due to a new song, it will also change the album art displayed. If there's no album art found, the widget will simply close. 

edit: Some changes should be made to this class in the future, such as allowing the album art to update without creating / destroying the widget. Some groundwork was set for splitting functionality into it's own functions.