### PR TITLE
Restarting

### DIFF
--- a/quodlibet/quodlibet/_main.py
+++ b/quodlibet/quodlibet/_main.py
@@ -59,6 +59,9 @@ class Application(object):
     is_quitting = False
     """True after quit() is called at least once"""
 
+    restart = False
+    """True if the program should restart after quitting"""
+
     @property
     def icon_name(self):
         return self.id
@@ -75,9 +78,10 @@ class Application(object):
     def browser(self):
         return self.window.browser
 
-    def quit(self):
+    def quit(self, *, restart=False):
         from gi.repository import GLib
 
+        self.restart = restart
         self.is_quitting = True
 
         def idle_quit():

--- a/quodlibet/quodlibet/errorreport/main.py
+++ b/quodlibet/quodlibet/errorreport/main.py
@@ -101,7 +101,7 @@ def run_error_dialogs(exc_info, sentry_error):
         response = dialog.run()
         if response == ErrorDialog.RESPONSE_QUIT:
             dialog.destroy()
-            app.quit()
+            app.quit(restart=True)
         elif response == ErrorDialog.RESPONSE_SUBMIT:
             dialog.hide()
             submit_dialog = SubmitErrorDialog(

--- a/quodlibet/quodlibet/errorreport/ui.py
+++ b/quodlibet/quodlibet/errorreport/ui.py
@@ -67,7 +67,7 @@ class ErrorDialog(Gtk.MessageDialog):
         self.set_transient_for(parent)
         self.set_modal(True)
         self.add_button(_("Submit Error Report"), self.RESPONSE_SUBMIT)
-        self.add_button(_("Quit Program"), self.RESPONSE_QUIT)
+        self.add_button(_("Restart"), self.RESPONSE_QUIT)
         self.add_button(_("Ignore Error"), Gtk.ResponseType.CANCEL)
         self.set_default_response(Gtk.ResponseType.CANCEL)
 

--- a/quodlibet/quodlibet/main.py
+++ b/quodlibet/quodlibet/main.py
@@ -215,3 +215,6 @@ def main(argv=None):
     session_client.close()
 
     print_d("Finished shutdown.")
+
+    if app.restart:
+        os.execv(sys.executable, ["python"] + sys.argv)

--- a/quodlibet/quodlibet/qltk/quodlibetwindow.py
+++ b/quodlibet/quodlibet/qltk/quodlibetwindow.py
@@ -407,6 +407,7 @@ MENU = """
       <separator/>
       <menuitem action='RefreshLibrary' always-show-image='true'/>
       <separator/>
+      <menuitem action='Restart' always-show-image='true'/>
       <menuitem action='Quit' always-show-image='true'/>
     </menu>
 
@@ -911,6 +912,10 @@ class QuodLibetWindow(Window, PersistentWindowMixin, AppWindow):
         act = Action(name="Plugins", label=_('_Plugins'),
                      icon_name=Icons.SYSTEM_RUN)
         act.connect('activate', self.__plugins)
+        ag.add_action(act)
+
+        act = Action(name="Restart", label=_('_Restart'))
+        act.connect('activate', lambda *x: app.quit(restart=True))
         ag.add_action(act)
 
         act = Action(name="Quit", label=_('_Quit'),


### PR DESCRIPTION
Fixes #2376. In addition to adding a restart button on the crash reporter I've also added a restart button to the file menu above Quit.

On windows this solution has the annoying behaviour of the old process appearing to exit and the new process just using the same console. What I've read seems to suggest that on unix it'll replace the process nicely though and there doesn't seem to be a good way of doing that on windows.

I think what I've got for communicating when to restart is ok though I'm open to suggestions if anyone has anything they'd prefer.