### PR TITLE
mediaserver: Make label about conig file wrap and text selectable

### DIFF
--- a/quodlibet/quodlibet/ext/events/mediaserver.py
+++ b/quodlibet/quodlibet/ext/events/mediaserver.py
@@ -50,6 +50,8 @@ class MediaServer(EventPlugin):
                      "enabled=true")
 
         exp_lbl = Gtk.Label(label=conf_exp)
+        exp_lbl.set_selectable(True)
+        exp_lbl.set_line_wrap(True)
         exp_lbl.set_alignment(0, 0)
 
         conf_lbl = Gtk.Label()


### PR DESCRIPTION
If the translation for the label is very long, the plugin window can become very large without the label being wrapped.

All other plugin text is selectable, so make this label selectable, too.