### PR TITLE
Added 'Thumb Rating' Plugin

### DIFF
--- a/quodlibet/po/POTFILES.in
+++ b/quodlibet/po/POTFILES.in
@@ -67,6 +67,7 @@ quodlibet/ext/events/squeezebox_sync.py
 quodlibet/ext/events/synchronizedlyrics.py
 quodlibet/ext/events/telepathy_status.py
 quodlibet/ext/events/themeswitcher.py
+quodlibet/ext/events/thumbrating.py
 quodlibet/ext/events/toggle_menu.py
 quodlibet/ext/events/trayicon/appindicator.py
 quodlibet/ext/events/trayicon/__init__.py

--- a/quodlibet/quodlibet/ext/events/thumbrating.py
+++ b/quodlibet/quodlibet/ext/events/thumbrating.py
@@ -1,0 +1,154 @@
+# -*- coding: utf-8 -*-
+#
+# View Lyrics: a Quod Libet plugin for viewing lyrics.
+# Copyright (C) 2018 Eoin O'Neill (eoinoneill1991@gmail.com)
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+
+from gi.repository import Gtk
+from quodlibet import _
+from quodlibet.plugins.events import EventPlugin
+from quodlibet.qltk import Icons, ToggleButton
+from quodlibet.plugins.gui import UserInterfacePlugin
+
+
+class RatingBox(Gtk.VBox):
+    def __init__(self):
+        super(RatingBox, self).__init__(self)
+
+        self.thumb_ups = 1
+        self.thumb_downs = 1
+
+        self.title = Gtk.Label("")
+        self.title.set_line_wrap(True)
+        self.title.set_lines(2)
+
+        hbox = Gtk.HBox()
+        self.upvote = ToggleButton("👍", "")
+        self.downvote = ToggleButton("👎", "")
+        self.upvote.connect("toggled", self.__thumb_toggled)
+        self.downvote.connect("toggled", self.__thumb_toggled)
+        self.score_label = Gtk.Label("----")
+        self.upvote.set_property("height-request", 50)
+        self.downvote.set_property("height-request", 50)
+        hbox.pack_start(self.upvote, True, True, 5)
+        hbox.pack_start(self.downvote, True, True, 5)
+
+        self.hbox = hbox
+        self.pack_start(self.title, False, False, 10)
+        self.pack_start(self.score_label, True, True, 5)
+        self.pack_start(self.hbox, False, False, 5)
+
+    def set_current_title(self, title):
+        self.title.set_text(title)
+
+    def set_current_score(self, cth_up, cth_down):
+        self.thumb_ups = cth_up
+        self.thumb_downs = cth_down
+        self.__set_pending_score_value(self.thumb_ups - self.thumb_downs)
+
+    def poll_vote(self, reset=True):
+        upward = 1 if self.upvote.get_active() else 0
+        downward = 1 if self.downvote.get_active() else 0
+        vote = (upward, downward)
+        if reset:
+            self.downvote.set_active(False)
+            self.upvote.set_active(False)
+        return vote
+
+    def __set_pending_score_value(self, score):
+        existing_score = self.thumb_ups - self.thumb_downs
+        if score == existing_score:
+            self.score_label.set_markup("<b>"
+                                        + str(int(score))
+                                        + "</b>")
+        elif score > existing_score:
+            self.score_label.set_markup("<b><span foreground=\"green\">"
+                                        + str(int(score))
+                                        + "</span></b>")
+        else:
+            self.score_label.set_markup("<b><span foreground=\"red\">"
+                                        + str(int(score))
+                                        + "</span></b>")
+
+    def __thumb_toggled(self, button):
+        if button.get_active():
+            if button == self.upvote:
+                self.downvote.set_active(False)
+            elif button == self.downvote:
+                self.upvote.set_active(False)
+
+        vote = self.poll_vote(False)
+        self.__set_pending_score_value(
+            self.thumb_ups + vote[0] - self.thumb_downs - vote[1])
+
+
+class ThumbRating(EventPlugin, UserInterfacePlugin):
+    """ Plugin for more hands off rating system using a
+    thumb up / thumbdown system. """
+
+    PLUGIN_ID = 'Thumb Rating'
+    PLUGIN_NAME = _('Thumb Rating')
+    PLUGIN_DESC = _('Adds a thumb-up/thumb-down scoring system '
+                    'which is converted to a rating value. Useful '
+                    'for keeping running vote totals and sorting by '
+                    '\'~#score\'.')
+    PLUGIN_ICON = Icons.USER_BOOKMARKS
+
+    # Threshold value where points should be recalculated
+    score_point_threshold = 0.2
+
+    def enabled(self):
+        self.rating_box = RatingBox()
+
+    def create_sidebar(self):
+        vbox = Gtk.VBox()
+        vbox.pack_start(self.rating_box, False, False, 0)
+        vbox.show_all()
+        return vbox
+
+    def disabled(self):
+        self.rating_box.destroy()
+
+    def plugin_on_song_ended(self, song, stopped):
+        if song is not None:
+            poll = self.rating_box.poll_vote()
+            if poll[0] >= 1 or poll[1] >= 1:
+                ups = int(song.get("~#wins") or 0)
+                downs = int(song.get("~#losses") or 0)
+                ups += poll[0]
+                downs += poll[1]
+                song["~#wins"] = ups
+                song["~#losses"] = downs
+                song["~#rating"] = ups / max((ups + downs), 2)
+                # note: ^^^ Look into implementing w/ confidence intervals!
+                song["~#score"] = ups - downs
+
+    def plugin_on_song_started(self, song):
+        if song is not None:
+            ups = int(song("~#wins") or 0)
+            downs = int(song("~#losses") or 0)
+
+            # Handle case where there's no score but user has a defined rating.
+            if (ups + downs == 0) and (song.get("~#rating")):
+                percent = song["~#rating"]
+                ups = int(percent * 10)
+                downs = int((1.0 - percent) * 10.0)
+                song["~#wins"] = ups
+                song["~#losses"] = downs
+            elif song.get("~#rating") and \
+                abs((ups / max((ups + downs), 2)) - song["~#rating"]) > \
+                    self.score_point_threshold:
+                # Cases where rating and points are not in alignment.
+                total = max(ups + downs, 10)
+                percent = song["~#rating"]
+                ups = int(percent * total)
+                downs = int((1.0 - percent) * total)
+                song["~#wins"] = ups
+                song["~#losses"] = downs
+
+            self.rating_box.set_current_score(ups, downs)
+            self.rating_box.set_current_title(song("~artist~title"))


### PR DESCRIPTION
## Thumb Rating System

> This plugin allows users to vote on the currently playing song using a thumb-up/thumb-down tally system. This has some benefits over the vanilla star-rating system by allowing users to make an easier decision multiple times in order to accurately calculate a final star total. It will also more accurately measure a users affinity to a song over a period of time. Unlike the existing auto-rating plugin, this plugin allows for a neutral state where the rating does not change. It also doesn't make the assumption that a skipped song is an inferior song.
    
>  You can sort you songs by a score tag ("~#score") in order to sort your music from least liked to most liked.


<p align="center">
  <img src="https://user-images.githubusercontent.com/3040352/48962319-323c8e00-ef33-11e8-8d75-032c235b7b30.png">
</p>

This plugin currently uses the Addon GUI space to add the thumb up and down buttons. However, I think it would be useful to add the ability to add plugin buttons to the playhead area to allow plugins to add additional play controls. A mock-up of what I think might be useful at some point:

<p align="center">
     <img src="https://user-images.githubusercontent.com/3040352/48962744-80ed2680-ef39-11e8-80db-e27e2c31b7e8.png">
</p>

I'm curious to see if others agree with me on this idea. Basically, I see the secondary area after the play controls as a HBox of multiple plugin controls inserted into that area. It would be useful in any circumstance like this where you want to add a few simple buttons for either playback or actions on an active song. 