### PR TITLE
Small string fixes

### DIFF
--- a/quodlibet/quodlibet/ext/events/mqtt.py
+++ b/quodlibet/quodlibet/ext/events/mqtt.py
@@ -134,11 +134,11 @@ class MqttPublisherPlugin(EventPlugin, PluginConfigMixin):
 
         (_("Playing Pattern"),
          Config.PAT_PLAYING,
-         _("Status text when a song is started.") + _ACCEPTS_PATTERNS),
+         _("Status text when a song is started.") + ' ' + _ACCEPTS_PATTERNS),
 
         (_("Paused Pattern"),
          Config.PAT_PAUSED,
-         _("Text when a song is paused.") + _ACCEPTS_PATTERNS),
+         _("Text when a song is paused.") + ' ' + _ACCEPTS_PATTERNS),
 
         (_("No-song Text"),
          Config.STATUS_SONGLESS,

--- a/quodlibet/quodlibet/ext/events/mqtt.py
+++ b/quodlibet/quodlibet/ext/events/mqtt.py
@@ -128,7 +128,7 @@ class MqttPublisherPlugin(EventPlugin, PluginConfigMixin):
         (_("Broker hostname"), Config.HOST,
          _("broker hostname / IP (defaults to localhost)")),
 
-        (_("Broker port"), Config.PORT, _("broker port (defaults to 1883")),
+        (_("Broker port"), Config.PORT, _("broker port (defaults to 1883)")),
 
         (_("Topic"), Config.TOPIC, _("Topic")),
 


### PR DESCRIPTION
Fixes incomplete parentheses and spaces missing between sentences in tooltips in the MQTT Publisher plugin.

For the spaces: Is the fix done like this okay, or would it be better to combine the tooltip strings into one for each (duplicating the _Accepts QL patterns …_ text)?