### PR TITLE
Github: add / update templates for new Issues and PRs

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,12 @@
+Contributing to Quod Libet
+--------------------------
+
+When raising a new issue:
+ 1. Choose whether it's a bug of a feature request
+ 1. Check the existing issues.
+ 1. Fill in the appropriate template as described there
+
+If you have related ideas, please file them separately and mention
+the issue numbers of previous ideas.
+
+For more details, see the [contributing guide](../quodlibet/docs/development/contributing.rst)

--- a/.github/CONTRIBUTING.rst
+++ b/.github/CONTRIBUTING.rst
@@ -1,9 +1,0 @@
-::
-
-    When creating a new issue please try to answer the following questions:
-
-    * What did you try to do?
-    * What did you expect to happen?
-    * What did happen instead?
-    * Which version of Quod Libet?
-    * Which operating system including version (Ubuntu 14.04, Win7, Debian sid, ...)?

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,36 @@
+Steps to reproduce
+------------------
+
+> (What did you try to do?)
+
+
+Expected Output
+---------------
+
+> (What should happen?)
+
+
+Actual Output
+-------------
+
+> (What did happen? (including any logs if possible))
+
+
+Test System
+-----------
+
+### Which version of Quod Libet?
+> (e.g. 4.2)
+
+### Which operating system 
+> (e.g. Ubuntu 18.04, Win10, Debian Sid, MacOS 10.14...)?
+
+
+### If it's audio-related, what back-end?
+> (e.g. `gstreamer 1.14.4`)
+
+
+Additional Information
+----------------------
+
+> (anything else relevant here)

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,0 +1,30 @@
+Requesting a feature
+--------------------
+_Please make sure your feature hasn't [been requested already](https://github.com/quodlibet/quodlibet/issues?utf8=%E2%9C%93&q=is%3Aissue+). 
+It's much easier to continue or vote on an existing discussion that start a new one._
+
+_Please then complete this template and remove this section 
+and any unnecessary text. Thanks for helping with Quod Libet!_
+
+
+
+The proposed change
+-------------------
+
+> (A brief description of how the new feature / change should look / behave)
+
+
+Benefits of this change
+-----------------------
+
+> (What are the benefits? Who are they for?)
+
+
+Any issues this might cause
+---------------------------
+
+> (Performance: will this cause browsers or libraries to be noticeably slower 
+> or less predictable?)
+>
+> (Migrations: some changes, e.g. to tag formats, have huge impact for existing users. 
+Migrations are possible but can require a lot of thought.)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+Check-list
+----------
+
+ * [ ] There is a linked issue discussing the motivations for this feature or bugfix
+ * [ ] Unit tests have been added where possible
+ * [ ] I've added / updated documentation for any user-facing features.
+ * [ ] Performance seems to be comparable or better than current `master`
+
+
+What this change is adding / fixing
+-----------------------------------
+
+> A high-level description of the changes. 
+> Hopefully the commits are atomic and well described, but this is the overall 
+> summary of the change, to other developers / maintainers, plus any TODOs.


### PR DESCRIPTION
 * Split issue templates into bug-fixes and feature requests. :)
 * Formalise these a bit, but largely keeping to existing contribution guidelines.
 * Move existing Contributing guide to Markdown (wasn't showing in Github)
 * Add a PR template, with some sections and guidelines
 * TODO: the actual Github config to use different template types

Comments welcome :)