### PR TITLE
Adapt po files after tooltip punctuation fixes in #3208

### DIFF
--- a/quodlibet/po/da.po
+++ b/quodlibet/po/da.po
@@ -1650,9 +1650,9 @@ msgid "Add '[paused]'"
 msgstr "Tilføj '[sat på pause]'"
 
 #: ../quodlibet/ext/events/gajim_status.py:165
-msgid "If checked, '[paused]' will be added to status message on pause."
+msgid "If checked, '[paused]' will be added to status message on pause"
 msgstr ""
-"Hvis tilvalgt, tilføjes '[sat på pause]' til statusmeddelelse ved pause."
+"Hvis tilvalgt, tilføjes '[sat på pause]' til statusmeddelelse ved pause"
 
 #: ../quodlibet/ext/events/gajim_status.py:189
 msgid "Statuses for which message will be changed"
@@ -2039,8 +2039,8 @@ msgstr ""
 "standard."
 
 #: ../quodlibet/ext/events/qlscrobbler.py:574
-msgid "Songs matching this filter will not be submitted."
-msgstr "Sange som matcher dette filter vil ikke blive indsendt."
+msgid "Songs matching this filter will not be submitted"
+msgstr "Sange som matcher dette filter vil ikke blive indsendt"
 
 #: ../quodlibet/ext/events/qlscrobbler.py:582
 msgid "_Offline mode (don't submit anything)"
@@ -3016,8 +3016,8 @@ msgid "Password:"
 msgstr "Adgangskode:"
 
 #: ../quodlibet/ext/_shared/squeezebox/base.py:131
-msgid "Library directory the server connects to."
-msgstr "Biblioteksmappe som serveren opretter forbindelse til."
+msgid "Library directory the server connects to"
+msgstr "Biblioteksmappe som serveren opretter forbindelse til"
 
 #: ../quodlibet/ext/_shared/squeezebox/base.py:133
 msgid "Library path:"
@@ -4463,10 +4463,10 @@ msgstr "Deaktivér afspilning uden _huller"
 #: ../quodlibet/player/gstbe/prefs.py:71
 msgid ""
 "Disabling gapless playback can avoid track changing problems with some "
-"GStreamer versions."
+"GStreamer versions"
 msgstr ""
 "Deaktivering af afspilning uden huller kan forhindre problemer ved skift af "
-"spor med nogle versioner af GStreamer."
+"spor med nogle versioner af GStreamer"
 
 #: ../quodlibet/player/gstbe/util.py:103
 msgid "No GStreamer audio sink found"
@@ -5883,8 +5883,8 @@ msgid "Search after _typing"
 msgstr "Søg efter _skrivning"
 
 #: ../quodlibet/qltk/searchbar.py:145
-msgid "Show search results after the user stops typing."
-msgstr "Vis søgeresultater når brugeren stopper med at skrive."
+msgid "Show search results after the user stops typing"
+msgstr "Vis søgeresultater når brugeren stopper med at skrive"
 
 #: ../quodlibet/qltk/searchbar.py:212
 msgid "_Limit:"

--- a/quodlibet/po/el.po
+++ b/quodlibet/po/el.po
@@ -1795,10 +1795,10 @@ msgid "Add '[paused]'"
 msgstr "παυμένο"
 
 #: ../quodlibet/ext/events/gajim_status.py:163
-msgid "If checked, '[paused]' will be added to status message on pause."
+msgid "If checked, '[paused]' will be added to status message on pause"
 msgstr ""
 "Αν τσεκαριστεί κατά την παύση θα προστεθεί το '[paused]' στο μήνυμα "
-"κατάστασης."
+"κατάστασης"
 
 #: ../quodlibet/ext/events/gajim_status.py:187
 #, fuzzy
@@ -2239,8 +2239,8 @@ msgstr ""
 "για τη χρήση προκαθορισμένου."
 
 #: ../quodlibet/ext/events/qlscrobbler.py:568
-msgid "Songs matching this filter will not be submitted."
-msgstr "Τα τραγούδια που ταιριάζουν με αυτό το φίλτρο δεν θα υποβάλλονται."
+msgid "Songs matching this filter will not be submitted"
+msgstr "Τα τραγούδια που ταιριάζουν με αυτό το φίλτρο δεν θα υποβάλλονται"
 
 #: ../quodlibet/ext/events/qlscrobbler.py:576
 msgid "_Offline mode (don't submit anything)"
@@ -3052,8 +3052,8 @@ msgid "Password:"
 msgstr "Κωδικός:"
 
 #: ../quodlibet/ext/_shared/squeezebox/base.py:130
-msgid "Library directory the server connects to."
-msgstr "Κατάλογος μουσικοθήκης στον οποίο συνδέεται ο διακομιστής."
+msgid "Library directory the server connects to"
+msgstr "Κατάλογος μουσικοθήκης στον οποίο συνδέεται ο διακομιστής"
 
 #: ../quodlibet/ext/_shared/squeezebox/base.py:132
 msgid "Library path:"
@@ -4408,10 +4408,10 @@ msgstr "Απενεργοποίηση αναπαραγωγής χωρίς κεν�
 #: ../quodlibet/player/gstbe/prefs.py:70
 msgid ""
 "Disabling gapless playback can avoid track changing problems with some "
-"GStreamer versions."
+"GStreamer versions"
 msgstr ""
 "Η απενεργοποίηση της αναπαραγωγής χωρίς κενά μερικές φορές αποτρέπει "
-"προβλήματα αλλαγής τραγουδιών με ορισμένες εκδόσεις του Gstreamer."
+"προβλήματα αλλαγής τραγουδιών με ορισμένες εκδόσεις του Gstreamer"
 
 #: ../quodlibet/player/gstbe/util.py:93
 msgid "No GStreamer audio sink found"
@@ -5836,7 +5836,7 @@ msgid "Search after _typing"
 msgstr "Αναζήτηση με την _πληκτρολόγηση"
 
 #: ../quodlibet/qltk/searchbar.py:132
-msgid "Show search results after the user stops typing."
+msgid "Show search results after the user stops typing"
 msgstr ""
 "Εμφάνισε τα αποτελέσματα αναζήτησης αφού ο χρήστης σταματήσει την "
 "πληκτρολόγηση"

--- a/quodlibet/po/es.po
+++ b/quodlibet/po/es.po
@@ -5933,8 +5933,8 @@ msgid "Search after _typing"
 msgstr "Buscar despues de _escribir"
 
 #: ../quodlibet/qltk/searchbar.py:132
-msgid "Show search results after the user stops typing."
-msgstr "Mostrar los resultados después de terminar de escribir."
+msgid "Show search results after the user stops typing"
+msgstr "Mostrar los resultados después de terminar de escribir"
 
 #: ../quodlibet/qltk/searchbar.py:187
 msgid "_Limit:"

--- a/quodlibet/po/eu.po
+++ b/quodlibet/po/eu.po
@@ -5903,9 +5903,9 @@ msgid "Search after _typing"
 msgstr "Bilatu ida_tzi ondoren"
 
 #: ../quodlibet/qltk/searchbar.py:132
-msgid "Show search results after the user stops typing."
+msgid "Show search results after the user stops typing"
 msgstr ""
-"Bistarazi bilaketa emaitzak erabiltzaileak tekleatzeari utzi bezain laster."
+"Bistarazi bilaketa emaitzak erabiltzaileak tekleatzeari utzi bezain laster"
 
 #: ../quodlibet/qltk/searchbar.py:187
 msgid "_Limit:"

--- a/quodlibet/po/fi.po
+++ b/quodlibet/po/fi.po
@@ -1660,10 +1660,10 @@ msgid "Add '[paused]'"
 msgstr "Lisää ”[keskeytetty]”"
 
 #: ../quodlibet/ext/events/gajim_status.py:165
-msgid "If checked, '[paused]' will be added to status message on pause."
+msgid "If checked, '[paused]' will be added to status message on pause"
 msgstr ""
 "Jos valittu, teksti ”[keskeytetty]” lisätään tilaviestiin toiston ollessa "
-"keskeytetty."
+"keskeytetty"
 
 #: ../quodlibet/ext/events/gajim_status.py:189
 msgid "Statuses for which message will be changed"
@@ -2050,8 +2050,8 @@ msgstr ""
 "tyhjäksi käyttääksesi oletusasetusta."
 
 #: ../quodlibet/ext/events/qlscrobbler.py:574
-msgid "Songs matching this filter will not be submitted."
-msgstr "Tähän suodattimeen täsmääviä kappaleita ei lähetetä."
+msgid "Songs matching this filter will not be submitted"
+msgstr "Tähän suodattimeen täsmääviä kappaleita ei lähetetä"
 
 #: ../quodlibet/ext/events/qlscrobbler.py:582
 msgid "_Offline mode (don't submit anything)"
@@ -3040,8 +3040,8 @@ msgid "Password:"
 msgstr "Salasana:"
 
 #: ../quodlibet/ext/_shared/squeezebox/base.py:131
-msgid "Library directory the server connects to."
-msgstr "Kirjastokansio, johon palvelin kytkeytyy."
+msgid "Library directory the server connects to"
+msgstr "Kirjastokansio, johon palvelin kytkeytyy"
 
 #: ../quodlibet/ext/_shared/squeezebox/base.py:133
 msgid "Library path:"
@@ -4497,10 +4497,10 @@ msgstr "Poista katkoton toisto käytöstä"
 #: ../quodlibet/player/gstbe/prefs.py:71
 msgid ""
 "Disabling gapless playback can avoid track changing problems with some "
-"GStreamer versions."
+"GStreamer versions"
 msgstr ""
 "Katkottoman toiston poistamisella käytöstä voi välttää kappaleen vaihtumisen "
-"ongelmat joidenkin GStreamerin versioiden kanssa."
+"ongelmat joidenkin GStreamerin versioiden kanssa"
 
 #: ../quodlibet/player/gstbe/util.py:103
 msgid "No GStreamer audio sink found"
@@ -5919,7 +5919,7 @@ msgid "Search after _typing"
 msgstr "Päivitä hakutuloksia jatkuvasti"
 
 #: ../quodlibet/qltk/searchbar.py:145
-msgid "Show search results after the user stops typing."
+msgid "Show search results after the user stops typing"
 msgstr "Päivitä haun tuloksia jatkuvasti kirjoituksen aikana"
 
 #: ../quodlibet/qltk/searchbar.py:212

--- a/quodlibet/po/fr.po
+++ b/quodlibet/po/fr.po
@@ -1702,8 +1702,8 @@ msgid "Add '[paused]'"
 msgstr "Ajouter '[paused]'"
 
 #: quodlibet/ext/events/gajim_status.py:164
-msgid "If checked, '[paused]' will be added to status message on pause."
-msgstr "Si coché, '[paused]' sera ajouté au message de statut en pause."
+msgid "If checked, '[paused]' will be added to status message on pause"
+msgstr "Si coché, '[paused]' sera ajouté au message de statut en pause"
 
 #: quodlibet/ext/events/gajim_status.py:188
 msgid "Statuses for which message will be changed"
@@ -2098,8 +2098,8 @@ msgstr ""
 "la valeur par défaut."
 
 #: quodlibet/ext/events/qlscrobbler.py:573
-msgid "Songs matching this filter will not be submitted."
-msgstr "Les titres correspondant à cette recherche ne seront pas soumis."
+msgid "Songs matching this filter will not be submitted"
+msgstr "Les titres correspondant à cette recherche ne seront pas soumis"
 
 #: quodlibet/ext/events/qlscrobbler.py:581
 msgid "_Offline mode (don't submit anything)"
@@ -3107,8 +3107,8 @@ msgid "Password:"
 msgstr "Mot de passe :"
 
 #: quodlibet/ext/_shared/squeezebox/base.py:130
-msgid "Library directory the server connects to."
-msgstr "Répertoire la bibliothèque auquel le serveur se connecte."
+msgid "Library directory the server connects to"
+msgstr "Répertoire la bibliothèque auquel le serveur se connecte"
 
 #: quodlibet/ext/_shared/squeezebox/base.py:132
 msgid "Library path:"
@@ -4565,10 +4565,10 @@ msgstr "Désactiver la _lecture sans blanc"
 #: quodlibet/player/gstbe/prefs.py:70
 msgid ""
 "Disabling gapless playback can avoid track changing problems with some "
-"GStreamer versions."
+"GStreamer versions"
 msgstr ""
 "Désactiver la lecture sans blanc peut éviter les problèmes de changement de "
-"piste avec certaines versions de GStreamer."
+"piste avec certaines versions de GStreamer"
 
 #: quodlibet/player/gstbe/util.py:101
 msgid "No GStreamer audio sink found"
@@ -6050,7 +6050,7 @@ msgid "Search after _typing"
 msgstr "Rechercher après avoir _tapé au clavier"
 
 #: quodlibet/qltk/searchbar.py:147
-msgid "Show search results after the user stops typing."
+msgid "Show search results after the user stops typing"
 msgstr ""
 "Afficher le résultat d'une recherche dès que l'utilisateur a terminé la "
 "saisie"

--- a/quodlibet/po/gl.po
+++ b/quodlibet/po/gl.po
@@ -5921,8 +5921,8 @@ msgid "Search after _typing"
 msgstr "Procurar despois de _escrever"
 
 #: ../quodlibet/qltk/searchbar.py:132
-msgid "Show search results after the user stops typing."
-msgstr "Mostrar os resultados despois de rematar de escrever."
+msgid "Show search results after the user stops typing"
+msgstr "Mostrar os resultados despois de rematar de escrever"
 
 #: ../quodlibet/qltk/searchbar.py:187
 msgid "_Limit:"

--- a/quodlibet/po/he.po
+++ b/quodlibet/po/he.po
@@ -1129,8 +1129,8 @@ msgid "Password:"
 msgstr "סיסמה:"
 
 #: quodlibet/ext/_shared/squeezebox/base.py:130
-msgid "Library directory the server connects to."
-msgstr "מחיצת הספריה אליה מתחבר השרת."
+msgid "Library directory the server connects to"
+msgstr "מחיצת הספריה אליה מתחבר השרת"
 
 #: quodlibet/ext/_shared/squeezebox/base.py:132
 msgid "Library path:"
@@ -1637,8 +1637,8 @@ msgid "Add '[paused]'"
 msgstr "הוספה '[מושהה]'"
 
 #: quodlibet/ext/events/gajim_status.py:164
-msgid "If checked, '[paused]' will be added to status message on pause."
-msgstr "אם סומן, '[משהה]' יתווסף למצב הודעה בזמן השהיה."
+msgid "If checked, '[paused]' will be added to status message on pause"
+msgstr "אם סומן, '[משהה]' יתווסף למצב הודעה בזמן השהיה"
 
 #: quodlibet/ext/events/gajim_status.py:188
 msgid "Statuses for which message will be changed"
@@ -2016,8 +2016,8 @@ msgid "The pattern used to format the title for submission. Leave blank for defa
 msgstr "הדפוס משמש לתִּיבְנוּת כותרת לשגור. להשאיר ריק לברירת המחדל."
 
 #: quodlibet/ext/events/qlscrobbler.py:573
-msgid "Songs matching this filter will not be submitted."
-msgstr "שירים התואמים למסנן זה לא ישוגרו."
+msgid "Songs matching this filter will not be submitted"
+msgstr "שירים התואמים למסנן זה לא ישוגרו"
 
 #: quodlibet/ext/events/qlscrobbler.py:581
 msgid "_Offline mode (don't submit anything)"
@@ -4304,9 +4304,9 @@ msgstr "נטרול השמעת _נטול פערים"
 #: quodlibet/player/gstbe/prefs.py:70
 msgid ""
 "Disabling gapless playback can avoid track changing problems with some GStreamer "
-"versions."
+"versions"
 msgstr ""
-"השבתת השמעת נטול פערים עשוי למנוע בעיות בהחלפת רצועה בעלת מספר גרסאות ג'סטרימר."
+"השבתת השמעת נטול פערים עשוי למנוע בעיות בהחלפת רצועה בעלת מספר גרסאות ג'סטרימר"
 
 #: quodlibet/player/gstbe/util.py:101
 msgid "No GStreamer audio sink found"
@@ -5688,8 +5688,8 @@ msgid "Search after _typing"
 msgstr "חיפוש לאחר _הקלדה"
 
 #: quodlibet/qltk/searchbar.py:147
-msgid "Show search results after the user stops typing."
-msgstr "הצגת תוצאות חיפוש מיד לאחר סיום הקלדה."
+msgid "Show search results after the user stops typing"
+msgstr "הצגת תוצאות חיפוש מיד לאחר סיום הקלדה"
 
 #: quodlibet/qltk/searchbar.py:215
 msgid "_Limit:"

--- a/quodlibet/po/it.po
+++ b/quodlibet/po/it.po
@@ -5864,7 +5864,7 @@ msgid "Search after _typing"
 msgstr "Cerca dopo aver digitato"
 
 #: ../quodlibet/qltk/searchbar.py:132
-msgid "Show search results after the user stops typing."
+msgid "Show search results after the user stops typing"
 msgstr "Mostra i risultati della ricerca dopo che l'utente smette di scrivere"
 
 #: ../quodlibet/qltk/searchbar.py:187

--- a/quodlibet/po/lt.po
+++ b/quodlibet/po/lt.po
@@ -5879,8 +5879,8 @@ msgid "Search after _typing"
 msgstr "Ieško_ti bevedant užklausą"
 
 #: ../quodlibet/qltk/searchbar.py:132
-msgid "Show search results after the user stops typing."
-msgstr "Rodyti paieškos rezultatus vartotojui baigus įvesti užklausą."
+msgid "Show search results after the user stops typing"
+msgstr "Rodyti paieškos rezultatus vartotojui baigus įvesti užklausą"
 
 #: ../quodlibet/qltk/searchbar.py:187
 msgid "_Limit:"

--- a/quodlibet/po/lv.po
+++ b/quodlibet/po/lv.po
@@ -5884,9 +5884,9 @@ msgid "Search after _typing"
 msgstr "Meklēt pēc ieraks_tīšanas"
 
 #: ../quodlibet/qltk/searchbar.py:132
-msgid "Show search results after the user stops typing."
+msgid "Show search results after the user stops typing"
 msgstr ""
-"Parāda meklējuma rezultātus pēc tam, kad lietotājs ir pārtraucis rakstīt."
+"Parāda meklējuma rezultātus pēc tam, kad lietotājs ir pārtraucis rakstīt"
 
 #: ../quodlibet/qltk/searchbar.py:187
 msgid "_Limit:"

--- a/quodlibet/po/nb.po
+++ b/quodlibet/po/nb.po
@@ -1641,9 +1641,9 @@ msgid "Add '[paused]'"
 msgstr "Legg til «[på pause]»"
 
 #: ../quodlibet/ext/events/gajim_status.py:165
-msgid "If checked, '[paused]' will be added to status message on pause."
+msgid "If checked, '[paused]' will be added to status message on pause"
 msgstr ""
-"Hvis dette er valgt, blir «[paused]» lagt til statusmeldinger ved pause."
+"Hvis dette er valgt, blir «[paused]» lagt til statusmeldinger ved pause"
 
 #: ../quodlibet/ext/events/gajim_status.py:189
 msgid "Statuses for which message will be changed"
@@ -2032,8 +2032,8 @@ msgstr ""
 "bruke standardmønster."
 
 #: ../quodlibet/ext/events/qlscrobbler.py:566
-msgid "Songs matching this filter will not be submitted."
-msgstr "Låter som samsvarer med dette filteret blir ikke sendt inn."
+msgid "Songs matching this filter will not be submitted"
+msgstr "Låter som samsvarer med dette filteret blir ikke sendt inn"
 
 #: ../quodlibet/ext/events/qlscrobbler.py:574
 msgid "_Offline mode (don't submit anything)"
@@ -3011,8 +3011,8 @@ msgid "Password:"
 msgstr "Passord:"
 
 #: ../quodlibet/ext/_shared/squeezebox/base.py:131
-msgid "Library directory the server connects to."
-msgstr "Bibliotekmappe som tjener kobler til."
+msgid "Library directory the server connects to"
+msgstr "Bibliotekmappe som tjener kobler til"
 
 #: ../quodlibet/ext/_shared/squeezebox/base.py:133
 msgid "Library path:"
@@ -4453,10 +4453,10 @@ msgstr "Slå av _sømløs avspilling"
 #: ../quodlibet/player/gstbe/prefs.py:71
 msgid ""
 "Disabling gapless playback can avoid track changing problems with some "
-"GStreamer versions."
+"GStreamer versions"
 msgstr ""
 "Slå av sømløs avspilling for å omgå problemer som oppstår med enkelte "
-"versjoner av GStreamer."
+"versjoner av GStreamer"
 
 #: ../quodlibet/player/gstbe/util.py:104
 msgid "No GStreamer audio sink found"
@@ -5855,8 +5855,8 @@ msgid "Search after _typing"
 msgstr "Søk e_tter skriving"
 
 #: ../quodlibet/qltk/searchbar.py:142
-msgid "Show search results after the user stops typing."
-msgstr "Vil søketreff når bruker slutter å skrive."
+msgid "Show search results after the user stops typing"
+msgstr "Vil søketreff når bruker slutter å skrive"
 
 #: ../quodlibet/qltk/searchbar.py:201
 msgid "_Limit:"

--- a/quodlibet/po/nl.po
+++ b/quodlibet/po/nl.po
@@ -1797,10 +1797,10 @@ msgid "Add '[paused]'"
 msgstr "gepauzeerd"
 
 #: ../quodlibet/ext/events/gajim_status.py:163
-msgid "If checked, '[paused]' will be added to status message on pause."
+msgid "If checked, '[paused]' will be added to status message on pause"
 msgstr ""
 "Indien aangevinkt wordt '[gepauzeerd]' toegevoegd aan het statusbericht "
-"wanneer het nummer gepauzeerd is."
+"wanneer het nummer gepauzeerd is"
 
 #: ../quodlibet/ext/events/gajim_status.py:187
 #, fuzzy
@@ -2249,8 +2249,8 @@ msgstr ""
 "standaardinstelling."
 
 #: ../quodlibet/ext/events/qlscrobbler.py:568
-msgid "Songs matching this filter will not be submitted."
-msgstr "Nummers die overeenkomen met deze filter zullen niet worden ingediend."
+msgid "Songs matching this filter will not be submitted"
+msgstr "Nummers die overeenkomen met deze filter zullen niet worden ingediend"
 
 #: ../quodlibet/ext/events/qlscrobbler.py:576
 msgid "_Offline mode (don't submit anything)"
@@ -3059,8 +3059,8 @@ msgid "Password:"
 msgstr "Wachtwoord:"
 
 #: ../quodlibet/ext/_shared/squeezebox/base.py:130
-msgid "Library directory the server connects to."
-msgstr "Bibliotheekdirectory waarmee de server verbindt."
+msgid "Library directory the server connects to"
+msgstr "Bibliotheekdirectory waarmee de server verbindt"
 
 #: ../quodlibet/ext/_shared/squeezebox/base.py:132
 msgid "Library path:"
@@ -4410,10 +4410,10 @@ msgstr "_Gapless afspelen uitschakelen"
 #: ../quodlibet/player/gstbe/prefs.py:70
 msgid ""
 "Disabling gapless playback can avoid track changing problems with some "
-"GStreamer versions."
+"GStreamer versions"
 msgstr ""
 "Uitschakelen van gapless afspelen kan trackwisselproblemen bij sommige "
-"GStreamer-versies vermijden."
+"GStreamer-versies vermijden"
 
 #: ../quodlibet/player/gstbe/util.py:93
 msgid "No GStreamer audio sink found"
@@ -5831,8 +5831,8 @@ msgid "Search after _typing"
 msgstr "Zoeken na _typen"
 
 #: ../quodlibet/qltk/searchbar.py:132
-msgid "Show search results after the user stops typing."
-msgstr "Toon zoekresultaten nadat de gebruiker stopt met typen."
+msgid "Show search results after the user stops typing"
+msgstr "Toon zoekresultaten nadat de gebruiker stopt met typen"
 
 #: ../quodlibet/qltk/searchbar.py:187
 msgid "_Limit:"

--- a/quodlibet/po/pl.po
+++ b/quodlibet/po/pl.po
@@ -1617,10 +1617,10 @@ msgid "Add '[paused]'"
 msgstr "Dodanie „[wstrzymano]”"
 
 #: quodlibet/ext/events/gajim_status.py:165
-msgid "If checked, '[paused]' will be added to status message on pause."
+msgid "If checked, '[paused]' will be added to status message on pause"
 msgstr ""
 "Jeśli jest zaznaczone, to „[wstrzymano]” będzie dodawane do wiadomości stanu "
-"podczas wstrzymania."
+"podczas wstrzymania"
 
 #: quodlibet/ext/events/gajim_status.py:189
 msgid "Statuses for which message will be changed"
@@ -2014,8 +2014,8 @@ msgstr ""
 "pola spowoduje użycie domyślnego."
 
 #: quodlibet/ext/events/qlscrobbler.py:574
-msgid "Songs matching this filter will not be submitted."
-msgstr "Utwory pasujące do tego filtru nie będą wysyłane."
+msgid "Songs matching this filter will not be submitted"
+msgstr "Utwory pasujące do tego filtru nie będą wysyłane"
 
 #: quodlibet/ext/events/qlscrobbler.py:582
 msgid "_Offline mode (don't submit anything)"
@@ -3002,8 +3002,8 @@ msgid "Password:"
 msgstr "Hasło:"
 
 #: quodlibet/ext/_shared/squeezebox/base.py:131
-msgid "Library directory the server connects to."
-msgstr "Katalog kolekcji, z którym serwer ma się łączyć."
+msgid "Library directory the server connects to"
+msgstr "Katalog kolekcji, z którym serwer ma się łączyć"
 
 #: quodlibet/ext/_shared/squeezebox/base.py:133
 msgid "Library path:"
@@ -4444,10 +4444,10 @@ msgstr "Wyłączenie płynnego _odtwarzania"
 #: quodlibet/player/gstbe/prefs.py:71
 msgid ""
 "Disabling gapless playback can avoid track changing problems with some "
-"GStreamer versions."
+"GStreamer versions"
 msgstr ""
 "Wyłączenie płynnego odtwarzania może pomóc uniknąć problemów podczas "
-"zmieniania utworów w niektórych wersjach biblioteki GStreamer."
+"zmieniania utworów w niektórych wersjach biblioteki GStreamer"
 
 #: quodlibet/player/gstbe/util.py:102
 msgid "No GStreamer audio sink found"
@@ -5872,8 +5872,8 @@ msgid "Search after _typing"
 msgstr "Wy_szukiwanie podczas pisania"
 
 #: quodlibet/qltk/searchbar.py:145
-msgid "Show search results after the user stops typing."
-msgstr "Wyświetla wyniki wyszukiwania, kiedy użytkownik przestaje pisać."
+msgid "Show search results after the user stops typing"
+msgstr "Wyświetla wyniki wyszukiwania, kiedy użytkownik przestaje pisać"
 
 #: quodlibet/qltk/searchbar.py:212
 msgid "_Limit:"

--- a/quodlibet/po/pt.po
+++ b/quodlibet/po/pt.po
@@ -1674,9 +1674,9 @@ msgid "Add '[paused]'"
 msgstr "Adicionar \"[pausado]\""
 
 #: quodlibet/ext/events/gajim_status.py:164
-msgid "If checked, '[paused]' will be added to status message on pause."
+msgid "If checked, '[paused]' will be added to status message on pause"
 msgstr ""
-"Se marcada, adiciona \"[pausado]\" ao fim da mensagem durante uma pausa."
+"Se marcada, adiciona \"[pausado]\" ao fim da mensagem durante uma pausa"
 
 #: quodlibet/ext/events/gajim_status.py:188
 msgid "Statuses for which message will be changed"
@@ -2070,8 +2070,8 @@ msgstr ""
 "branco para usar o padrão."
 
 #: quodlibet/ext/events/qlscrobbler.py:573
-msgid "Songs matching this filter will not be submitted."
-msgstr "Músicas que corresponderem a este filtro não serão enviadas."
+msgid "Songs matching this filter will not be submitted"
+msgstr "Músicas que corresponderem a este filtro não serão enviadas"
 
 #: quodlibet/ext/events/qlscrobbler.py:581
 msgid "_Offline mode (don't submit anything)"
@@ -3102,8 +3102,8 @@ msgid "Password:"
 msgstr "Senha:"
 
 #: quodlibet/ext/_shared/squeezebox/base.py:130
-msgid "Library directory the server connects to."
-msgstr "Pasta de biblioteca que o servidor se conecta."
+msgid "Library directory the server connects to"
+msgstr "Pasta de biblioteca que o servidor se conecta"
 
 #: quodlibet/ext/_shared/squeezebox/base.py:132
 msgid "Library path:"
@@ -4546,10 +4546,10 @@ msgstr "Desativar reprodução sem intervalos"
 #: quodlibet/player/gstbe/prefs.py:70
 msgid ""
 "Disabling gapless playback can avoid track changing problems with some "
-"GStreamer versions."
+"GStreamer versions"
 msgstr ""
 "Desativar a reprodução sem intervalos pode evitar problemas na troca de "
-"faixas que ocorrem em certas versões do GStreamer."
+"faixas que ocorrem em certas versões do GStreamer"
 
 #: quodlibet/player/gstbe/util.py:101
 msgid "No GStreamer audio sink found"
@@ -6025,8 +6025,8 @@ msgid "Search after _typing"
 msgstr "Pesquise após digi_tar"
 
 #: quodlibet/qltk/searchbar.py:147
-msgid "Show search results after the user stops typing."
-msgstr "Exibir resultados da pesquisa após o usuário terminar de digitar."
+msgid "Show search results after the user stops typing"
+msgstr "Exibir resultados da pesquisa após o usuário terminar de digitar"
 
 #: quodlibet/qltk/searchbar.py:215
 msgid "_Limit:"

--- a/quodlibet/po/ru.po
+++ b/quodlibet/po/ru.po
@@ -1665,8 +1665,8 @@ msgid "Add '[paused]'"
 msgstr "Добавлять '[paused]'"
 
 #: ../quodlibet/ext/events/gajim_status.py:165
-msgid "If checked, '[paused]' will be added to status message on pause."
-msgstr "Если отмечено, '[paused]' в статус будет добавлено сообщение о паузе."
+msgid "If checked, '[paused]' will be added to status message on pause"
+msgstr "Если отмечено, '[paused]' в статус будет добавлено сообщение о паузе"
 
 #: ../quodlibet/ext/events/gajim_status.py:189
 msgid "Statuses for which message will be changed"
@@ -2049,8 +2049,8 @@ msgstr ""
 "значения по умолчанию."
 
 #: ../quodlibet/ext/events/qlscrobbler.py:574
-msgid "Songs matching this filter will not be submitted."
-msgstr "Треки, соответствующие этому фильтру, не будут отправлены."
+msgid "Songs matching this filter will not be submitted"
+msgstr "Треки, соответствующие этому фильтру, не будут отправлены"
 
 #: ../quodlibet/ext/events/qlscrobbler.py:582
 msgid "_Offline mode (don't submit anything)"
@@ -3022,8 +3022,8 @@ msgid "Password:"
 msgstr "Пароль:"
 
 #: ../quodlibet/ext/_shared/squeezebox/base.py:131
-msgid "Library directory the server connects to."
-msgstr "Каталог фонотеки, к которому подключается сервер."
+msgid "Library directory the server connects to"
+msgstr "Каталог фонотеки, к которому подключается сервер"
 
 #: ../quodlibet/ext/_shared/squeezebox/base.py:133
 msgid "Library path:"
@@ -4459,10 +4459,10 @@ msgstr "_Отключить воспроизведение без пауз"
 #: ../quodlibet/player/gstbe/prefs.py:71
 msgid ""
 "Disabling gapless playback can avoid track changing problems with some "
-"GStreamer versions."
+"GStreamer versions"
 msgstr ""
 "Отключение воспроизведения без пауз (gapless) может помочь решить проблемы "
-"при смене треков с некоторыми версиями GStreamer."
+"при смене треков с некоторыми версиями GStreamer"
 
 #: ../quodlibet/player/gstbe/util.py:103
 msgid "No GStreamer audio sink found"
@@ -5881,8 +5881,8 @@ msgid "Search after _typing"
 msgstr "_Производить поиск по окончании ввода"
 
 #: ../quodlibet/qltk/searchbar.py:144
-msgid "Show search results after the user stops typing."
-msgstr "Производить поиск сразу после прекращения ввода."
+msgid "Show search results after the user stops typing"
+msgstr "Производить поиск сразу после прекращения ввода"
 
 #: ../quodlibet/qltk/searchbar.py:208
 msgid "_Limit:"

--- a/quodlibet/po/sv.po
+++ b/quodlibet/po/sv.po
@@ -5849,7 +5849,7 @@ msgid "Search after _typing"
 msgstr "Sök när man slutat skriva"
 
 #: ../quodlibet/qltk/searchbar.py:132
-msgid "Show search results after the user stops typing."
+msgid "Show search results after the user stops typing"
 msgstr "Visa sökresultat när användaren har slutat skriva"
 
 #: ../quodlibet/qltk/searchbar.py:187


### PR DESCRIPTION
See https://github.com/quodlibet/quodlibet/pull/3208#issuecomment-509030661.

For each instance of the tooltip strings changed in #3208, I updated the source and the translation string (made their ending punctuation match). This way, the strings will appear translated again after `build_mo`. Some languages had none of the strings translated, so they weren’t touched.


