### PR TITLE
Scale player volume properly in mpris2 API

### DIFF
--- a/quodlibet/quodlibet/ext/events/mpris/mpris2.py
+++ b/quodlibet/quodlibet/ext/events/mpris/mpris2.py
@@ -338,7 +338,7 @@ value="false"/>
             elif name == "Shuffle":
                 player_options.shuffle = value
             elif name == "Volume":
-                player.volume = value
+                player.volume = value ** 3.0
 
     def get_property(self, interface, name):
         player = app.player
@@ -385,7 +385,7 @@ value="false"/>
             elif name == "Metadata":
                 return self.__get_metadata()
             elif name == "Volume":
-                return player.volume
+                return player.volume ** (1.0 / 3.0)
             elif name == "Position":
                 return player.get_position() * 1000
             elif name == "MinimumRate":


### PR DESCRIPTION
* This fixes an issue where KDE Connect Android app
  is showing different volume than Quod Libet GUI.