### PR TITLE
themeswitcher: also list themes which target specific gtk versions

### DIFF
--- a/quodlibet/quodlibet/ext/events/themeswitcher.py
+++ b/quodlibet/quodlibet/ext/events/themeswitcher.py
@@ -100,6 +100,17 @@ class ThemeSwitcher(EventPlugin):
         theme_dirs += [
             os.path.join(d, "themes") for d in xdg_get_system_data_dirs()]
 
+        def is_valid_teme_dir(path):
+            """If the path contains a theme for the running gtk version"""
+
+            major = qltk.gtk_version[0]
+            minor = qltk.gtk_version[1]
+            names = ["gtk-%d.%d" % (major, m) for m in range(minor, -1, -1)]
+            for name in names:
+                if os.path.isdir(os.path.join(path, name)):
+                    return True
+            return False
+
         themes = set()
         for theme_dir in set(theme_dirs):
             try:
@@ -107,8 +118,7 @@ class ThemeSwitcher(EventPlugin):
             except OSError:
                 continue
             for dir_ in subdirs:
-                gtk_dir = os.path.join(theme_dir, dir_, "gtk-3.0")
-                if os.path.isdir(gtk_dir):
+                if is_valid_teme_dir(os.path.join(theme_dir, dir_)):
                     themes.add(dir_)
 
         try:


### PR DESCRIPTION
It was only looking for gtk-3.0 directories but with gtk 3.18 or so
a features was added that a theme could be named "gtk-3.20" and any gtk
version equal or newer than that would use it.

Copy this logic in the theme switcher plugin. This for examples makes
the Breeze theme show up.