### PR TITLE
Cutom Commands: Make description row translatable

### DIFF
--- a/quodlibet/quodlibet/ext/songsmenu/custom_commands.py
+++ b/quodlibet/quodlibet/ext/songsmenu/custom_commands.py
@@ -126,7 +126,7 @@ class Command(JSONObject):
                 or "playlistindex" in self.pattern)
 
     def __str__(self):
-        return 'Command: "{command} {pattern}"'.format(**dict(self.data))
+        return _('Command: "{command} {pattern}"').format(**dict(self.data))
 
 
 class CustomCommands(PlaylistPlugin, SongsMenuPlugin, PluginConfigMixin):


### PR DESCRIPTION
Make the description row in the custom-commands window translatable. The word _Command_ was not translatable, as can be seen in the attached screenshot:

![custom-commands](https://user-images.githubusercontent.com/5852189/60685226-2db15e00-9ea2-11e9-9f1f-520577b381e9.png)

I think it would be even nicer to remove the word _Command_ from that row altogether, and just display the actual command there. It should be clear from the context what it is. So it would be, e.g.:

**Compress files**
file-roller -d <~filename>

instead of:

**Compress files**
Command: "file-roller -d <~filename>"

I can do another PR, if this is desired.
