### PR TITLE
Improve tag splitting

### DIFF
--- a/quodlibet/docs/guide/editing_tags.rst
+++ b/quodlibet/docs/guide/editing_tags.rst
@@ -97,3 +97,29 @@ song or for several songs. Edit patterns the same way you would for *Edit
 tags from path* (see above). This feature even lets you move them to a
 different directory; for more info see the :ref:`renaming files
 guide <RenamingFiles>`.
+
+Splitting Tags
+--------------
+
+If a tag contains a value that can be regarded as multiple tag values, it is
+often possible to split the tag. This can be done by right-clicking on the tag
+and then selecting the appropriate split in the ``Split Tag`` menu. 
+
+There are in general two types of tag splitting possible: splitting on a single
+character and *subtag* splitting (extracting values in enclosures). The
+separating characters for both can be configured in the *Tags* tab in the
+preferences.
+
+Splitting on a single character - like ``,`` or ``&`` - will split a tag into
+multiple tags of the same type, but with different values. An example of this
+can be an artist tag with the value ``Foo, Bar``, that can be split into two
+separate tags *artist* = ``Foo`` and *artist* = ``Bar``.
+
+With *subtag* splitting, the end of the tag value must contain a value enclosed
+in some pair of characters - like ``()`` or ``[]``. Depending on the type of
+tag, the enclosed value can then be extracted and put in a new tag. An example
+of this can be an album tag with the value ``Album (CD 1)``, which can be split
+into *album* = ``Album`` and *discnumber* = ``1``. The enclosure can also
+contain multiple values separated by a single-character separator as explained
+above, like *artist* = ``Foo (Bar, Baz)``, which can be split into *artist* =
+``Foo``, *performer* = ``Bar`` and *performer* = ``Baz``.

--- a/quodlibet/quodlibet/config.py
+++ b/quodlibet/quodlibet/config.py
@@ -242,6 +242,9 @@ INITIAL = {
         # characters to split tags on
         "split_on": "/ & ,",
 
+        # characters used when extracting subtitles/subtags
+        "sub_split_on": "\u301c\u301c \uff08\uff09 [] () ~~ --",
+
         # ID3 encodings to try
         "id3encoding": "",
 

--- a/quodlibet/quodlibet/qltk/edittags.py
+++ b/quodlibet/quodlibet/qltk/edittags.py
@@ -198,10 +198,11 @@ class SplitValues(Gtk.ImageMenuItem):
         self.set_image(Gtk.Image.new_from_icon_name(
             Icons.EDIT_FIND_REPLACE, Gtk.IconSize.MENU))
         spls = config.gettext("editing", "split_on").split()
-        vals = split_value(value, spls)
+        vals = [val if len(val) <= 64 else val[:64] + "…"
+                for val in split_value(value, spls)]
         string = ", ".join(["{}={}".format(tag, val) for val in vals])
         self.set_label(string)
-        self.set_sensitive(len(split_value(value, spls)) > 1)
+        self.set_sensitive(len(vals) > 1)
 
     def activated(self, tag, value):
         spls = config.gettext("editing", "split_on").split()
@@ -221,6 +222,7 @@ class SplitDisc(Gtk.ImageMenuItem):
 
         album, disc = split_album(value)
         if disc is not None:
+            album = album if len(album) <= 64 else album[:64] + "…"
             self.set_label("{}={}, {}={}".format(tag, album,
                            self.needs[0], disc))
 
@@ -246,6 +248,9 @@ class SplitTitle(Gtk.ImageMenuItem):
 
         title, versions = split_title(value, tag_spls, sub_spls)
         if versions:
+            title = title if len(title) <= 64 else title[:64] + "…"
+            versions = [ver if len(ver) <= 64 else ver[:64] + "…"
+                        for ver in versions]
             string = (", ".join(["{}={}".format(tag, title)] +
                ["{}={}".format(self.needs[0], ver) for ver in versions]))
             self.set_label(string)
@@ -272,6 +277,9 @@ class SplitPerson(Gtk.ImageMenuItem):
 
         artist, others = split_people(value, tag_spls, sub_spls)
         if others:
+            artist = artist if len(artist) <= 64 else artist[:64] + "…"
+            others = [other if len(other) <= 64 else other[:64] + "…"
+                        for other in others]
             string = (", ".join(["{}={}".format(tag, artist)] +
                 ["{}={}".format(self.needs[0], o) for o in others]))
             self.set_label(string)

--- a/quodlibet/quodlibet/qltk/edittags.py
+++ b/quodlibet/quodlibet/qltk/edittags.py
@@ -15,6 +15,7 @@ from quodlibet import C_, _
 from quodlibet import qltk
 from quodlibet import config
 from quodlibet import util
+from quodlibet import app
 
 from quodlibet.util import massagers
 
@@ -682,8 +683,13 @@ class EditTags(Gtk.VBox):
             split_menu.append(pref_item)
 
             def show_prefs(parent):
-                from quodlibet.qltk.prefs import PreferencesWindow
-                window = PreferencesWindow(parent, open_page="tagging")
+                from quodlibet.qltk.exfalsowindow import ExFalsoWindow
+                if isinstance(app.window, ExFalsoWindow):
+                    from quodlibet.qltk.exfalsowindow import PreferencesWindow
+                    window = PreferencesWindow(parent)
+                else:
+                    from quodlibet.qltk.prefs import PreferencesWindow
+                    window = PreferencesWindow(parent, open_page="tagging")
                 window.show()
 
             connect_obj(pref_item, "activate", show_prefs, self)

--- a/quodlibet/quodlibet/qltk/edittags.py
+++ b/quodlibet/quodlibet/qltk/edittags.py
@@ -224,7 +224,7 @@ class SplitDisc(Gtk.ImageMenuItem):
             self.set_label("{}={}, {}={}".format(tag, album,
                            self.needs[0], disc))
 
-        self.set_sensitive(split_album(value)[1] is not None)
+        self.set_sensitive(disc is not None)
 
     def activated(self, tag, value):
         album, disc = split_album(value)
@@ -241,19 +241,21 @@ class SplitTitle(Gtk.ImageMenuItem):
             label=_("Split _Version out of Title"), use_underline=True)
         self.set_image(Gtk.Image.new_from_icon_name(
             Icons.EDIT_FIND_REPLACE, Gtk.IconSize.MENU))
-        spls = config.gettext("editing", "split_on").split()
+        tag_spls = config.gettext("editing", "split_on").split()
+        sub_spls = config.gettext("editing", "sub_split_on").split()
 
-        title, versions = split_title(value)
+        title, versions = split_title(value, tag_spls, sub_spls)
         if versions:
             string = (", ".join(["{}={}".format(tag, title)] +
                ["{}={}".format(self.needs[0], ver) for ver in versions]))
             self.set_label(string)
 
-        self.set_sensitive(bool(split_title(value, spls)[1]))
+        self.set_sensitive(bool(versions))
 
     def activated(self, tag, value):
-        spls = config.gettext("editing", "split_on").split()
-        title, versions = split_title(value, spls)
+        tag_spls = config.gettext("editing", "split_on").split()
+        sub_spls = config.gettext("editing", "sub_split_on").split()
+        title, versions = split_title(value, tag_spls, sub_spls)
         return [(tag, title)] + [("version", v) for v in versions]
 
 
@@ -265,19 +267,21 @@ class SplitPerson(Gtk.ImageMenuItem):
         super(SplitPerson, self).__init__(label=self.title, use_underline=True)
         self.set_image(Gtk.Image.new_from_icon_name(
             Icons.EDIT_FIND_REPLACE, Gtk.IconSize.MENU))
-        spls = config.gettext("editing", "split_on").split()
+        tag_spls = config.gettext("editing", "split_on").split()
+        sub_spls = config.gettext("editing", "sub_split_on").split()
 
-        artist, others = split_people(value, spls)
+        artist, others = split_people(value, tag_spls, sub_spls)
         if others:
             string = (", ".join(["{}={}".format(tag, artist)] +
                 ["{}={}".format(self.needs[0], o) for o in others]))
             self.set_label(string)
 
-        self.set_sensitive(bool(split_people(value, spls)[1]))
+        self.set_sensitive(bool(others))
 
     def activated(self, tag, value):
-        spls = config.gettext("editing", "split_on").split()
-        artist, others = split_people(value, spls)
+        tag_spls = config.gettext("editing", "split_on").split()
+        sub_spls = config.gettext("editing", "sub_split_on").split()
+        artist, others = split_people(value, tag_spls, sub_spls)
         return [(tag, artist)] + [(self.needs[0], o) for o in others]
 
 

--- a/quodlibet/quodlibet/qltk/edittags.py
+++ b/quodlibet/quodlibet/qltk/edittags.py
@@ -26,7 +26,7 @@ from quodlibet.qltk.wlw import WritingWindow
 from quodlibet.qltk.window import Dialog
 from quodlibet.qltk.models import ObjectStore
 from quodlibet.qltk.ccb import ConfigCheckButton
-from quodlibet.qltk.x import Button, MenuItem
+from quodlibet.qltk.x import SeparatorMenuItem, Button, MenuItem
 from quodlibet.qltk._editutils import EditingPluginHandler, OverwriteWarning
 from quodlibet.qltk._editutils import WriteFailedError
 from quodlibet.qltk import Icons
@@ -663,7 +663,10 @@ class EditTags(Gtk.VBox):
                     if len(vals) > 1 and vals[1][1]:
                         split_menu.append(b)
 
-            pref_item = MenuItem(_("_Preferences"), Icons.PREFERENCES_SYSTEM)
+            if split_menu.get_children():
+                split_menu.append(SeparatorMenuItem())
+
+            pref_item = MenuItem(_("_Configure"), Icons.PREFERENCES_SYSTEM)
             split_menu.append(pref_item)
 
             def show_prefs(parent):

--- a/quodlibet/quodlibet/qltk/edittags.py
+++ b/quodlibet/quodlibet/qltk/edittags.py
@@ -663,6 +663,16 @@ class EditTags(Gtk.VBox):
                     if len(vals) > 1 and vals[1][1]:
                         split_menu.append(b)
 
+            pref_item = MenuItem(_("_Preferences"), Icons.PREFERENCES_SYSTEM)
+            split_menu.append(pref_item)
+
+            def show_prefs(parent):
+                from quodlibet.qltk.prefs import PreferencesWindow
+                window = PreferencesWindow(parent, open_page="tagging")
+                window.show()
+
+            connect_obj(pref_item, "activate", show_prefs, self)
+
             split_item = MenuItem(_("_Split Tag"), Icons.EDIT_FIND_REPLACE)
 
             if split_menu.get_children():

--- a/quodlibet/quodlibet/qltk/exfalsowindow.py
+++ b/quodlibet/quodlibet/qltk/exfalsowindow.py
@@ -28,13 +28,13 @@ from quodlibet.qltk.renamefiles import RenameFiles
 from quodlibet.qltk.tagsfrompath import TagsFromPath
 from quodlibet.qltk.tracknumbers import TrackNumbers
 from quodlibet.qltk.menubutton import MenuButton
-from quodlibet.qltk.entry import UndoEntry
 from quodlibet.qltk.about import AboutDialog
 from quodlibet.qltk.songsmenu import SongsMenuPluginHandler
 from quodlibet.qltk.x import Align, SeparatorMenuItem, ConfigRHPaned, \
     Button, SymbolicIconImage, MenuItem
-from quodlibet.qltk.window import PersistentWindowMixin, Window, UniqueWindow
+from quodlibet.qltk.window import PersistentWindowMixin, Window
 from quodlibet.qltk.msg import CancelRevertSave
+from quodlibet.qltk.prefs import PreferencesWindow as QLPreferencesWindow
 from quodlibet.qltk import Icons
 from quodlibet.util.i18n import numeric_phrase
 from quodlibet.util.path import mtime, normalize_path
@@ -271,28 +271,18 @@ class ExFalsoWindow(Window, PersistentWindowMixin, AppWindow):
         self.emit('changed', files)
 
 
-class PreferencesWindow(UniqueWindow):
+class PreferencesWindow(QLPreferencesWindow):
     def __init__(self, parent):
         if self.is_not_unique():
             return
-        super(PreferencesWindow, self).__init__()
+        super(QLPreferencesWindow, self).__init__()
         self.set_title(_("Ex Falso Preferences"))
         self.set_border_width(12)
         self.set_resizable(False)
         self.set_transient_for(parent)
 
-        vbox = Gtk.VBox(spacing=6)
-        hb = Gtk.HBox(spacing=6)
-        e = UndoEntry()
-        e.set_text(config.get("editing", "split_on"))
-        e.connect('changed', self.__changed, 'editing', 'split_on')
-        l = Gtk.Label(label=_("Split _on:"))
-        l.set_use_underline(True)
-        l.set_mnemonic_widget(e)
-        hb.pack_start(l, False, True, 0)
-        hb.pack_start(e, True, True, 0)
-        vbox.pack_start(hb, False, True, 0)
-        f = qltk.Frame(_("Tag Editing"), child=vbox)
+        tagging = self.Tagging()
+        f = qltk.Frame(_("Tag Editing"), child=(tagging.tag_editing_vbox()))
 
         close = Button(_("_Close"), Icons.WINDOW_CLOSE)
         connect_obj(close, 'clicked', lambda x: x.destroy(), self)
@@ -309,9 +299,6 @@ class PreferencesWindow(UniqueWindow):
 
         connect_obj(self, 'destroy', PreferencesWindow.__destroy, self)
         self.get_child().show_all()
-
-    def __changed(self, entry, section, name):
-        config.set(section, name, entry.get_text())
 
     def __destroy(self):
         config.save()

--- a/quodlibet/quodlibet/qltk/exfalsowindow.py
+++ b/quodlibet/quodlibet/qltk/exfalsowindow.py
@@ -279,7 +279,7 @@ class PreferencesWindow(QLPreferencesWindow):
         self.set_title(_("Ex Falso Preferences"))
         self.set_border_width(12)
         self.set_resizable(False)
-        self.set_transient_for(parent)
+        self.set_transient_for(qltk.get_top_parent(parent))
 
         tagging = self.Tagging()
         f = qltk.Frame(_("Tag Editing"), child=(tagging.tag_editing_vbox()))

--- a/quodlibet/quodlibet/qltk/prefs.py
+++ b/quodlibet/quodlibet/qltk/prefs.py
@@ -600,29 +600,62 @@ class PreferencesWindow(UniqueWindow):
                      tooltip=_("Save changes to tags without confirmation "
                                "when editing multiple files"))
             vbox.pack_start(cb, False, True, 0)
-            hb = Gtk.HBox(spacing=6)
-            e = UndoEntry()
-            e.set_text(config.get("editing", "split_on"))
-            e.connect('changed', self.__changed, 'editing', 'split_on')
-            e.set_tooltip_text(
+
+            split_entry = UndoEntry()
+            split_entry.set_text(config.get("editing", "split_on"))
+            split_entry.connect('changed', self.__changed, 'editing',
+                                'split_on')
+            split_entry.set_tooltip_text(
                 _("A set of separators to use when splitting tag values "
                   "in the tag editor. "
                   "The list is space-separated"))
+            split_entry.props.expand = True
 
-            def do_revert_split(button, section, option):
+            sub_entry = UndoEntry()
+            sub_entry.set_text(config.get("editing", "sub_split_on"))
+            sub_entry.connect('changed', self.__changed, 'editing',
+                              'sub_split_on')
+            sub_entry.set_tooltip_text(
+                _("A set of separators to use when extracting subtags from "
+                  "tags in the tag editor. "
+                  "The list is space-separated, and each entry must only "
+                  "contain two characters."))
+            sub_entry.props.expand = True
+
+            def do_revert_split(button, entry, section, option):
                 config.reset(section, option)
-                e.set_text(config.get(section, option))
+                entry.set_text(config.get(section, option))
 
             split_revert = Button(_("_Revert"), Icons.DOCUMENT_REVERT)
-            split_revert.connect("clicked", do_revert_split, "editing",
-                                 "split_on")
-            l = Gtk.Label(label=_("Split _on:"))
-            l.set_use_underline(True)
-            l.set_mnemonic_widget(e)
-            hb.pack_start(l, False, True, 0)
-            hb.pack_start(e, True, True, 0)
-            hb.pack_start(split_revert, False, True, 0)
-            vbox.pack_start(hb, False, True, 0)
+            split_revert.connect("clicked", do_revert_split, split_entry,
+                                 "editing", "split_on")
+            split_label = Gtk.Label(label=_("Split _tag on:"))
+            split_label.set_use_underline(True)
+            split_label.set_mnemonic_widget(split_entry)
+
+            sub_revert = Button(_("_Revert"), Icons.DOCUMENT_REVERT)
+            sub_revert.connect("clicked", do_revert_split, sub_entry,
+                               "editing", "sub_split_on")
+            sub_label = Gtk.Label(label=_("Split _subtag on:"))
+            sub_label.set_use_underline(True)
+            sub_label.set_mnemonic_widget(split_entry)
+
+            split_align = Align(halign=Gtk.Align.START)
+            split_align.add(split_label)
+            sub_align = Align(halign=Gtk.Align.START)
+            sub_align.add(sub_label)
+
+            grid = Gtk.Grid(column_spacing=6, row_spacing=6)
+            grid.add(split_align)
+            grid.add(split_entry)
+            grid.add(split_revert)
+            grid.attach(sub_align, 0, 1, 1, 1)
+            grid.attach(sub_entry, 1, 1, 1, 1)
+            grid.attach(sub_revert, 2, 1, 1, 1)
+            grid.props.expand = False
+
+            vbox.pack_start(grid, False, False, 6)
+
             return vbox
 
         def __init__(self):

--- a/quodlibet/quodlibet/qltk/prefs.py
+++ b/quodlibet/quodlibet/qltk/prefs.py
@@ -701,7 +701,7 @@ class PreferencesWindow(UniqueWindow):
             for child in self.get_children():
                 child.show_all()
 
-    def __init__(self, parent):
+    def __init__(self, parent, open_page=None):
         if self.is_not_unique():
             return
         super(PreferencesWindow, self).__init__()
@@ -711,14 +711,18 @@ class PreferencesWindow(UniqueWindow):
         self.set_transient_for(qltk.get_top_parent(parent))
 
         self.__notebook = notebook = qltk.Notebook()
-        for Page in [self.SongList, self.Browsers, self.Player,
-                     self.Library, self.Tagging]:
+        pages = [self.SongList, self.Browsers, self.Player, self.Library,
+                 self.Tagging]
+        for Page in pages:
             page = Page()
             page.show()
             notebook.append_page(page)
 
-        page_name = config.get("memory", "prefs_page", "")
-        self.set_page(page_name)
+        if open_page in [page.name for page in pages]:
+            self.set_page(open_page)
+        else:
+            page_name = config.get("memory", "prefs_page", "")
+            self.set_page(page_name)
 
         def on_switch_page(notebook, page, page_num):
             config.set("memory", "prefs_page", page.name)

--- a/quodlibet/tests/test_util_string_splitters.py
+++ b/quodlibet/tests/test_util_string_splitters.py
@@ -75,6 +75,14 @@ class Tsplit_title(TestCase):
         self.failUnlessEqual(
             split_title("foo [b c]", " "), ("foo", ["b", "c"]))
 
+    def test_custom_subtag_splitter(self):
+        self.failUnlessEqual(
+            split_title("foo |b c|", " ", ["||"]), ("foo", ["b", "c"]))
+        self.failUnlessEqual(
+            split_title("foo abc", " ", ["ac"]), ("foo", ["b"]))
+        self.failUnlessEqual(
+            split_title("foo (a)", " ", []), ("foo (a)", []))
+
 
 class Tsplit_album(TestCase):
     def test_album_looks_like_disc(self):
@@ -100,6 +108,10 @@ class Tsplit_album(TestCase):
     def test_weird_not_disc(self):
         self.failUnlessEqual(
             split_album("foo ~crazy 3~"), ("foo ~crazy 3~", None))
+
+    def test_custom_splitter(self):
+        self.failUnlessEqual(
+            split_album("foo |CD 1|", ["||"]), ("foo", "1"))
 
 
 class Tsplit_people(TestCase):
@@ -137,3 +149,7 @@ class Tsplit_people(TestCase):
         self.failUnlessEqual(
             split_people("Psycho Killer [Talking Heads Cover]"),
             ("Psycho Killer", ["Talking Heads"]))
+
+    def test_custom_splitter(self):
+        self.failUnlessEqual(
+            split_people("foo |With bar|", " ", ["||"]), ("foo", ["bar"]))


### PR DESCRIPTION
- [x] Show split suggestions in a submenu
- [x] Add link to preferences in submenu
- [ ] ~Remove/integrate plugins in `ext/splitting.py`~
- [x] Allow setting subtitle splitters (`(), [], ...`) in preferences
- [x] Document it (format, separators etc.)
- [x] Update exfalso preferences too

Fixes #2958 and fixes #1029.