### PR TITLE
player: Make external volume cubic by default

### DIFF
--- a/quodlibet/quodlibet/ext/events/mpdserver/main.py
+++ b/quodlibet/quodlibet/ext/events/mpdserver/main.py
@@ -270,7 +270,7 @@ class MPDService(object):
     def setvol(self, value):
         """value: 0..100"""
 
-        self._app.player.volume_cubic = value / 100.0
+        self._app.player.volume = value / 100.0
 
     def repeat(self, value):
         self._options.repeat = value
@@ -308,7 +308,7 @@ class MPDService(object):
             state = "stop"
 
         status = [
-            ("volume", int(app.player.volume_cubic * 100)),
+            ("volume", int(app.player.volume * 100)),
             ("repeat", int(self._options.repeat)),
             ("random", int(self._options.shuffle)),
             ("single", int(self._options.single)),

--- a/quodlibet/quodlibet/ext/events/mpris/mpris2.py
+++ b/quodlibet/quodlibet/ext/events/mpris/mpris2.py
@@ -338,7 +338,7 @@ value="false"/>
             elif name == "Shuffle":
                 player_options.shuffle = value
             elif name == "Volume":
-                player.volume_cubic = value
+                player.volume = value
 
     def get_property(self, interface, name):
         player = app.player
@@ -386,7 +386,7 @@ value="false"/>
                 return self.__get_metadata()
             elif name == "Volume":
                 # https://gitlab.freedesktop.org/mpris/mpris-spec/issues/8
-                return player.volume_cubic
+                return player.volume
             elif name == "Position":
                 return player.get_position() * 1000
             elif name == "MinimumRate":

--- a/quodlibet/quodlibet/player/_base.py
+++ b/quodlibet/quodlibet/player/_base.py
@@ -151,19 +151,12 @@ class BasePlayer(GObject.GObject, Equalizer):
 
     @property
     def volume(self):
-        return self.props.volume
+        """Use a cubic scale for the externally exposed volume"""
+        return self.props.volume ** (1.0 / 3.0)
 
     @volume.setter
     def volume(self, v):
-        self.props.volume = min(1.0, max(0.0, v))
-
-    @property
-    def volume_cubic(self):
-        return self.volume ** (1.0 / 3.0)
-
-    @volume_cubic.setter
-    def volume_cubic(self, value):
-        self.volume = value ** 3.0
+        self.props.volume = min(1.0, max(0.0, v ** 3.0))
 
     @property
     def mute(self):

--- a/quodlibet/quodlibet/player/gstbe/player.py
+++ b/quodlibet/quodlibet/player/gstbe/player.py
@@ -523,7 +523,7 @@ class GStreamerPlayer(BasePlayer, GStreamerPluginHandler):
 
         if not self.has_external_volume:
             # Restore volume/ReplayGain and mute state
-            self.volume = self._volume
+            self.props.volume = self._volume
             self.mute = self._mute
 
         # ReplayGain information gets lost when destroying

--- a/quodlibet/quodlibet/qltk/controls.py
+++ b/quodlibet/quodlibet/qltk/controls.py
@@ -75,12 +75,12 @@ class Volume(Gtk.VolumeButton):
 
     def __volume_changed(self, button, volume, player):
         player.handler_block(self._id2)
-        player.volume = volume ** 3.0
+        player.volume = volume
         player.handler_unblock(self._id2)
 
     def __volume_notify(self, player, prop):
         self.handler_block(self._id)
-        self.set_value(player.volume ** (1.0 / 3.0))
+        self.set_value(player.volume)
         self.handler_unblock(self._id)
 
     def __mute_notify(self, player, prop):
@@ -100,7 +100,7 @@ class Volume(Gtk.VolumeButton):
         # false starting point update the slider on any action on the
         # volume button.
         self.handler_block(self._id)
-        self.set_value(player.volume ** (1.0 / 3.0))
+        self.set_value(player.volume)
         self.handler_unblock(self._id)
         # same with mute
         self._update_mute(player)

--- a/quodlibet/tests/plugin/test_mpris.py
+++ b/quodlibet/tests/plugin/test_mpris.py
@@ -182,11 +182,11 @@ class TMPRIS(PluginTestCase):
             return float(self._wait()[0])
 
         assert get_volume() == 1.0
-        app.player.volume_cubic = 0.5
+        app.player.volume = 0.5
         assert get_volume() == 0.5
         self._prop().Set(piface, "Volume", 0.25, **args)
         self._wait()
-        assert app.player.volume_cubic == 0.25
+        assert app.player.volume == 0.25
 
     def test_metadata(self):
         args = {"reply_handler": self._reply, "error_handler": self._error}

--- a/quodlibet/tests/test_player.py
+++ b/quodlibet/tests/test_player.py
@@ -161,12 +161,11 @@ class TPlayerMixin(object):
 
     def test_volume_cubic(self):
         self.player.volume = 1
-        assert self.player.volume_cubic == 1
+        assert self.player.props.volume == 1
         self.player.volume = 0
-        assert self.player.volume_cubic == 0
-        self.player.volume_cubic = 0.5
-        assert self.player.volume_cubic == 0.5
-        assert self.player.volume == 0.125
+        assert self.player.props.volume == 0
+        self.player.volume = 0.5
+        assert self.player.props.volume == 0.125
 
     def test_remove(self):
         self.player.remove(None)
@@ -398,17 +397,17 @@ class TVolume(TestCase):
     def test_setget(self):
         for i in [0.0, 1.2, 0.24, 1.0, 0.9]:
             self.v.set_value(i)
-            self.failUnlessAlmostEqual(self.p.volume, self.v.get_value() ** 3)
+            self.failUnlessAlmostEqual(self.p.volume, self.v.get_value())
 
     def test_add(self):
         self.v.set_value(0.5)
         self.v += 0.1
-        self.failUnlessAlmostEqual(self.p.volume, 0.6 ** 3)
+        self.failUnlessAlmostEqual(self.p.volume, 0.6)
 
     def test_sub(self):
         self.v.set_value(0.5)
         self.v -= 0.1
-        self.failUnlessAlmostEqual(self.p.volume, 0.4 ** 3)
+        self.failUnlessAlmostEqual(self.p.volume, 0.4)
 
     def test_add_boundry(self):
         self.v.set_value(0.95)


### PR DESCRIPTION
Check-list
----------

 * [x] There is a linked issue discussing the motivations for this feature or bugfix
 * [x] Unit tests have been added where possible
 * [ ] I've added / updated documentation for any user-facing features.
 * [x] Performance seems to be comparable or better than current `master`


What this change is adding / fixing
-----------------------------------
Different parts of the codebase have gradually been changed from using a linear volume scale to a cubic one instead (see 9217dfb5d117dfdf5013cd84028db0d5e703a93d, 44aa244408aef31236a22e145dfc31565b14ca06, 1f3bb3280b93d1715469c8fb608f380a93128f3d, #3098)

This commit introduces some consistency by making a cubic volume the default. This will also fix the CLI and some plugins erroneously modifying the internal/linear volume directly.

Fixes #3125

There is a slight risk of breakage when changing the volume semantic like this, but it seems like the remaining parts of the codebase using `player.volume`  (that are not touched by this commit) are plugins that also should use the cubic volume interface.

It seems to work fine with the testing I've done, but I might have overlooked something, so feedback is welcome.