### PR TITLE
Fix Set Exact Rating plugin for use on multiple selected songs

### DIFF
--- a/quodlibet/quodlibet/ext/songsmenu/exact_rating.py
+++ b/quodlibet/quodlibet/ext/songsmenu/exact_rating.py
@@ -52,7 +52,7 @@ class ExactRating(SongsMenuPlugin):
         if (count > 1 and config.getboolean("browsers",
                 "rating_confirm_multiple")):
             confirm_dialog = ConfirmRateMultipleDialog(
-                self.plugin_window, count, value)
+                self.plugin_window, _("Change _Rating"), count, value)
             if confirm_dialog.run() != Gtk.ResponseType.YES:
                 return
 


### PR DESCRIPTION
The call to `ConfirmMultipleRateDialog()` was malformed and missed a necessary argument. This would close #3022