### PR TITLE
Simplify launcher for macOS

### DIFF
--- a/osx_bundle/misc/bundle/launcher.sh
+++ b/osx_bundle/misc/bundle/launcher.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-bundle="$(dirname "$(dirname "$(dirname "$0")")")"
+bundle=$(cd "$(dirname "$(dirname "$(dirname "$0")")")"; pwd)
 bundle_contents="$bundle"/Contents
 bundle_res="$bundle_contents"/Resources
 bundle_lib="$bundle_res"/lib

--- a/osx_bundle/misc/bundle/launcher.sh
+++ b/osx_bundle/misc/bundle/launcher.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-bundle=$(cd "$(dirname "$(dirname "$(dirname "$0")")")"; pwd)
+bundle="$(dirname "$(dirname "$(dirname "$0")")")"
 bundle_contents="$bundle"/Contents
 bundle_res="$bundle_contents"/Resources
 bundle_lib="$bundle_res"/lib
@@ -51,13 +51,13 @@ export QUODLIBET_NO_HINTS=yes
 
 # select target based on our basename
 APP=$(basename "$0")
-if [ "$APP" == "run" ]; then
+if [ "$APP" = "run" ]; then
     "$PYTHON" "$@"
-elif  [ "$APP" == "gst-plugin-scanner" ]; then
+elif  [ "$APP" = "gst-plugin-scanner" ]; then
     # Starting with 10.11 OSX will no longer pass DYLD_LIBRARY_PATH
     # to child processes. To work around use this launcher for the
     # GStreamer plugin scanner helper
     "$bundle_res/libexec/gstreamer-1.0/gst-plugin-scanner" "$@"
 else
-    "$PYTHON" "$bundle_contents/Resources/bin/$APP" "$@"
+    "$PYTHON" "$bundle_bin/$APP" "$@"
 fi

--- a/osx_bundle/misc/bundle/launcher.sh
+++ b/osx_bundle/misc/bundle/launcher.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 bundle=$(cd "$(dirname "$(dirname "$(dirname "$0")")")"; pwd)
 bundle_contents="$bundle"/Contents


### PR DESCRIPTION
Check-list
----------

 * [ ] There is a linked issue discussing the motivations for this feature or bugfix
 * [ ] Unit tests have been added where possible
 * [ ] I've added / updated documentation for any user-facing features.
 * [x] Performance seems to be comparable or better than current `master`

No difference when using `time` but it should theoretically be faster

What this change is adding / fixing
-----------------------------------
I have dash (a faster posix only shell) for my /bin/sh. It doesn't work with the current launcher script.
While I was there I cleaned some other things up.

I added some changes by consulting shellcheck and tested them on my own machine

- We don't need to cd ... pwd because dirname outputs the path anyway.
- Actually put $bundle_bin to use.
- Change comparisons to be POSIX-compatible, `==` is not going to work when someone has dash as their /bin/sh.