### PR TITLE
Fix filesel relative paths

### DIFF
--- a/quodlibet/quodlibet/qltk/filesel.py
+++ b/quodlibet/quodlibet/qltk/filesel.py
@@ -287,9 +287,9 @@ class DirectoryTree(RCMHintedTreeView, MultiDragTreeView):
     def go_to(self, path_to_go):
         assert isinstance(path_to_go, fsnative)
 
-        # The path should not be relative in normal situations.
+        # The path should be normalized in normal situations.
         # On some systems and special environments (pipenv) there might be
-        # a relative path at least during tests, though.
+        # a non-normalized path at least during tests, though.
         path_to_go = os.path.normpath(path_to_go)
 
         model = self.get_model()

--- a/quodlibet/quodlibet/qltk/filesel.py
+++ b/quodlibet/quodlibet/qltk/filesel.py
@@ -287,7 +287,11 @@ class DirectoryTree(RCMHintedTreeView, MultiDragTreeView):
     def go_to(self, path_to_go):
         assert isinstance(path_to_go, fsnative)
 
-        # FIXME: what about non-normalized paths?
+        # The path should not be relative in normal situations.
+        # On some systems and special environments (pipenv) there might be
+        # a relative path at least during tests, though.
+        path_to_go = os.path.normpath(path_to_go)
+
         model = self.get_model()
 
         # Find the top level row which has the largest common

--- a/quodlibet/tests/test_qltk_filesel.py
+++ b/quodlibet/tests/test_qltk_filesel.py
@@ -60,7 +60,7 @@ class TDirectoryTree(TestCase):
             model, rows = dirlist.get_selection().get_selected_rows()
             selected = [model[row][0] for row in rows]
             dirlist.destroy()
-            self.failUnlessEqual([path], selected)
+            self.failUnlessEqual([os.path.normpath(path)], selected)
 
     def test_bad_initial(self):
         invalid = os.path.join("bin", "file", "does", "not", "exist")


### PR DESCRIPTION
From the Python docs for os.path.normpath:
> Normalize a pathname by collapsing redundant separators and up-level references so that A//B, A/B/, A/./B and A/foo/../B all become A/B. This string manipulation may change the meaning of a path that contains symbolic links. On Windows, it converts forward slashes to backward slashes.

I couldn't figure out a case where there would be a . or .. in the path in normal use, as all the paths Quod Libet or Ex Falso receives are either from the file browser or drag'n'dropping or enqueueing if I am correct. The former two never result in . or .. in the path, and the latter actually does not support relative paths at the moment - I think this might be worth another issue maybe?

Therefore I think it's a problem occurring only with that specific test case, but it shouldn't break anything either to do the path normalization in DirectoryTree's go_to and not just fix the test.