### PR TITLE
feat: #2380: remember filelist scroll position on tag save

### DIFF
--- a/quodlibet/quodlibet/qltk/filesel.py
+++ b/quodlibet/quodlibet/qltk/filesel.py
@@ -525,6 +525,7 @@ class FileSelector(Paned):
 
         model = ObjectStore()
         filelist = AllTreeView(model=model)
+        filelist.connect("draw", self.__restore_scroll_pos_on_draw)
 
         column = TreeViewColumn(title=_("Songs"))
         column.set_sizing(Gtk.TreeViewColumnSizing.AUTOSIZE)
@@ -637,6 +638,13 @@ class FileSelector(Paned):
 
         fselect.handler_unblock(self.__sig)
         fselect.emit('changed')
+        self._saved_scroll_pos = filelist.get_vadjustment().get_value()
+
+    def __restore_scroll_pos_on_draw(self, treeview, context):
+        if self._saved_scroll_pos:
+            vadj = treeview.get_vadjustment()
+            vadj.set_value(self._saved_scroll_pos)
+            self._saved_scroll_pos = None
 
 
 def _get_main_folders():


### PR DESCRIPTION
Fixes usability issue #2380: the file list was always scrolled to top when saving tags in Ex Falso. Now it remembers the position.

I had to handle this with the draw signal, as any attempts to change the vadjustment during other signals were in vain - the scroll position was always reset.