### PR TITLE
Added small explanation on how to escape special characters in search terms

### DIFF
--- a/quodlibet/docs/guide/searching.rst
+++ b/quodlibet/docs/guide/searching.rst
@@ -53,6 +53,10 @@ To search a specific tag, use a search like::
 The search terms can't use quotes (``"``), slashes (``/``), hashes (``#``),
 pipes (``|``), ampersands (``&``), or bangs (``!``); these characters have
 special meanings for advanced searches.
+If you need to search and match one of those special characters,
+you can use regex search which gives you the possibility to escape them, e.g.
+
+ * ``filename=/\/Music\/Alternative/``
 
 In QL 3.9 onwards, you can also use `!=` to search for things not equal::
 


### PR DESCRIPTION
Check-list
----------

 * [x] There is a linked issue discussing the motivations for this feature or bugfix: #3110 
 * [x] I've added / updated documentation for any user-facing features.
 * [x] Performance seems to be comparable or better than current `master`


What this change is adding / fixing
-----------------------------------

It wasn't clear in the doc that it's possible to have a search including special characters. This is just to explain that it can be achieved using regex.  
