### PR TITLE
windows: use GetLogicalDriveStringsW instead of accessing all possible drives. Fixes #3049

### DIFF
--- a/quodlibet/quodlibet/qltk/filesel.py
+++ b/quodlibet/quodlibet/qltk/filesel.py
@@ -124,19 +124,11 @@ def get_favorites():
         return paths
 
 
-def _get_win_drives():
-    """Returns a list of paths for all available drives e.g. ['C:\\']"""
-
-    assert os.name == "nt"
-    drives = [letter + u":\\" for letter in u"CDEFGHIJKLMNOPQRSTUVWXYZ"]
-    return [d for d in drives if os.path.isdir(d)]
-
-
 def get_drives():
     """A list of accessible drives"""
 
     if os.name == "nt":
-        return _get_win_drives()
+        return windows.get_logical_drive_strings()
     else:
         paths = []
         for mount in Gio.VolumeMonitor.get().get_mounts():

--- a/quodlibet/quodlibet/util/winapi.py
+++ b/quodlibet/quodlibet/util/winapi.py
@@ -519,3 +519,8 @@ class KnownFolderFlag(int):
     CREATE = 0x00008000
     NO_APPCONTAINER_REDIRECTION = 0x00010000
     ALIAS_ONLY = 0x80000000
+
+
+GetLogicalDriveStringsW = windll.kernel32.GetLogicalDriveStringsW
+GetLogicalDriveStringsW.restype = wintypes.DWORD
+GetLogicalDriveStringsW.argtypes = [wintypes.DWORD, wintypes.LPWSTR]

--- a/quodlibet/tests/test_windows.py
+++ b/quodlibet/tests/test_windows.py
@@ -57,3 +57,9 @@ class TWindows(TestCase):
     def test_get_link_target_non_exist(self):
         with self.assertRaises(WindowsError):
             windows.get_link_target(u"nopenope.lnk")
+
+    def test_get_logical_drive_strings(self):
+        res = windows.get_logical_drive_strings()
+        assert isinstance(res, list)
+        if res:
+            assert isinstance(res[0], str)


### PR DESCRIPTION
We currently stat all possible drive letters which may be the cause of access error
messages described in #3049.

Use a proper Windows API to get the drive list instead.