### PR TITLE
Consistent simple tooltips wrt. period at the end

### DIFF
--- a/quodlibet/quodlibet/ext/_shared/squeezebox/base.py
+++ b/quodlibet/quodlibet/ext/_shared/squeezebox/base.py
@@ -127,7 +127,7 @@ class SqueezeboxPluginMixin(PluginConfigMixin):
 
         ve = UndoEntry()
         ve.set_text(str(cfg["library_dir"]))
-        ve.set_tooltip_text(_("Library directory the server connects to."))
+        ve.set_tooltip_text(_("Library directory the server connects to"))
         ve.connect('changed', value_changed, 'server_library_dir')
         rows.append((Gtk.Label(label=_("Library path:")), ve))
 

--- a/quodlibet/quodlibet/ext/events/gajim_status.py
+++ b/quodlibet/quodlibet/ext/events/gajim_status.py
@@ -162,7 +162,7 @@ class GajimStatusMessage(EventPlugin):
         c.set_active(self.paused)
         c.connect('toggled', self.paused_changed)
         c.set_tooltip_text(_("If checked, '[paused]' will be added to "
-                             "status message on pause."))
+                             "status message on pause"))
 
         table = Gtk.Table()
         self.list = []

--- a/quodlibet/quodlibet/ext/events/qlscrobbler.py
+++ b/quodlibet/quodlibet/ext/events/qlscrobbler.py
@@ -570,7 +570,7 @@ class QLScrobbler(EventPlugin):
         entry = ValidatingEntry(Query.validator)
         entry.set_text(plugin_config.get('exclude'))
         entry.set_tooltip_text(
-                _("Songs matching this filter will not be submitted."))
+                _("Songs matching this filter will not be submitted"))
         entry.connect('changed', changed, 'exclude')
         table.attach(entry, 1, 2, row, row + 1)
         labels[row].set_mnemonic_widget(entry)

--- a/quodlibet/quodlibet/player/gstbe/prefs.py
+++ b/quodlibet/quodlibet/player/gstbe/prefs.py
@@ -68,7 +68,7 @@ class GstPlayerPreferences(Gtk.VBox):
         gapless_button.set_alignment(0.0, 0.5)
         gapless_button.set_tooltip_text(
             _("Disabling gapless playback can avoid track changing problems "
-              "with some GStreamer versions."))
+              "with some GStreamer versions"))
 
         widgets = [(pipe_label, e, apply_button),
                    (buffer_label, scale, None),

--- a/quodlibet/quodlibet/qltk/searchbar.py
+++ b/quodlibet/quodlibet/qltk/searchbar.py
@@ -144,7 +144,7 @@ class SearchBarBox(Gtk.Box):
             _("Search after _typing"), 'settings', 'eager_search',
             populate=True)
         cb.set_tooltip_text(
-            _("Show search results after the user stops typing."))
+            _("Show search results after the user stops typing"))
         cb.show()
         menu.prepend(cb)
 


### PR DESCRIPTION
Fix some instances of simple tooltips ending in a period. They shouldn't.

Regarding tooltips using multiple sentences, see #3209.