### PR TITLE
windows: use Gio.VolumeMonitor also on windows for drive discovery. Fixes #3049

### DIFF
--- a/quodlibet/quodlibet/qltk/filesel.py
+++ b/quodlibet/quodlibet/qltk/filesel.py
@@ -124,27 +124,17 @@ def get_favorites():
         return paths
 
 
-def _get_win_drives():
-    """Returns a list of paths for all available drives e.g. ['C:\\']"""
-
-    assert os.name == "nt"
-    drives = [letter + u":\\" for letter in u"CDEFGHIJKLMNOPQRSTUVWXYZ"]
-    return [d for d in drives if os.path.isdir(d)]
-
-
 def get_drives():
     """A list of accessible drives"""
 
-    if os.name == "nt":
-        return _get_win_drives()
-    else:
-        paths = []
-        for mount in Gio.VolumeMonitor.get().get_mounts():
-            path = mount.get_root().get_path()
-            if path is not None:
-                paths.append(glib2fsn(path))
+    paths = []
+    for mount in Gio.VolumeMonitor.get().get_mounts():
+        path = mount.get_root().get_path()
+        if path is not None:
+            paths.append(glib2fsn(path))
+    if os.name != "nt":
         paths.append("/")
-        return paths
+    return sorted(paths)
 
 
 def parse_gtk_bookmarks(data):


### PR DESCRIPTION
We currently stat all possible drive letters which may be the cause of access error
messages described in #3049.

Maybe Gio.VolumeMonitor does something smarter here.