### PR TITLE
Fix waveform scroll  #3149

### DIFF
--- a/quodlibet/quodlibet/ext/events/waveformseekbar.py
+++ b/quodlibet/quodlibet/ext/events/waveformseekbar.py
@@ -561,10 +561,10 @@ class WaveformScale(Gtk.EventBox):
 
     def do_scroll_event(self, event):
         if event.direction == Gdk.ScrollDirection.UP:
-            self._player.seek(self._player.get_position() + CONFIG.seek_amount)
+            self._player.seek(self._player.get_position() - CONFIG.seek_amount)
             self.queue_draw()
         elif event.direction == Gdk.ScrollDirection.DOWN:
-            self._player.seek(self._player.get_position() - CONFIG.seek_amount)
+            self._player.seek(self._player.get_position() + CONFIG.seek_amount)
             self.queue_draw()
 
     def set_position(self, position):

--- a/quodlibet/quodlibet/ext/events/waveformseekbar.py
+++ b/quodlibet/quodlibet/ext/events/waveformseekbar.py
@@ -561,10 +561,10 @@ class WaveformScale(Gtk.EventBox):
 
     def do_scroll_event(self, event):
         if event.direction == Gdk.ScrollDirection.UP:
-            self._player.seek(self._player.get_position() - CONFIG.seek_amount)
+            self._player.seek(self._player.get_position() + CONFIG.seek_amount)
             self.queue_draw()
         elif event.direction == Gdk.ScrollDirection.DOWN:
-            self._player.seek(self._player.get_position() + CONFIG.seek_amount)
+            self._player.seek(self._player.get_position() - CONFIG.seek_amount)
             self.queue_draw()
 
     def set_position(self, position):

--- a/quodlibet/quodlibet/qltk/seekbutton.py
+++ b/quodlibet/quodlibet/qltk/seekbutton.py
@@ -185,9 +185,9 @@ class HSlider(Gtk.Button):
         v = hscale.get_value()
         direction = event.direction
         if direction in [Gdk.ScrollDirection.DOWN, Gdk.ScrollDirection.RIGHT]:
-            v += adj.props.step_increment
-        elif direction in [Gdk.ScrollDirection.UP, Gdk.ScrollDirection.LEFT]:
             v -= adj.props.step_increment
+        elif direction in [Gdk.ScrollDirection.UP, Gdk.ScrollDirection.LEFT]:
+            v += adj.props.step_increment
         else:
             # newer Gdk.ScrollDirection.SMOOTH
             return


### PR DESCRIPTION
Fixed inconsistent scrolling on waveform seekbar as described in #3149 . Now scrolling DOWN on waveform seekbar seeks forward and scrolling UP seeks backwards. The behaviour is the same as scrolling on basic display time.
Another way to fix that would be to change scrolling behaviour of basic display time but (to me) scrolling down to seek forward seems more natural.