### PR TITLE
Custom Commands: Remove superfluous tooltip

### DIFF
--- a/quodlibet/quodlibet/ext/songsmenu/custom_commands.py
+++ b/quodlibet/quodlibet/ext/songsmenu/custom_commands.py
@@ -204,8 +204,6 @@ class CustomCommands(PlaylistPlugin, SongsMenuPlugin, PluginConfigMixin):
         hb.set_border_width(0)
 
         button = qltk.Button(_("Edit Custom Commands") + "…", Icons.EDIT)
-        button.set_tooltip_markup(_("Supports QL patterns\neg "
-                                    "<tt>&lt;~artist~title&gt;</tt>"))
         button.connect("clicked", cls.edit_patterns)
         hb.pack_start(button, True, True, 0)
         hb.show_all()


### PR DESCRIPTION
The tooltip on the _Edit Custom Commands_ button in the plugin window has a confusing tooltip. At least it confused me at first. What does it refer to? The fact that you can use QL patterns in the command definition? This is already mentioned in the plugin description and explained in-depth in the tooltip on the _Pattern_ field when editing a command.

It seems safe to remove to me.