### PR TITLE
Refresh song list on browser changes

### DIFF
--- a/quodlibet/quodlibet/browsers/albums/main.py
+++ b/quodlibet/quodlibet/browsers/albums/main.py
@@ -401,8 +401,7 @@ class AlbumList(Browser, util.InstanceTracker, VisibleUpdate,
 
     def finalize(self, restored):
         if not restored:
-            # Select the "All Albums" album, which is None
-            self.view.select_by_func(lambda r: r[0].album is None, one=True)
+            self.view.set_cursor((0,))
 
     @classmethod
     def _destroy_model(klass):

--- a/quodlibet/quodlibet/browsers/albums/main.py
+++ b/quodlibet/quodlibet/browsers/albums/main.py
@@ -399,6 +399,11 @@ class AlbumList(Browser, util.InstanceTracker, VisibleUpdate,
     def init(klass, library):
         super(AlbumList, klass).load_pattern()
 
+    def finalize(self, restored):
+        if not restored:
+            # Select the "All Albums" album, which is None
+            self.view.select_by_func(lambda r: r[0].album is None, one=True)
+
     @classmethod
     def _destroy_model(klass):
         klass.__model.destroy()

--- a/quodlibet/quodlibet/browsers/collection/main.py
+++ b/quodlibet/quodlibet/browsers/collection/main.py
@@ -387,7 +387,7 @@ class CollectionBrowser(Browser, util.InstanceTracker):
         return self.__search.get_text()
 
     def unfilter(self):
-        pass
+        self.filter_text("")
 
     def activate(self):
         self.view.get_selection().emit('changed')

--- a/quodlibet/quodlibet/browsers/covergrid/main.py
+++ b/quodlibet/quodlibet/browsers/covergrid/main.py
@@ -143,6 +143,11 @@ class CoverGrid(Browser, util.InstanceTracker, VisibleUpdate,
     def init(klass, library):
         super(CoverGrid, klass).load_pattern()
 
+    def finalize(self, restored):
+        if not restored:
+            # Select the "All Albums" album, which is None
+            self.select_by_func(lambda r: r[0].album is None, one=True)
+
     @classmethod
     def _destroy_model(klass):
         klass.__model.destroy()

--- a/quodlibet/quodlibet/browsers/covergrid/main.py
+++ b/quodlibet/quodlibet/browsers/covergrid/main.py
@@ -641,18 +641,16 @@ class CoverGrid(Browser, util.InstanceTracker, VisibleUpdate,
 
         keys = config.gettext("browsers", "covergrid", "").split("\n")
 
-        # FIXME: If albums is "" then it could be either all albums or
-        # no albums. If it's "" and some other stuff, assume no albums,
-        # otherwise all albums.
         self.__inhibit()
         if keys != [""]:
-
             def select_fun(row):
                 album = row[0].album
                 if not album:  # all
                     return False
                 return album.str_key in keys
             self.select_by_func(select_fun)
+        else:
+            self.select_by_func(lambda r: r[0].album is None)
         self.__uninhibit()
 
     def scroll(self, song):

--- a/quodlibet/quodlibet/browsers/covergrid/main.py
+++ b/quodlibet/quodlibet/browsers/covergrid/main.py
@@ -620,7 +620,6 @@ class CoverGrid(Browser, util.InstanceTracker, VisibleUpdate,
 
     def unfilter(self):
         self.filter_text("")
-        #self.view.set_cursor((0,), None, False)
 
     def activate(self):
         self.view.emit('selection-changed')

--- a/quodlibet/quodlibet/browsers/covergrid/prefs.py
+++ b/quodlibet/quodlibet/browsers/covergrid/prefs.py
@@ -70,9 +70,13 @@ class Preferences(qltk.UniqueWindow, EditDisplayPatternMixin):
 
         cb2 = ConfigCheckButton(
             _("Show \"All Albums\" Item"), "browsers", "covergrid_all")
-        cb2.set_active(config.getboolean("browsers", "covergrid_all", False))
-        cb2.connect('toggled',
-                   lambda s: browser.view.get_model().refilter())
+        cb2.set_active(config.getboolean("browsers", "covergrid_all", True))
+
+        def refilter(s):
+            mod = browser.view.get_model()
+            if mod:
+                mod.refilter()
+        cb2.connect('toggled', refilter)
         vbox.pack_start(cb2, False, True, 0)
 
         cb3 = ConfigCheckButton(

--- a/quodlibet/quodlibet/browsers/iradio.py
+++ b/quodlibet/quodlibet/browsers/iradio.py
@@ -524,6 +524,13 @@ class InternetRadio(Browser, util.InstanceTracker):
 
         klass.filters = None
 
+    def finalize(self, restored):
+        if not restored:
+            # Select "All Stations" by default
+            def sel_all(row):
+                return row[self.TYPE] == self.TYPE_ALL
+            self.view.select_by_func(sel_all, one=True)
+
     def __inhibit(self):
         self.view.get_selection().handler_block(self.__changed_sig)
 

--- a/quodlibet/quodlibet/browsers/iradio.py
+++ b/quodlibet/quodlibet/browsers/iradio.py
@@ -799,6 +799,9 @@ class InternetRadio(Browser, util.InstanceTracker):
 
         return filter_
 
+    def unfilter(self):
+        self.filter_text("")
+
     def __add_fav(self, songs):
         songs = [s for s in songs if s in self.__stations]
         type(self).__librarian.move(

--- a/quodlibet/quodlibet/browsers/paned/main.py
+++ b/quodlibet/quodlibet/browsers/paned/main.py
@@ -323,8 +323,6 @@ class PanedBrowser(Browser, util.InstanceTracker):
 
     def finalize(self, restored):
         config.settext("browsers", "query_text", u"")
-        if not restored:
-            self.fill_panes()
 
     def fill(self, songs):
         GLib.idle_add(self.songs_selected, list(songs))

--- a/quodlibet/quodlibet/qltk/quodlibetwindow.py
+++ b/quodlibet/quodlibet/qltk/quodlibetwindow.py
@@ -1110,9 +1110,9 @@ class QuodLibetWindow(Window, PersistentWindowMixin, AppWindow):
         if restore:
             self.browser.restore()
             self.browser.activate()
-        else:
-            self.browser.unfilter()
         self.browser.finalize(restore)
+        if not restore:
+            self.browser.unfilter()
         if self.browser.can_reorder:
             self.songlist.enable_drop()
         elif self.browser.dropped:

--- a/quodlibet/quodlibet/qltk/quodlibetwindow.py
+++ b/quodlibet/quodlibet/qltk/quodlibetwindow.py
@@ -1126,6 +1126,8 @@ class QuodLibetWindow(Window, PersistentWindowMixin, AppWindow):
         if window:
             GLib.idle_add(window.set_cursor, None)
 
+        self.browser.activate()
+
         player.replaygain_profiles[1] = self.browser.replaygain_profiles
         player.reset_replaygain()
         self.__browserbox.add(container)

--- a/quodlibet/quodlibet/qltk/quodlibetwindow.py
+++ b/quodlibet/quodlibet/qltk/quodlibetwindow.py
@@ -1110,6 +1110,8 @@ class QuodLibetWindow(Window, PersistentWindowMixin, AppWindow):
         if restore:
             self.browser.restore()
             self.browser.activate()
+        else:
+            self.browser.unfilter()
         self.browser.finalize(restore)
         if self.browser.can_reorder:
             self.songlist.enable_drop()
@@ -1125,8 +1127,6 @@ class QuodLibetWindow(Window, PersistentWindowMixin, AppWindow):
         # Reset the cursor when done loading the browser
         if window:
             GLib.idle_add(window.set_cursor, None)
-
-        self.browser.activate()
 
         player.replaygain_profiles[1] = self.browser.replaygain_profiles
         player.reset_replaygain()

--- a/quodlibet/tests/plugin/test_mpris.py
+++ b/quodlibet/tests/plugin/test_mpris.py
@@ -50,6 +50,9 @@ class TMPRIS(PluginTestCase):
         config.init()
         init_fake_app()
 
+        while Gtk.events_pending():
+            Gtk.main_iteration()
+
         app.window.songlist.set_songs([A1, A2])
         app.player.go_to(None)
         self.m = self.plugin()

--- a/quodlibet/tests/test_browsers_paned.py
+++ b/quodlibet/tests/test_browsers_paned.py
@@ -92,7 +92,7 @@ class TPanedBrowser(TestCase):
         self.failUnless(self.bar.can_filter_text())
 
     def test_filter_text(self):
-        self.bar.finalize(False)
+        self.bar.activate()
 
         self.bar.filter_text("artist=nope")
         self._wait()
@@ -103,14 +103,14 @@ class TPanedBrowser(TestCase):
         self.failUnlessEqual(set(self.last), set(SONGS[1:]))
 
     def test_filter_value(self):
-        self.bar.finalize(False)
+        self.bar.activate()
         expected = [SONGS[0]]
         self.bar.filter("artist", ["boris"])
         self._wait()
         self.failUnlessEqual(self.last, expected)
 
     def test_filter_notvalue(self):
-        self.bar.finalize(False)
+        self.bar.activate()
         expected = SONGS[1:4]
         self.bar.filter("artist", ["notvalue", "mu", "piman"])
         self._wait()
@@ -139,7 +139,7 @@ class TPanedBrowser(TestCase):
         self.failUnlessEqual(self.emit_count, 1)
 
     def test_restore_selection(self):
-        self.bar.finalize(False)
+        self.bar.activate()
         self.bar.filter("artist", [u"piman"])
         self.bar.save()
         self.bar.unfilter()
@@ -150,7 +150,7 @@ class TPanedBrowser(TestCase):
             self.assertTrue(u"piman" in song.list("artist"))
 
     def test_set_all_panes(self):
-        self.bar.finalize(False)
+        self.bar.activate()
         self.bar.set_all_panes()
 
     def test_restore_pane_width(self):


### PR DESCRIPTION
The issue about song selections persisting across browser switches has been described in #2948 and #2374. I think this refresh behavior is more intuitive.

Since the song list will now be empty after switches if no album is selected, the cover grid and album list browser will automatically select the "All Albums" album. This is the same behavior as for the paned browser (and practically the same as the search and iradio browser).