### PR TITLE
Add original date sort option to album browser

### DIFF
--- a/quodlibet/quodlibet/browsers/albums/main.py
+++ b/quodlibet/quodlibet/browsers/albums/main.py
@@ -3,6 +3,7 @@
 #           2012-2018 Nick Boultbee
 #           2009-2014 Christoph Reiter
 #           2018      Uriel Zajaczkovski
+#           2019      Ruud van Asseldonk
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -127,6 +128,27 @@ def compare_date(a1, a2):
             cmp(a1.key, a2.key))
 
 
+def compare_original_date(a1, a2):
+    a1, a2 = a1.album, a2.album
+    if a1 is None:
+        return -1
+    if a2 is None:
+        return 1
+    if not a1.title:
+        return 1
+    if not a2.title:
+        return -1
+
+    # Take the original date if it is set, or fall back to the regular date
+    # otherewise.
+    a1_date = a1.get("originaldate", a1.date)
+    a2_date = a2.get("originaldate", a2.date)
+
+    return (cmpa(a1_date, a2_date) or
+            cmpa(a1.sort, a2.sort) or
+            cmp(a1.key, a2.key))
+
+
 def compare_genre(a1, a2):
     a1, a2 = a1.album, a2.album
     if a1 is None:
@@ -184,6 +206,7 @@ class PreferencesButton(Gtk.HBox):
             (_("_Title"), self.__compare_title),
             (_("_Artist"), self.__compare_artist),
             (_("_Date"), self.__compare_date),
+            (_("_Original Date"), self.__compare_original_date),
             (_("_Genre"), self.__compare_genre),
             (_("_Rating"), self.__compare_rating),
             (_("_Playcount"), self.__compare_avgplaycount),
@@ -241,6 +264,10 @@ class PreferencesButton(Gtk.HBox):
     def __compare_date(self, model, i1, i2, data):
         a1, a2 = model.get_value(i1), model.get_value(i2)
         return compare_date(a1, a2)
+
+    def __compare_original_date(self, model, i1, i2, data):
+        a1, a2 = model.get_value(i1), model.get_value(i2)
+        return compare_original_date(a1, a2)
 
     def __compare_genre(self, model, i1, i2, data):
         a1, a2 = model.get_value(i1), model.get_value(i2)

--- a/quodlibet/tests/test_browsers_albums.py
+++ b/quodlibet/tests/test_browsers_albums.py
@@ -1,5 +1,6 @@
 # Copyright 2012,2014 Christoph Reiter
 #                2016 Nick Boultbee
+#                2019 Ruud van Asseldonk
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -21,7 +22,7 @@ from quodlibet.browsers.albums import AlbumList
 from quodlibet.browsers.albums.models import AlbumItem
 from quodlibet.browsers.albums.prefs import Preferences, DEFAULT_PATTERN_TEXT
 from quodlibet.browsers.albums.main import (compare_title, compare_artist,
-    compare_genre, compare_rating, compare_date)
+    compare_genre, compare_rating, compare_date, compare_original_date)
 from quodlibet.formats import AudioFile
 from quodlibet.library import SongLibrary, SongLibrarian
 from quodlibet.util.collection import Album
@@ -115,6 +116,17 @@ class TAlbumSort(TestCase):
         n = self._get_album({"album": ""})
 
         self.assertOrder(compare_date, [AlbumItem(None), a, b, c, n])
+
+    def test_sort_original_date(self):
+        a = self._get_album({"album": "b", "date": "1970"})
+        b = self._get_album({"album": "a", "date": "2038",
+                             "originaldate": "1967"})
+        c = self._get_album({"album": "a", "date": ""})
+        d = self._get_album({"album": "b", "originaldate": "1971"})
+        n = self._get_album({"album": ""})
+
+        self.assertOrder(compare_original_date,
+                         [AlbumItem(None), b, a, d, c, n])
 
     def test_sort_rating(self):
         a = self._get_album({"album": "b", "~#rating": 0.5})


### PR DESCRIPTION
Check-list
----------

 * [x] *There is a linked issue discussing the motivations for this feature or bugfix*
        Fixes #913. It is not quite as generic as #1486, but at least it is a small step forward.
 * [x] *Unit tests have been added where possible*
 * [ ] *I've added / updated documentation for any user-facing features*
        I could not find any documentation this specific, I don't think anything needs to be updated.
 * [x] Performance seems to be comparable or better than current `master`
        I perceive no difference between sorting by date or original date when browsing my own library of ~1100 albums.

What this change is adding / fixing
-----------------------------------

> This change allows sorting by original date in the album list browser. I have many albums where the date tag contains the release date, which might be a CD reissue from the 90s of an album released in the 70s. Previously such albums used to be sorted among albums released in the 90s. Now they are properly sorted by original release date.
