### PR TITLE
Save custom eq presets

### DIFF
--- a/quodlibet/quodlibet/ext/events/equalizer.py
+++ b/quodlibet/quodlibet/ext/events/equalizer.py
@@ -210,7 +210,7 @@ class Equalizer(EventPlugin):
         def clicked_db(button):
             selected_index = self._combo_custom.get_active()
             if selected_index < 1:
-                return # Select...
+                return # Select…
             selected = self._combo_custom.get_active_text()
             self._combo_custom.set_active(0)
             self._combo_custom.remove(selected_index)
@@ -245,7 +245,7 @@ class Equalizer(EventPlugin):
 
         def default_combo_changed(combo):
             if combo.get_active() < 1:
-                return # Select...
+                return # Select…
             self._combo_custom.set_active(0)
             gain = sorted_presets[combo.get_active() - 1][1][1]
             gain = interp_bands(PRESET_BANDS, app.player.eq_bands, gain)
@@ -254,7 +254,7 @@ class Equalizer(EventPlugin):
 
         def custom_combo_changed(combo):
             if combo.get_active() < 1:
-                return # Select...
+                return # Select…
             self._combo_default.set_active(0)
             gain = self._config[combo.get_active_text()]
             for (g, a) in zip(gain, adjustments):
@@ -266,7 +266,7 @@ class Equalizer(EventPlugin):
         # Default presets
         combo = Gtk.ComboBoxText()
         self._combo_default = combo
-        combo.append_text(_("Select..."))
+        combo.append_text(_("Select…"))
         combo.set_active(0)
         for key, (name, gain) in sorted_presets:
             combo.append_text(name)
@@ -293,7 +293,7 @@ class Equalizer(EventPlugin):
         # Custom presets
         combo = Gtk.ComboBoxText()
         self._combo_custom = combo
-        combo.append_text(_("Select..."))
+        combo.append_text(_("Select…"))
         combo.set_active(0)
 
         custom_presets = self._config.keys() - {"Current"}

--- a/quodlibet/quodlibet/ext/events/equalizer.py
+++ b/quodlibet/quodlibet/ext/events/equalizer.py
@@ -2,13 +2,12 @@
 # Copyright 2010 Steven Robertson
 #           2012 Christoph Reiter
 #           2017 Nick Boultbee
+#           2018 Olli Helin
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation; either version 2 of the License, or
 # (at your option) any later version.
-
-# TODO: Include saving and loading.
 
 from gi.repository import Gtk, Gdk
 
@@ -17,7 +16,9 @@ from quodlibet import app
 from quodlibet import config
 from quodlibet.qltk import Button, Icons
 from quodlibet.plugins.events import EventPlugin
+from quodlibet.util import print_e, print_w
 
+import ast
 
 # Presets (roughly) taken from Pulseaudio equalizer
 PRESET_BANDS = [50, 100, 156, 220, 311, 440, 622, 880, 1250, 1750, 2500,
@@ -86,10 +87,25 @@ def interp_bands(src_band, target_band, src_gain):
 
 def get_config():
     try:
-        eq_levels_str = config.get('plugins', 'equalizer_levels')
-        return [float(s) for s in eq_levels_str.split(',')]
-    except (config.Error, ValueError):
-        return []
+        config_str = config.get('plugins', 'equalizer_levels')
+        config_dict = ast.literal_eval(config_str)
+
+        if isinstance(config_dict, list):
+            print_w("Converting old EQ config to new format.")
+            config_dict = {"Current": config_dict}
+        if not isinstance(config_dict, dict):
+            raise ValueError("Saved config is of wrong type.")
+        if not "Current" in config_dict.keys():
+            raise ValueError("Saved config was malformed.")
+
+        # Run through the values to check everything is of correct type.
+        for key in config_dict.keys():
+            [float(s) for s in config_dict[key]]
+
+        return config_dict
+    except (config.Error, ValueError) as e:
+        print_e(str(e))
+        return {"Current": []}
 
 
 class Equalizer(EventPlugin):
@@ -107,14 +123,17 @@ class Equalizer(EventPlugin):
     def __init__(self):
         super(Equalizer, self).__init__()
         self._enabled = False
+        self._config = {}
 
     def apply(self):
         if not self.player_has_eq:
             return
-        levels = self._enabled and get_config() or []
+        levels = self._enabled and get_config()["Current"] or []
         lbands = len(app.player.eq_bands)
-        app.player.eq_values = (levels[:min(len(levels), lbands)] +
-                                   [0.] * max(0, (lbands - len(levels))))
+        if len(levels) != lbands:
+            print_w("Number of bands didn't match current. Using flat EQ.")
+            levels = [0.] * lbands
+        app.player.eq_values = levels
 
     def enabled(self):
         self._enabled = True
@@ -125,13 +144,13 @@ class Equalizer(EventPlugin):
         self.apply()
 
     def PluginPreferences(self, win):
-        vb = Gtk.VBox(spacing=6)
+        main_vbox = Gtk.VBox(spacing=12)
         if not self.player_has_eq:
             l = Gtk.Label()
             l.set_markup(
                 _('The current backend does not support equalization.'))
-            vb.pack_start(l, False, True, 0)
-            return vb
+            main_vbox.pack_start(l, False, True, 0)
+            return main_vbox
 
         def format_hertz(band):
             if band >= 1000:
@@ -139,7 +158,13 @@ class Equalizer(EventPlugin):
             return _('%d Hz') % band
 
         bands = [format_hertz(band) for band in app.player.eq_bands]
-        levels = get_config() + [0.] * len(bands)
+        self._config = get_config()
+        levels = self._config["Current"]
+
+        # This fixes possible old corrupt config files with extra level values.
+        if len(levels) != len(bands):
+            print_w("Number of bands didn't match current. Using flat EQ.")
+            levels = [0.] * len(bands)
 
         table = Gtk.Table(rows=len(bands), columns=3)
         table.set_col_spacings(6)
@@ -148,8 +173,9 @@ class Equalizer(EventPlugin):
             rounded = int(adj.get_value() * 2) / 2.0
             adj.set_value(rounded)
             levels[idx] = rounded
-            config.set('plugins', 'equalizer_levels',
-                       ','.join(str(lv) for lv in levels))
+
+            self._config["Current"] = levels
+            config.set('plugins', 'equalizer_levels', str(self._config))
             self.apply()
 
         adjustments = []
@@ -172,36 +198,142 @@ class Equalizer(EventPlugin):
             hs.set_value_pos(Gtk.PositionType.RIGHT)
             hs.connect('format-value', lambda s, v: _('%.1f dB') % v)
             table.attach(hs, 2, 3, i, i + 1)
-        vb.pack_start(table, True, True, 0)
+        main_vbox.pack_start(table, True, True, 0)
 
-        def clicked_cb(button):
+        # Reset EQ button
+        def clicked_rb(button):
             [adj.set_value(0) for adj in adjustments]
+            self._combo_default.set_active(0)
+            self._combo_custom.set_active(0)
+
+        # Delete custom preset button
+        def clicked_db(button):
+            selected_index = self._combo_custom.get_active()
+            if selected_index < 1:
+                return # Select...
+            selected = self._combo_custom.get_active_text()
+            self._combo_custom.set_active(0)
+            self._combo_custom.remove(selected_index)
+            del self._config[selected]
+            config.set('plugins', 'equalizer_levels', str(self._config))
+
+        # Save custom preset button
+        def clicked_sb(button):
+            name = self._preset_name_entry.get_text()
+            is_new = not name in self._config.keys()
+
+            levels = [adj.get_value() for adj in adjustments]
+            self._config[name] = levels
+            config.set('plugins', 'equalizer_levels', str(self._config))
+
+            self._preset_name_entry.set_text("")
+            if is_new:
+                self._combo_custom.append_text(name)
+
+            def find_iter(list_store, text):
+                i = list_store.get_iter_first()
+                while (i is not None):
+                    if list_store.get_value(i, 0) == text:
+                        return i
+                    i = list_store.iter_next(i)
+                return None
+
+            itr = find_iter(self._combo_custom.get_model(), name)
+            self._combo_custom.set_active_iter(itr)
 
         sorted_presets = sorted(PRESETS.items())
 
-        def combo_changed(combo):
-            # custom, skip
-            if not combo.get_active():
-                return
+        def default_combo_changed(combo):
+            if combo.get_active() < 1:
+                return # Select...
+            self._combo_custom.set_active(0)
             gain = sorted_presets[combo.get_active() - 1][1][1]
             gain = interp_bands(PRESET_BANDS, app.player.eq_bands, gain)
             for (g, a) in zip(gain, adjustments):
                 a.set_value(g)
 
+        def custom_combo_changed(combo):
+            if combo.get_active() < 1:
+                return # Select...
+            self._combo_default.set_active(0)
+            gain = self._config[combo.get_active_text()]
+            for (g, a) in zip(gain, adjustments):
+                a.set_value(g)
+
+        frame = Gtk.Frame(label="Default presets", label_xalign=0.5)
+        main_middle_hbox = Gtk.HBox(spacing=6)
+
+        # Default presets
         combo = Gtk.ComboBoxText()
-        combo.append_text(_("Custom"))
+        self._combo_default = combo
+        combo.append_text(_("Select..."))
         combo.set_active(0)
         for key, (name, gain) in sorted_presets:
             combo.append_text(name)
-        combo.connect("changed", combo_changed)
+        combo.connect("changed", default_combo_changed)
 
-        bbox = Gtk.HButtonBox()
-        clear = Button(_("_Clear"), Icons.EDIT_CLEAR)
-        clear.connect('clicked', clicked_cb)
-        bbox.pack_start(combo, True, True, 0)
-        bbox.pack_start(clear, True, True, 0)
-        vb.pack_start(bbox, True, True, 0)
-        return vb
+        # This block is just for padding.
+        padboxv = Gtk.VBox()
+        padboxv.pack_start(combo, True, True, 6)
+        padboxh = Gtk.HBox()
+        padboxh.pack_start(padboxv, True, True, 6)
+        frame.add(padboxh)
+
+        main_middle_hbox.pack_start(frame, True, True, 0)
+
+        reset = Button(_("_Reset EQ"), Icons.EDIT_UNDO)
+        reset.connect('clicked', clicked_rb)
+        main_middle_hbox.pack_start(reset, False, False, 0)
+
+        main_vbox.pack_start(main_middle_hbox, False, False, 0)
+
+        frame = Gtk.Frame(label="Custom presets", label_xalign=0.5)
+        main_bottom_vbox = Gtk.VBox()
+
+        # Custom presets
+        combo = Gtk.ComboBoxText()
+        self._combo_custom = combo
+        combo.append_text(_("Select..."))
+        combo.set_active(0)
+
+        custom_presets = self._config.keys() - {"Current"}
+        for key in custom_presets:
+            combo.append_text(key)
+        combo.connect("changed", custom_combo_changed)
+        hb = Gtk.HBox(spacing=6)
+        hb.pack_start(combo, True, True, 0)
+
+        delete = Button(_("_Delete selected"), Icons.EDIT_DELETE)
+        delete.connect('clicked', clicked_db)
+        hb.pack_start(delete, False, False, 0)
+
+        main_bottom_vbox.pack_start(hb, True, True, 6)
+        hs = Gtk.HSeparator()
+        main_bottom_vbox.pack_start(hs, True, True, 6)
+
+        hb = Gtk.HBox()
+        l = Gtk.Label(label="Preset name for saving:")
+        hb.pack_start(l, False, False, 0)
+        main_bottom_vbox.pack_start(hb, False, False, 0)
+
+        e = Gtk.Entry()
+        self._preset_name_entry = e
+        hb = Gtk.HBox(spacing=6)
+        hb.pack_start(e, True, True, 0)
+
+        save = Button(_("_Save"), Icons.DOCUMENT_SAVE)
+        save.connect('clicked', clicked_sb)
+        hb.pack_start(save, False, False, 0)
+
+        main_bottom_vbox.pack_start(hb, True, True, 6)
+
+        # This block is just for padding.
+        padboxh = Gtk.HBox()
+        padboxh.pack_start(main_bottom_vbox, True, True, 6)
+        frame.add(padboxh)
+
+        main_vbox.pack_start(frame, True, True, 0)
+        return main_vbox
 
     def __rightclick(self, hs, event):
         if event.button == Gdk.BUTTON_SECONDARY:


### PR DESCRIPTION
Implements #2389 (saving and loading of custom EQ presets) and makes the UI a bit more user friendly. Should be backwards compatible with old config files (converts them when loading).