### PR TITLE
docs: Generate list of plugins from source

### DIFF
--- a/quodlibet/docs/conf.py
+++ b/quodlibet/docs/conf.py
@@ -26,7 +26,8 @@ needs_sphinx = "1.3"
 
 sys.path.append(os.path.join(dir_, "ext"))
 
-extensions = ['sphinx.ext.autodoc', 'sphinx.ext.extlinks', 'contributors']
+extensions = ['sphinx.ext.autodoc', 'sphinx.ext.extlinks',
+              'contributors', 'plugins']
 
 source_suffix = '.rst'
 master_doc = 'index'

--- a/quodlibet/docs/ext/plugins.py
+++ b/quodlibet/docs/ext/plugins.py
@@ -1,0 +1,56 @@
+from docutils.parsers.rst import Directive
+from docutils import nodes
+from quodlibet.util import get_module_dir
+from quodlibet.util.modulescanner import ModuleScanner
+from quodlibet.plugins import list_plugins, Plugin
+import quodlibet
+import os
+
+
+class PluginsDirective(Directive):
+
+    has_content = True
+
+    def get_plugins(self):
+        # Most of this code is copied directly from tests/plugin/__init__.py
+        # Consider moving this to a function that both can call instead
+        PLUGIN_DIRS = []
+
+        root = os.path.join(get_module_dir(quodlibet), "ext")
+        for entry in os.listdir(root):
+            if entry.startswith("_"):
+                continue
+            path = os.path.join(root, entry)
+            if not os.path.isdir(path):
+                continue
+            PLUGIN_DIRS.append(path)
+
+        ms = ModuleScanner(PLUGIN_DIRS)
+        ms.rescan()
+
+        plugins = []
+        for name, module in ms.modules.items():
+            for plugin in list_plugins(module.module):
+                plugins.append(Plugin(plugin))
+
+        return plugins
+
+    def run(self):
+        plugins = self.get_plugins()
+        output = []
+
+        for plugin in sorted(plugins, key=lambda p: p.name):
+            title = nodes.title(text=plugin.name)
+            par = nodes.paragraph(text=plugin.description)
+
+            section = nodes.section()
+            section['ids'].append(plugin.id)
+            section += title
+            section += par
+            output.append(section)
+
+        return output
+
+
+def setup(app):
+    app.add_directive('plugins', PluginsDirective)

--- a/quodlibet/docs/guide/index.rst
+++ b/quodlibet/docs/guide/index.rst
@@ -9,6 +9,7 @@ User Guide
     searching
     stats_rating.rst
     browse/index
+    plugins
     editing_tags
     renaming_files
     playback/index

--- a/quodlibet/docs/guide/plugins.rst
+++ b/quodlibet/docs/guide/plugins.rst
@@ -1,0 +1,11 @@
+.. _Plugins:
+
+Plugins
+=======
+
+Quod Libet ships with a number of different plugins that can be enabled in the plugin manager. Here you can see a list of all available plugins and their corresponding descriptions.
+
+Available Plugins
+-----------------
+
+.. plugins::


### PR DESCRIPTION
Initial attempt at implementing #1994.

Works pretty well I would say, but doesn't include plugins with optional dependencies, as exceptions are thrown when importing the modules. Need to find some workaround for this.

The generated page looks like this:

![plugin_list_docs](https://user-images.githubusercontent.com/7038699/47228867-d58b0800-d3b5-11e8-8bda-2ae9288c4e73.png)
