### PR TITLE
Add new Banshee import plugin

### DIFF
--- a/quodlibet/po/POTFILES.in
+++ b/quodlibet/po/POTFILES.in
@@ -42,6 +42,7 @@ quodlibet/ext/events/appinfo.py
 quodlibet/ext/events/auto_library_update.py
 quodlibet/ext/events/automask.py
 quodlibet/ext/events/autorating.py
+quodlibet/ext/events/bansheeimport.py
 quodlibet/ext/events/clock.py
 quodlibet/ext/events/equalizer.py
 quodlibet/ext/events/gajim_status.py

--- a/quodlibet/quodlibet/ext/events/bansheeimport.py
+++ b/quodlibet/quodlibet/ext/events/bansheeimport.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018 Phidica Veia
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+
+from gi.repository import Gtk
+from senf import uri2fsn
+
+from quodlibet import _
+from quodlibet import app
+from quodlibet import util
+from quodlibet.qltk import Icons
+from quodlibet.qltk.msg import WarningMessage, ErrorMessage
+from quodlibet.util.path import expanduser, normalize_path
+from quodlibet.plugins.events import EventPlugin
+
+
+def do_import(parent, library):
+    db_path = expanduser("~/.config/banshee-1/banshee.db")
+    msg = _("test db path %s") % db_path
+    # FIXME: this is just a warning so it works with older QL
+    WarningMessage(parent, BansheeImport.PLUGIN_NAME, msg).run()
+
+
+class BansheeImport(EventPlugin):
+    PLUGIN_ID = "bansheeimport"
+    PLUGIN_NAME = _("Banshee Import")
+    PLUGIN_DESC = _("Imports ratings and song statistics from Banshee.")
+    PLUGIN_ICON = Icons.DOCUMENT_OPEN
+
+    def PluginPreferences(self, *args):
+        button = Gtk.Button(label=_("Start Import"))
+
+        def clicked_cb(button):
+            do_import(button, app.library)
+
+        button.connect("clicked", clicked_cb)
+        return button

--- a/quodlibet/quodlibet/ext/events/bansheeimport.py
+++ b/quodlibet/quodlibet/ext/events/bansheeimport.py
@@ -12,7 +12,6 @@ from senf import uri2fsn
 
 from quodlibet import _
 from quodlibet import app
-from quodlibet import qltk
 from quodlibet import ngettext
 from quodlibet import util
 from quodlibet.qltk.entry import UndoEntry

--- a/quodlibet/quodlibet/ext/events/bansheeimport.py
+++ b/quodlibet/quodlibet/ext/events/bansheeimport.py
@@ -6,6 +6,8 @@
 # the Free Software Foundation; either version 2 of the License, or
 # (at your option) any later version.
 
+import sqlite3
+
 from gi.repository import Gtk
 from senf import uri2fsn
 
@@ -16,6 +18,30 @@ from quodlibet.qltk import Icons
 from quodlibet.qltk.msg import WarningMessage, ErrorMessage
 from quodlibet.util.path import expanduser, normalize_path
 from quodlibet.plugins.events import EventPlugin
+
+
+class BansheeDBImporter:
+
+    def __init__(self, library):
+
+        self._library = library
+        self._changed_songs = []
+
+    def read(self, db):
+        """Iterate through the library and search for data to import for
+        each song
+        """
+
+        for song in self._library:
+            print("filename: %s" % song["~filename"])
+
+    def finish(self):
+        """Call at the end, also returns number of songs with data imported"""
+
+        count = len(self._changed_songs)
+        self._library.changed(self._changed_songs)
+        self._changed_songs = []
+        return count
 
 
 def do_import(parent, library):

--- a/quodlibet/quodlibet/ext/events/bansheeimport.py
+++ b/quodlibet/quodlibet/ext/events/bansheeimport.py
@@ -52,25 +52,24 @@ class BansheeDBImporter:
 
             has_changed = False
 
-            if row["Rating"] is not None:
-                try:
-                    # banshee stores ratings as integers up to 5
-                    value = row["Rating"] / 5.0
-                except ValueError:
-                    pass
-                else:
-                    song["~#rating"] = value
-                    has_changed = True
+            # rating is stored as integer from 0 to 5
+            b_rating = row["Rating"] / 5.0
+            if b_rating != song("~#rating"):
+                song["~#rating"] = b_rating
+                has_changed = True
 
-            if row["PlayCount"] is not None:
+            # play count is stored as integer from 0
+            if row["PlayCount"] != song("~#playcount"):
                 # summing play counts would break on multiple imports
                 song["~#playcount"] = row["PlayCount"]
                 has_changed = True
 
-            if row["SkipCount"] is not None:
+            # skip count is stored as integer from 0
+            if row["SkipCount"] != song("~#skipcount"):
                 song["~#skipcount"] = row["SkipCount"]
                 has_changed = True
 
+            # timestamp is stored as integer or None
             if row["LastPlayedStamp"] is not None:
                 value = row["LastPlayedStamp"]
                 # keep timestamp if it is newer than what we had

--- a/quodlibet/quodlibet/ext/events/bansheeimport.py
+++ b/quodlibet/quodlibet/ext/events/bansheeimport.py
@@ -8,7 +8,7 @@
 import sqlite3
 
 from gi.repository import Gtk
-from senf import uri2fsn
+from senf import uri2fsn, text2fsn
 
 from quodlibet import _
 from quodlibet import app
@@ -96,11 +96,12 @@ class BansheeDBImporter:
 
 def do_import(parent, library):
     db_path = expanduser(BansheeImport.USR_PATH)
-    db = sqlite3.connect(db_path)
 
     importer = BansheeDBImporter(library)
     try:
+        db = sqlite3.connect(db_path)
         importer.read(db)
+        db.close()
     except sqlite3.OperationalError:
         msg = _("Specified Banshee database is malformed or missing")
         WarningMessage(parent, BansheeImport.PLUGIN_NAME, msg).run()
@@ -112,13 +113,12 @@ def do_import(parent, library):
         ErrorMessage(parent, BansheeImport.PLUGIN_NAME, msg).run()
     else:
         count = importer.finish()
-        preamble = "Successfully imported ratings and statistics for "
-        msg = ngettext(preamble + "%d song", preamble + "%d songs",
-                       count) % count
+        msg = ngettext(
+            "Successfully imported ratings and statistics for %d song",
+            "Successfully imported ratings and statistics for %d songs",
+            count) % count
         Message(Gtk.MessageType.INFO, parent, BansheeImport.PLUGIN_NAME,
                 msg).run()
-
-    db.close()
 
 
 class BansheeImport(EventPlugin):
@@ -142,7 +142,7 @@ class BansheeImport(EventPlugin):
         entry.set_text(BansheeImport.DEF_PATH)
 
         def path_activate(entry, *args):
-            path = entry.get_text()
+            path = text2fsn(entry.get_text())
             if BansheeImport.USR_PATH != path:
                 BansheeImport.USR_PATH = path
 

--- a/quodlibet/quodlibet/ext/events/bansheeimport.py
+++ b/quodlibet/quodlibet/ext/events/bansheeimport.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2018 Phidica Veia
 #
 # This program is free software; you can redistribute it and/or modify

--- a/quodlibet/tests/plugin/test_bansheeimport.py
+++ b/quodlibet/tests/plugin/test_bansheeimport.py
@@ -60,9 +60,9 @@ class TBansheeImport(PluginTestCase):
             lib.add([song])
 
             # test recovery of basic song
-            data = {"path" : song("~filename"), "rating" : 1,
-            "playcount" : 1, "skipcount" : 2,
-            "lastplayed" : 1371802107, "added" : 1260691996}
+            data = {"path": song("~filename"), "rating": 1,
+            "playcount": 1, "skipcount": 2,
+            "lastplayed": 1371802107, "added": 1260691996}
 
             db = get_example_db(data["path"], data["rating"],
                                 data["playcount"], data["skipcount"],
@@ -81,9 +81,9 @@ class TBansheeImport(PluginTestCase):
             self.assertEqual(count, 1)
 
             # test recovery of different version of same song
-            data_mod = {"path" : song("~filename"), "rating" : 2,
-            "playcount" : 4, "skipcount" : 1,
-            "lastplayed" : data["lastplayed"] - 1, "added" : data["added"] + 1}
+            data_mod = {"path": song("~filename"), "rating": 2,
+            "playcount": 4, "skipcount": 1,
+            "lastplayed": data["lastplayed"] - 1, "added": data["added"] + 1}
 
             db = get_example_db(data_mod["path"], data_mod["rating"],
                                 data_mod["playcount"], data_mod["skipcount"],

--- a/quodlibet/tests/plugin/test_bansheeimport.py
+++ b/quodlibet/tests/plugin/test_bansheeimport.py
@@ -101,3 +101,15 @@ class TBansheeImport(PluginTestCase):
             self.assertEqual(song("~#lastplayed"), data["lastplayed"])
             self.assertEqual(song("~#added"), data["added"])
             self.assertEqual(count, 1)
+
+            # test that no recovery is performed when data is identical
+            db = get_example_db(data_mod["path"], data_mod["rating"],
+                                data_mod["playcount"], data_mod["skipcount"],
+                                data_mod["lastplayed"], data_mod["added"])
+
+            importer = self.mod.BansheeDBImporter(lib)
+            importer.read(db)
+            count = importer.finish()
+            db.close()
+
+            self.assertEqual(count, 0)

--- a/quodlibet/tests/plugin/test_bansheeimport.py
+++ b/quodlibet/tests/plugin/test_bansheeimport.py
@@ -21,7 +21,7 @@ def get_example_db(song_path, rating, playcount, skipcount, lastplayed,
     # create a temporary database in memory
     db = sqlite3.connect(':memory:')
 
-    # create a trimmed version of a banshee track table
+    # create a simplified version of a banshee track table
     csr = db.cursor()
     csr.execute('''CREATE TABLE CoreTracks(
                 ArtistID INTEGER,

--- a/quodlibet/tests/plugin/test_bansheeimport.py
+++ b/quodlibet/tests/plugin/test_bansheeimport.py
@@ -55,4 +55,8 @@ class TBansheeImport(PluginTestCase):
             db = get_example_db(data["path"], data["rating"],
                                 data["lastplayed"], data["dateadded"])
 
+            importer = self.mod.BansheeDBImporter(lib)
+            importer.read(db)
+            importer.finish()
+
             db.close()

--- a/quodlibet/tests/plugin/test_bansheeimport.py
+++ b/quodlibet/tests/plugin/test_bansheeimport.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018 Phidica Veia
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+
+import sqlite3
+from senf import fsn2uri
+
+from quodlibet.formats import AudioFile
+
+from tests.helper import temp_filename
+from quodlibet.library.libraries import SongFileLibrary
+from . import PluginTestCase
+
+
+def get_example_db(song_path, rating, lastplayed, dateadded):
+    # create a temporary database in memory
+    db = sqlite3.connect(':memory:')
+
+    # create table
+    csr = db.cursor()
+    csr.execute('''CREATE TABLE CoreTracks
+                (Uri, Title, ArtistID, AlbumID, Rating, PlayCount, SkipCount,
+                LastPlayedStamp, DateAddedStamp)''')
+
+    # insert song and save
+    song_uri = fsn2uri(song_path)
+    csr.execute('INSERT INTO CoreTracks VALUES (?,?,?,?,?,?,?,?,?)',
+                (song_uri, 'Music', 1, 1, rating, 1, 2, lastplayed, dateadded))
+    db.commit()
+
+    # give the user the in-memory database
+    return db
+
+
+class TBansheeImport(PluginTestCase):
+
+    def setUp(self):
+        self.mod = self.modules["bansheeimport"]
+
+    def test(self):
+        lib = SongFileLibrary()
+
+        with temp_filename() as song_fn:
+            song = AudioFile({"~filename": song_fn})
+            song.sanitize()
+            lib.add([song])
+
+            data = {"path" : song("~filename"), "rating" : 1,
+            "lastplayed" : 1371802107, "dateadded" : 1260691996}
+
+            db = get_example_db(data["path"], data["rating"],
+                                data["lastplayed"], data["dateadded"])
+
+            db.close()

--- a/quodlibet/tests/plugin/test_bansheeimport.py
+++ b/quodlibet/tests/plugin/test_bansheeimport.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2018 Phidica Veia
 #
 # This program is free software; you can redistribute it and/or modify


### PR DESCRIPTION
Check-list
----------

 * [ ] There is a linked issue discussing the motivations for this feature or bugfix
 * [x] Unit tests have been added where possible
 * [x] ~~I've added / updated documentation for any user-facing features.~~ (Not applicable)
 * [x] Performance seems to be comparable or better than current `master`


What this change is adding / fixing
-----------------------------------

Merging this pull request would add a new plugin that imports song information from the database of the [Banshee](http://banshee.fm/) music player, to improve the quality of life for users migrating from Banshee to QL. It was modelled after the pre-existing Rhythmbox importer and works similarly to match the URI stored in the Banshee db to songs QL has added. We import the ratings, play/skip counts, date of most recent play, and date added to library.

The Banshee database is SQLite, so we simply use the standard Python `sqlite3` libary. No new dependencies are added.

I have written and included a test program for the importer.

The plugin is no more complex than the Rhythmbox importer, and, as Banshee has ceased further development, would require very little future maintenance.