### PR TITLE
Closes #3179: Tracks without track number are now sorted before first track (Same for disk numbers)

### DIFF
--- a/quodlibet/quodlibet/formats/_audio.py
+++ b/quodlibet/quodlibet/formats/_audio.py
@@ -136,7 +136,7 @@ class AudioFile(dict, ImageContainer):
             self[key] = value
 
     def __song_key(self):
-        return (self("~#disc", 1), self("~#track", 1),
+        return (self("~#disc", 0), self("~#track", 0),
             human(self("artistsort")),
             self.get("musicbrainz_artistid", ""),
             human(self.get("title", "")),

--- a/quodlibet/tests/test_formats__audio.py
+++ b/quodlibet/tests/test_formats__audio.py
@@ -876,12 +876,12 @@ class TAudioFile(TestCase):
 
     def test_sort_key_defaults(self):
         AF = AudioFile
-        assert AF().sort_key == AF({"tracknumber": "1"}).sort_key
-        assert AF().sort_key == AF({"tracknumber": "1/1"}).sort_key
+        assert AF().sort_key == AF({"tracknumber": "0"}).sort_key
+        assert AF().sort_key != AF({"tracknumber": "1/1"}).sort_key
         assert AF().sort_key < AF({"tracknumber": "2/2"}).sort_key
 
-        assert AF().sort_key == AF({"discnumber": "1"}).sort_key
-        assert AF().sort_key == AF({"discnumber": "1/1"}).sort_key
+        assert AF().sort_key == AF({"discnumber": "0"}).sort_key
+        assert AF().sort_key != AF({"discnumber": "1/1"}).sort_key
         assert AF().sort_key < AF({"discnumber": "2/2"}).sort_key
 
     def test_sort_cache(self):


### PR DESCRIPTION
before:
![before fix](https://user-images.githubusercontent.com/3063858/59974534-a0bafa80-95ad-11e9-88bd-c140037f084d.png)

now:
![before after fix](https://user-images.githubusercontent.com/3063858/59974535-a284be00-95ad-11e9-9e68-715d1c42118f.png)
