### PR TITLE
Improved `VGM` Metadata Tag Parsing. (GD3 Support)

### DIFF
--- a/quodlibet/quodlibet/formats/vgm.py
+++ b/quodlibet/quodlibet/formats/vgm.py
@@ -4,12 +4,27 @@
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation; either version 2 of the License, or
 # (at your option) any later version.
-
-"""http://www.smspower.org/uploads/Music/vgmspec161.txt"""
-
 import struct
 
 from ._audio import AudioFile, translate_errors
+
+# VGM and GD3 SPECs:
+# http://www.smspower.org/uploads/Music/vgmspec170.txt
+# http://www.smspower.org/uploads/Music/gd3spec100.txt
+GD3_TAG_PTR_POS = 0x14
+GD3_TAG_PTR_SIZE = 4
+
+GD3_ENGLISH_TITLE = 0
+GD3_JAPANESE_TITLE = 1
+GD3_ENGLISH_GAME = 2
+GD3_JAPANESE_GAME = 3
+GD3_ENGLISH_SYSTEM = 4
+GD3_JAPANESE_SYSTEM = 5
+GD3_ENGLISH_ARTIST = 6
+GD3_JAPANESE_ARTIST = 7
+GD3_DATE = 8
+GD3_DUMPER = 9
+GD3_COMMENT = 10
 
 
 class VgmFile(AudioFile):
@@ -21,7 +36,8 @@ class VgmFile(AudioFile):
             with open(filename, "rb") as h:
                 header = h.read(64)
                 if len(header) != 64 or header[:4] != b"Vgm ":
-                    raise Exception("Not a VGM file")
+                    # filename useful to show (helps w/ faulty VGM files.)
+                    raise Exception(filename + " not a VGM file")
 
                 samples_to_sec = lambda s: s / 44100.
                 samples = struct.unpack('<i', header[24:28])[0]
@@ -37,6 +53,13 @@ class VgmFile(AudioFile):
                     length += samples_to_sec(loop_samples)
 
                 self["~#length"] = length
+
+                gd3_position = struct.unpack('<i',
+                                             header[GD3_TAG_PTR_POS:
+                                                    GD3_TAG_PTR_POS
+                                                    + GD3_TAG_PTR_SIZE])[0]
+                h.seek(GD3_TAG_PTR_POS + gd3_position)
+                self.update(parse_gd3(h.read()))
 
         self.sanitize(filename)
 
@@ -54,6 +77,40 @@ class VgmFile(AudioFile):
             return ["title"]
         else:
             return k == "title"
+
+
+def parse_gd3(data):
+    tags = {}
+    if data[0:4] != b'Gd3 ':
+        print('Invalid Gd3, Missing Header...')
+        return tags
+
+    version = data[4:8]
+    # Should be [0x00, 0x10, 0x00, 0x00] currently.
+    # We should hold onto it for possible branching if standards change.
+
+    gd3_length = struct.unpack('<i', data[8:12])[0]
+    # Length of gd3 footer. This means we can actually add more tags to the end
+    # with APETAG at some point. (Or at least consider...)
+
+    entries = data[12:12+gd3_length].decode('utf-16').split('\0')
+
+    tags["title"] = entries[GD3_ENGLISH_TITLE] \
+        if (entries[GD3_ENGLISH_TITLE] == entries[GD3_JAPANESE_TITLE]) \
+        else \
+        '\n'.join(filter(None, [entries[GD3_ENGLISH_TITLE],
+                                entries[GD3_JAPANESE_TITLE]]))
+
+    tags["artist"] = '\n'.join(filter(None, [entries[GD3_ENGLISH_ARTIST],
+                                             entries[GD3_JAPANESE_ARTIST]]))
+    tags["console"] = '\n'.join(filter(None, [entries[GD3_ENGLISH_SYSTEM],
+                                              entries[GD3_JAPANESE_SYSTEM]]))
+    tags["album"] = '\n'.join(filter(None, [entries[GD3_ENGLISH_GAME],
+                                            entries[GD3_JAPANESE_GAME]]))
+    tags["date"] = entries[GD3_DATE]
+    tags["dumper"] = entries[GD3_DUMPER]
+    tags["comment"] = entries[GD3_COMMENT]
+    return tags
 
 
 loader = VgmFile

--- a/quodlibet/tests/test_formats_vgm.py
+++ b/quodlibet/tests/test_formats_vgm.py
@@ -19,7 +19,19 @@ class TVgmFile(TestCase):
     def test_reload(self):
         self.song["title"] = "foobar"
         self.song.reload()
-        self.failUnlessEqual(self.song("title"), "foobar")
+        self.failUnlessEqual(self.song("title"), "Chaos Emerald")
+
+    def test_gd3_tags(self):
+        expected_tags = {
+            "title": "Chaos Emerald",
+            "album": "Sonic the Hedgehog\nソニック・ザ・ヘッジホッグ",
+            "console": "Sega Mega Drive\nセガメガドライブ",
+            "artist": "Masato Nakamura\n中村正人",
+            "date": "1991"
+        }
+
+        for k, v in expected_tags.items():
+            self.failUnlessEqual(self.song[k], v)
 
     def test_write(self):
         self.song.write()


### PR DESCRIPTION
## Overview
This PR gives Quodlibet the ability to properly scan `vgm` files for title, album, artist, and other tags available via the [gd3 tag standard](https://vgmrips.net/wiki/GD3_Specification). It uses Quodlibet's multiple tag system to store both Japanese and English entries (when applicable.) This should help improve the user-experience of browsing a library with VGM files. ( related to: #1244 )

### Future Goals
There are more improvements that can be made here. Specifically, it would be nice if QuodLibet could work with additional APETAG footers on `vgm` and `spc` files to store information such as genre, rating, replaygain-data, and any other additionally unsupported tag entries. This is how some media players (foobar2000) like to embed additional tag data to chiptune formats. It would also be nice to have proper tag writing features for all supported chiptune formats. 

### The State of VGM w/ GStreamer (on Linux)
It's worth noting that the VGM format libraries used by GStreamer on Linux are very out of date. The current situation regarding libgme on linux is complicated, but the short of it is that there are many different forks that exist, each one supporting a different range of systems. 

If you want to gain additional system playback options (and additional sample playback accuracy) compared to the standard libgme installation, I would suggest you build [wyatt8740/Game_Music_Emu](https://github.com/wyatt8740/Game_Music_Emu) from source. Wyatt's repository is a fork of @kode54 's GME playback libraries but with added CMake support (allowing linux systems to build the library.) I'm currently working on my own fork of wyatts work locally, hoping to merge with it and eventually merge it with the KDE managed branch at [bitbucket::mpyne/game-music-emu](https://bitbucket.org/mpyne/game-music-emu/). If you are running quodlibet on Windows, you may be better off using [kode54/Game_Music_Emu](https://github.com/kode54/Game_Music_Emu).

My expectation is that GStreamer's vgm playback support will improve significantly in the future. @ValleyBell is working on a new vgm playback library [ValleyBell/libvgm](https://github.com/ValleyBell/libvgm) which should be able to support GStreamer with an eventual plugin (see discussion here: vgmrips/vgmplay#45)
 
Hopefully that wasn't too long winded. My main reason for explaining this stems from the potential to use a custom libgme build for quodlibet's flatpak, which would allow quodlibet to use a custom binary without interfering with system level libraries (ideal solution.) 