### PR TITLE
don't show generic Performance role description for ~performer:roles

### DIFF
--- a/quodlibet/quodlibet/formats/_audio.py
+++ b/quodlibet/quodlibet/formats/_audio.py
@@ -497,7 +497,9 @@ class AudioFile(dict, ImageContainer):
         role_map = {}
         for key in role_tag_keys:
             if key == role_tag:
-                # #2986: don't add a role description for the bare tag unless this is a composite tag (e.g. only show "(Performance)" for ~people:roles and not ~performer:roles)
+                # #2986: don't add a role description for the bare tag, unless
+                # this is a composite tag (e.g. only show "(Performance)" for
+                # ~people:roles and not ~performer:roles).
                 if sub_keys is None:
                     continue
                 else:

--- a/quodlibet/quodlibet/formats/_audio.py
+++ b/quodlibet/quodlibet/formats/_audio.py
@@ -496,8 +496,14 @@ class AudioFile(dict, ImageContainer):
 
         role_map = {}
         for key in role_tag_keys:
-            role = (TAG_ROLES.get(role_tag, role_tag) if key == role_tag
-                    else key.split(":", 1)[-1])
+            if key == role_tag:
+                # #2986: don't add a role description for the bare tag unless this is a composite tag (e.g. only show "(Performance)" for ~people:roles and not ~performer:roles)
+                if sub_keys is None:
+                    continue
+                else:
+                    role = TAG_ROLES.get(role_tag, role_tag)
+            else:
+                role = key.split(":", 1)[-1]
             for name in self.list(key):
                 role_map.setdefault(name, []).append(role)
 

--- a/quodlibet/tests/test_formats__audio.py
+++ b/quodlibet/tests/test_formats__audio.py
@@ -621,26 +621,25 @@ class TAudioFile(TestCase):
                        ("performer", "C")])
         self.failUnlessEqual(set(q.list("~performers")), {"A", "B", "C"})
         self.failUnlessEqual(set(q.list("~performers:roles")),
-                             {"A (Vocals)", "B (Guitar)", "C (Performance)"})
+                             {"A (Vocals)", "B (Guitar)", "C"})
 
     def test_performers_multi_value(self):
         q = AudioFile([
             ("performer:vocals", "X\nA\nY"),
             ("performer:guitar", "Y\nB\nA"),
-            ("performer", "C\nF\nB\nA"),
+            ("performer", "C\nB\nA"),
         ])
 
         self.failUnlessEqual(
-            set(q.list("~performer")), {"A", "B", "C", "F", "X", "Y"})
+            set(q.list("~performer")), {"A", "B", "C", "X", "Y"})
 
         self.failUnlessEqual(
             set(q.list("~performer:roles")), {
-                    "A (Guitar, Performance, Vocals)",
-                    "C (Performance)",
-                    "B (Guitar, Performance)",
+                    "A (Guitar, Vocals)",
+                    "C",
+                    "B (Guitar)",
                     "X (Vocals)",
                     "Y (Guitar, Vocals)",
-                    "F (Performance)",
                 })
 
     def test_people(self):


### PR DESCRIPTION
Fixes  #2986.