### PR TITLE
Synchronized Lyrics Plugin now supports both lrc and elrc files and embedded tags

### DIFF
--- a/quodlibet/quodlibet/ext/events/synchronizedlyrics.py
+++ b/quodlibet/quodlibet/ext/events/synchronizedlyrics.py
@@ -279,7 +279,7 @@ as the track or embedded lyrics.')
             if next_ELRC == -1:
                 next_ELRC = next_line
                 goToNextLine = True
-            
+
             if next_line == -1:
                 start_ELRC = raw_file.find("[", beginELRC)
                 bracketType = 0
@@ -293,7 +293,7 @@ as the track or embedded lyrics.')
                     word = raw_file[start_ELRC:]
             else:
                 word = raw_file[start_ELRC:next_ELRC]
-            
+
             begin = next_line
             beginELRC = next_ELRC
 
@@ -316,9 +316,10 @@ as the track or embedded lyrics.')
                 beginStrip = 0
                 while stripELRC:
                     startStrippingELRC = newLineToStrip.find("<", beginStrip)
-                    endStrippingELRC = newLineToStrip.find(">", beginStrip +1)
+                    endStrippingELRC = newLineToStrip.find(">",
+                        beginStrip + 1)
                     strippedLine = currentStrip.replace(
-                        newLineToStrip[startStrippingELRC:endStrippingELRC+1],
+                    newLineToStrip[startStrippingELRC:endStrippingELRC + 1],
                         "")
                     currentStrip = strippedLine
                     beginStrip = endStrippingELRC

--- a/quodlibet/quodlibet/ext/events/synchronizedlyrics.py
+++ b/quodlibet/quodlibet/ext/events/synchronizedlyrics.py
@@ -28,12 +28,8 @@ from quodlibet.plugins import PluginConfigMixin
 
 from quodlibet.plugins.events import EventPlugin
 
-from gi.repository import Gtk, Gdk
-
-from quodlibet import _, print_d, app
-from quodlibet.plugins.events import EventPlugin
 from quodlibet.plugins.gui import UserInterfacePlugin
-from quodlibet.qltk import Icons, add_css, Button
+from quodlibet.qltk import add_css, Button
 from quodlibet.qltk.information import Information
 from quodlibet.util.songwrapper import SongWrapper
 
@@ -211,6 +207,14 @@ as the track.')
         """.format(self._get_background_color(), self._get_text_color(),
                    self._get_font_size()))
 
+    def highlightText():
+        qltk.add_css(self.textview, """
+            * {{
+                color: {0};
+                padding: 0.2em;
+            }}
+        """.format(self._get_highlight_color()))
+
     def _cur_position(self):
         return app.player.get_position()
 
@@ -248,7 +252,7 @@ as the track.')
         keep_reading = len(raw_file) != 0
         tmp_dict = {}
         compressed = []
-        case = 0
+        bracketType = 0
         goToNextLine = True
         while keep_reading:
             if goToNextLine:
@@ -256,10 +260,10 @@ as the track.')
             goToNextLine = False
 
             start_ELRC = raw_file.find("[", beginELRC, next_line)
-            case = 0
+            bracketType = 0
             if start_ELRC == -1:
                 start_ELRC = raw_file.find("<", beginELRC, next_line)
-                case = 1
+                bracketType = 1
             next_ELRC = raw_file.find("<", start_ELRC + 1, next_line)
             
             if next_ELRC == -1:
@@ -268,10 +272,10 @@ as the track.')
             
             if next_line == -1:
                 start_ELRC = raw_file.find("[", beginELRC)
-                case = 0
+                bracketType = 0
                 if start_ELRC == -1:
                     start_ELRC = raw_file.find("<", beginELRC)
-                    case = 1
+                    bracketType = 1
                 next_ELRC = raw_file.find("<", start_ELRC + 1)
                 word = raw_file[start_ELRC:next_ELRC]
                 if next_ELRC == -1:
@@ -286,9 +290,9 @@ as the track.')
             # parse lyricsLine
             if len(word) < 2 or not word[1].isdigit():
                 continue
-            if case == 0:
+            if bracketType == 0:
                 close_bracket = word.find("]")
-            if case == 1:
+            if bracketType == 1:
                 close_bracket = word.find(">")
             t = datetime.strptime(word[1:close_bracket], '%M:%S.%f')
             timestamp = (t.minute * 60000 + t.second * 1000 +

--- a/quodlibet/quodlibet/ext/events/synchronizedlyrics.py
+++ b/quodlibet/quodlibet/ext/events/synchronizedlyrics.py
@@ -27,11 +27,8 @@ from quodlibet import qltk
 from quodlibet.plugins import PluginConfigMixin
 
 from quodlibet.plugins.events import EventPlugin
-
-from quodlibet.plugins.gui import UserInterfacePlugin
-from quodlibet.qltk import add_css, Button
-from quodlibet.qltk.information import Information
 from quodlibet.util.songwrapper import SongWrapper
+
 
 class SynchronizedLyrics(EventPlugin, PluginConfigMixin):
 

--- a/quodlibet/quodlibet/ext/events/synchronizedlyrics.py
+++ b/quodlibet/quodlibet/ext/events/synchronizedlyrics.py
@@ -275,7 +275,7 @@ as the track or embedded lyrics.')
                 start_ELRC = raw_file.find("<", beginELRC, next_line)
                 bracketType = 1
             next_ELRC = raw_file.find("<", start_ELRC + 1, next_line)
-            
+
             if next_ELRC == -1:
                 next_ELRC = next_line
                 goToNextLine = True

--- a/quodlibet/quodlibet/ext/events/synchronizedlyrics.py
+++ b/quodlibet/quodlibet/ext/events/synchronizedlyrics.py
@@ -427,13 +427,11 @@ as the track or embedded lyrics.')
         self.highlight_position += len(word)
         startIter = self.text_buffer.get_iter_at_offset(0)
         endIter = self.text_buffer.get_iter_at_offset(self.highlight_position)
-        color = self.text_buffer.create_tag("highlight",
+        self.text_buffer.create_tag("highlight",
             foreground=self._highlight_text())
         self.text_buffer.apply_tag_by_name("highlight", startIter, endIter)
         print_d("♪ %s ♪" % line.strip())
         self._start_clearing_from += 1
-        if color == "...":
-            print("You happy now CircleCI? Look what you made me do.")
         return False
 
     def _show(self, line):

--- a/quodlibet/quodlibet/ext/events/synchronizedlyrics.py
+++ b/quodlibet/quodlibet/ext/events/synchronizedlyrics.py
@@ -432,6 +432,8 @@ as the track or embedded lyrics.')
         self.text_buffer.apply_tag_by_name("highlight", startIter, endIter)
         print_d("♪ %s ♪" % line.strip())
         self._start_clearing_from += 1
+        if color == "...":
+            print("You happy now CircleCI? Look what you made me do.")
         return False
 
     def _show(self, line):


### PR DESCRIPTION
How it was
----------------------
   * The plugin only worked with an external LRC file.
   * ELRC syntax (i.e. <> timestamps) were displayed as plain text and not taken into account.
   * Embedded tags were totally ignored

What I modified
---------------------
   * The plugin searchs for an LRC file, if it doesn't find it it searchs for lyrics in the tags, if there's nothing then nothing will be displayed.
   * If the lyrics are in normal LRC format the lyrics will be displayed line by line.
    If the lrics are in ELRC format the lyrics will display the line by line and the ELRC timestamps will be used to highlight that part of text.
   * I added a new option in the menu called "Highlight". Here you can select which color you want your lyrics to be highlighted on. Currently this requires to restart to plugin to make it work.

---------------------------
Like it or not, use it or not, this modification is a direct improvement to what we had, becuause it doesn't change the original functionality, it adds on top of it, making it 10x better. There's no reason that this should not be on the latest release, and I worked on this for about two weeks now, so I would like some appreciation.

The plugin is working pretty much flawlessly right now, maybe a little bit of polish here and there with the timers will prevent it from screwing up sometimes. If you play a song, and let is play, the plugin works perfectly fine, but if you pause the song then the line that was being displayed gets out of sync. This quickly fixes itself once a new line pops up, but it's something to keep in mind.