### PR TITLE
Improve ignore & keep songs functionality in queue

### DIFF
--- a/quodlibet/quodlibet/config.py
+++ b/quodlibet/quodlibet/config.py
@@ -68,7 +68,7 @@ INITIAL = {
         "shufflequeue": "false",
         "queue_stop_at_end": "false",
         "queue_keep_songs": "false",
-        "queue_ignore": "false",
+        "queue_disable": "false",
 
         # <reversed?>tagname, song list sort
         "sortby": "0album",

--- a/quodlibet/quodlibet/qltk/icons.py
+++ b/quodlibet/quodlibet/qltk/icons.py
@@ -100,6 +100,7 @@ class Icons(str):
     PREFERENCES_DESKTOP_SCREENSAVER = "preferences-desktop-screensaver"
     PREFERENCES_DESKTOP_THEME = "preferences-desktop-theme"
     PROCESS_STOP = "process-stop"  # "_Stop"
+    SYSTEM_LOCK_SCREEN = "system-lock-screen"
     SYSTEM_RUN = "system-run"  # "_Execute"
     SYSTEM_SEARCH = "system-search"
     TEXT_HTML = "text-html"

--- a/quodlibet/quodlibet/qltk/queue.py
+++ b/quodlibet/quodlibet/qltk/queue.py
@@ -30,7 +30,7 @@ from quodlibet.qltk.menubutton import SmallMenuButton
 from quodlibet.qltk.songmodel import PlaylistModel
 from quodlibet.qltk.playorder import OrderInOrder, OrderShuffle
 from quodlibet.qltk.x import ScrolledWindow, SymbolicIconImage, \
-    SmallImageButton, MenuItem
+    SmallImageButton, SmallImageToggleButton, MenuItem
 from quodlibet.qltk.songlistcolumns import CurrentColumn
 
 QUEUE = os.path.join(quodlibet.get_user_dir(), "queue")
@@ -130,11 +130,6 @@ class QueueExpander(Gtk.Expander):
             populate=True)
         menu.append(stop_checkbox)
 
-        queue_ignore_cb = ConfigCheckMenuItem(
-            _("Ignore"), "memory", "queue_ignore",
-            populate=True)
-        menu.append(queue_ignore_cb)
-
         keep_checkbox = ConfigCheckMenuItem(
             _("Keep Songs"), "memory", "queue_keep_songs",
             populate=True)
@@ -158,6 +153,18 @@ class QueueExpander(Gtk.Expander):
         button.set_menu(menu)
 
         outer.pack_start(button, False, False, 0)
+
+        toggle = SmallImageToggleButton(
+            image=SymbolicIconImage(Icons.SYSTEM_LOCK_SCREEN,
+                                    Gtk.IconSize.MENU),
+            relief=Gtk.ReliefStyle.NONE,
+            tooltip_text=_("Disable queue"))
+        disabled = config.getboolean("memory", "queue_disable", False)
+        toggle.props.active = disabled
+        self.__queue_disable(disabled)
+        toggle.connect('toggled',
+                       lambda b: self.__queue_disable(b.props.active))
+        outer.pack_start(toggle, False, False, 6)
 
         close_button = SmallImageButton(
             image=SymbolicIconImage("window-close", Gtk.IconSize.MENU),
@@ -320,6 +327,10 @@ class QueueExpander(Gtk.Expander):
 
         menu_button.set_property('visible', expanded)
         config.set("memory", "queue_expanded", str(expanded))
+
+    def __queue_disable(self, disabled):
+        config.set("memory", "queue_disable", disabled)
+        self.queue.set_sensitive(not disabled)
 
 
 class QueueModel(PlaylistModel):

--- a/quodlibet/quodlibet/qltk/songmodel.py
+++ b/quodlibet/quodlibet/qltk/songmodel.py
@@ -61,11 +61,15 @@ class PlaylistMux(object):
         """Switch to the next song"""
 
         keep_songs = config.getboolean("memory", "queue_keep_songs", False)
-        q_ignore = config.getboolean("memory", "queue_ignore", False)
+        q_disable = config.getboolean("memory", "queue_disable", False)
 
         if (self.q.is_empty()
-                or (q_ignore and not (keep_songs and self.q.sourced))):
+                or q_disable
+                or (keep_songs and not self.q.sourced)):
             self.pl.next()
+            # The go_to is to make sure the playlist begins playing
+            # when the queue is disabled while being sourced
+            self.go_to(self.pl.current)
         else:
             self.q.next()
         self._check_sourced()
@@ -74,11 +78,13 @@ class PlaylistMux(object):
         """Switch to the next song (action comes from the user)"""
 
         keep_songs = config.getboolean("memory", "queue_keep_songs", False)
-        q_ignore = config.getboolean("memory", "queue_ignore", False)
+        q_disable = config.getboolean("memory", "queue_disable", False)
 
         if (self.q.is_empty()
-                or (q_ignore and not (keep_songs and self.q.sourced))):
+                or q_disable
+                or (keep_songs and not self.q.sourced)):
             self.pl.next_ended()
+            self.go_to(self.pl.current)
         else:
             self.q.next_ended()
         self._check_sourced()
@@ -87,10 +93,11 @@ class PlaylistMux(object):
         """Go to the previous song"""
 
         keep_songs = config.getboolean("memory", "queue_keep_songs", False)
-        q_ignore = config.getboolean("memory", "queue_ignore", False)
+        q_disable = config.getboolean("memory", "queue_disable", False)
 
-        if q_ignore or self.pl.sourced or not keep_songs:
+        if q_disable or self.pl.sourced or not keep_songs:
             self.pl.previous()
+            self.go_to(self.pl.current)
         else:
             self.q.previous()
         self._check_sourced()

--- a/quodlibet/tests/test_qltk_songmodel.py
+++ b/quodlibet/tests/test_qltk_songmodel.py
@@ -404,19 +404,21 @@ class TPlaylistMux(TestCase):
         self.assertTrue(self.q.sourced)
         self.assertEqual(self.mux.current, self.q[-1][0])
 
-    def test_queue_ignore(self):
+    def test_queue_disable(self):
         self.pl.set(range(10))
         self.q.set(range(10))
 
-        quodlibet.config.set("memory", "queue_ignore", True)
+        quodlibet.config.set("memory", "queue_disable", True)
         self.next()
         self.failUnlessEqual(len(self.pl.get()), len(range(10)))
         self.failUnlessEqual(len(self.q.get()), len(range(10)))
+        self.assertTrue(self.pl.sourced)
 
-        quodlibet.config.set("memory", "queue_ignore", False)
+        quodlibet.config.set("memory", "queue_disable", False)
         self.next()
         self.failUnlessEqual(len(self.pl.get()), len(range(10)))
         self.failUnlessEqual(len(self.q.get()), len(range(10)) - 1)
+        self.assertTrue(self.q.sourced)
 
     def test_queue_keep_songs(self):
         self.q.set(range(10))
@@ -424,6 +426,8 @@ class TPlaylistMux(TestCase):
         quodlibet.config.set("memory", "queue_keep_songs", True)
         self.next()
         self.failUnlessEqual(len(self.q.get()), len(range(10)))
+        self.failUnlessEqual(self.q.current, None)
+        self.mux.go_to(self.q[0].iter, source=self.q)
         self.failUnlessEqual(self.q.current, 0)
         self.next()
         self.failUnlessEqual(len(self.q.get()), len(range(10)))
@@ -433,6 +437,17 @@ class TPlaylistMux(TestCase):
         self.next()
         self.failUnlessEqual(len(self.q.get()), len(range(10)) - 1)
         self.failUnless(self.q.current is None)
+
+    def test_queue_disable_and_keep_songs(self):
+        self.pl.set(range(10))
+        self.q.set(range(10))
+
+        self.mux.go_to(self.q[0].iter, source=self.q)
+        quodlibet.config.set("memory", "queue_disable", True)
+        quodlibet.config.set("memory", "queue_keep_songs", True)
+
+        self.next()
+        self.assertTrue(self.pl.sourced)
 
     def tearDown(self):
         self.p.destroy()


### PR DESCRIPTION
This is an attempt to address the issues discussed in #2912.

The two main changes are:
- Replace the ignore option with a disable button in the queue header bar. When the queue is disabled, it cannot be played from (but songs can still be added to it).
- Replace the keep songs option with a mode submenu.

@declension @Treferwynd thoughts?