### PR TITLE
Consistent ending punctuation for multi-sentence tooltips

### DIFF
--- a/quodlibet/po/cs.po
+++ b/quodlibet/po/cs.po
@@ -1789,8 +1789,8 @@ msgstr "Nastavení"
 
 #: ../quodlibet/ext/events/mqtt.py:51
 #, python-format
-msgid "Accepts QL Patterns e.g. %s"
-msgstr "Akceptuje QL vzory, např. %s"
+msgid "Accepts QL Patterns e.g. %s."
+msgstr "Akceptuje QL vzory, např. %s."
 
 #: ../quodlibet/ext/events/mqtt.py:57
 msgid "MQTT Publisher"
@@ -2284,7 +2284,7 @@ msgstr "Přehrává se:"
 
 #: ../quodlibet/ext/events/telepathy_status.py:124
 #, python-format
-msgid "Status text when a song is started. Accepts QL Patterns e.g. %s"
+msgid "Status text when a song is started. Accepts QL Patterns e.g. %s."
 msgstr ""
 "Text statusu při začátku přehrávání. Je možné použít QL vzory jako např. %s."
 
@@ -2294,7 +2294,7 @@ msgstr "Zastaveno:"
 
 #: ../quodlibet/ext/events/telepathy_status.py:141
 #, python-format
-msgid "Status text when a song is paused. Accepts QL Patterns e.g. %s"
+msgid "Status text when a song is paused. Accepts QL Patterns e.g. %s."
 msgstr ""
 "Text statusu, když je přehrávání pozastaveno. Je možné použít QL vzory jako "
 "např. %s."
@@ -3275,7 +3275,7 @@ msgstr "parametr"
 msgid ""
 "If specified, a parameter whose occurrences in the command will be "
 "substituted with a user-supplied value, e.g. by using 'PARAM' all instances "
-"of '{PARAM}' in your command will have the value prompted for when run"
+"of '{PARAM}' in your command will have the value prompted for when run."
 msgstr ""
 "Je-li specifikováno,výskyty parametru v příkazu budou nahrazeny uživatelem "
 "zadanou hodnotou, např. při použití 'PARAM' budou všechny výskyty '{PARAM}' "
@@ -5370,7 +5370,7 @@ msgstr "Uložit změny tagů bez potvrzení v případě úpravy více tagů naj
 #: ../quodlibet/qltk/prefs.py:588
 msgid ""
 "A set of separators to use when splitting tag values in the tag editor. The "
-"list is space-separated"
+"list is space-separated."
 msgstr ""
 "Seznam oddělovačů pro rozdělování hodnot tagů. Položky jsou odděleny mezerou."
 

--- a/quodlibet/po/da.po
+++ b/quodlibet/po/da.po
@@ -1791,8 +1791,8 @@ msgstr "Præferencer"
 
 #: ../quodlibet/ext/events/mqtt.py:56
 #, python-format
-msgid "Accepts QL Patterns e.g. %s"
-msgstr "Accepterer QL-mønstre. F.eks. %s"
+msgid "Accepts QL Patterns e.g. %s."
+msgstr "Accepterer QL-mønstre. F.eks. %s."
 
 #: ../quodlibet/ext/events/mqtt.py:62
 msgid "MQTT Publisher"
@@ -2292,8 +2292,8 @@ msgstr "Afspiller:"
 
 #: ../quodlibet/ext/events/telepathy_status.py:124
 #, python-format
-msgid "Status text when a song is started. Accepts QL Patterns e.g. %s"
-msgstr "Statustekst når en sang startes. Accepterer QL-mønstre. F.eks. %s"
+msgid "Status text when a song is started. Accepts QL Patterns e.g. %s."
+msgstr "Statustekst når en sang startes. Accepterer QL-mønstre. F.eks. %s."
 
 #: ../quodlibet/ext/events/telepathy_status.py:140
 msgid "Paused:"
@@ -2301,9 +2301,9 @@ msgstr "Sat på pause:"
 
 #: ../quodlibet/ext/events/telepathy_status.py:141
 #, python-format
-msgid "Status text when a song is paused. Accepts QL Patterns e.g. %s"
+msgid "Status text when a song is paused. Accepts QL Patterns e.g. %s."
 msgstr ""
-"Statustekst når en sang er sat på pause. Accepterer QL-mønstre. F.eks. %s"
+"Statustekst når en sang er sat på pause. Accepterer QL-mønstre. F.eks. %s."
 
 #: ../quodlibet/ext/events/telepathy_status.py:157
 msgid "Plain text for status when there is no current song"
@@ -3407,11 +3407,11 @@ msgstr "parameter"
 msgid ""
 "If specified, a parameter whose occurrences in the command will be "
 "substituted with a user-supplied value, e.g. by using 'PARAM' all instances "
-"of '{PARAM}' in your command will have the value prompted for when run"
+"of '{PARAM}' in your command will have the value prompted for when run."
 msgstr ""
 "Hvis specificeret, erstattes en parameter som forekommer i kommandoen med en "
 "værdi som brugeren har givet, ved f.eks. at bruge 'PARAM' spørges der om "
-"værdien ved alle forekomster af '{PARAM}' i din kommando, når den køre"
+"værdien ved alle forekomster af '{PARAM}' i din kommando, når den køre."
 
 #: ../quodlibet/ext/songsmenu/custom_commands.py:56
 msgid "pattern"
@@ -5503,10 +5503,10 @@ msgstr "Gem ændringer til tags uden bekræftelse når flere filer redigeres"
 #: ../quodlibet/qltk/prefs.py:598
 msgid ""
 "A set of separators to use when splitting tag values in the tag editor. The "
-"list is space-separated"
+"list is space-separated."
 msgstr ""
 "Et sæt af separatorer som skal bruges når tag-værdier opdeles i tag-"
-"editoren. Listen er mellemrumssepareret"
+"editoren. Listen er mellemrumssepareret."
 
 #: ../quodlibet/qltk/prefs.py:621
 msgid "Tags"

--- a/quodlibet/po/el.po
+++ b/quodlibet/po/el.po
@@ -1982,7 +1982,7 @@ msgstr "Προτιμήσεις"
 msgid "Accepts QL Patterns e.g. %s"
 msgstr ""
 "Μήνυμα κατάστασης όταν κάποιο τραγούδι είναι παυμένο. Δέχεται πρότυπα QL π."
-"χ. %s"
+"χ. %s."
 
 #: ../quodlibet/ext/events/mqtt.py:56
 msgid "MQTT Publisher"
@@ -2452,10 +2452,10 @@ msgstr "Αναπαράγεται:"
 
 #: ../quodlibet/ext/events/telepathy_status.py:123
 #, python-format
-msgid "Status text when a song is started. Accepts QL Patterns e.g. %s"
+msgid "Status text when a song is started. Accepts QL Patterns e.g. %s."
 msgstr ""
 "Μήνυμα κατάστασης όταν αναπαράγεται κάποιο τραγούδι. Δέχεται πρότυπα QL π.χ. "
-"%s"
+"%s."
 
 #: ../quodlibet/ext/events/telepathy_status.py:139
 msgid "Paused:"
@@ -2463,10 +2463,10 @@ msgstr "Παυμένο:"
 
 #: ../quodlibet/ext/events/telepathy_status.py:140
 #, python-format
-msgid "Status text when a song is paused. Accepts QL Patterns e.g. %s"
+msgid "Status text when a song is paused. Accepts QL Patterns e.g. %s."
 msgstr ""
 "Μήνυμα κατάστασης όταν κάποιο τραγούδι είναι παυμένο. Δέχεται πρότυπα QL π."
-"χ. %s"
+"χ. %s."
 
 #: ../quodlibet/ext/events/telepathy_status.py:156
 msgid "Plain text for status when there is no current song"
@@ -3359,7 +3359,7 @@ msgstr "παράμετρος"
 msgid ""
 "If specified, a parameter whose occurrences in the command will be "
 "substituted with a user-supplied value, e.g. by using 'PARAM' all instances "
-"of '{PARAM}' in your command will have the value prompted for when run"
+"of '{PARAM}' in your command will have the value prompted for when run."
 msgstr ""
 "Αν οριστεί, μια παράμετρος η οποία θα αντικατασταθεί όπου βρεθεί με μια "
 "καθορισμένη από τον χρήστη τιμή, π.χ. χρησιμοποιώντας το 'PARAM' όλα τα "

--- a/quodlibet/po/fi.po
+++ b/quodlibet/po/fi.po
@@ -1801,8 +1801,8 @@ msgstr "Asetukset"
 
 #: ../quodlibet/ext/events/mqtt.py:56
 #, python-format
-msgid "Accepts QL Patterns e.g. %s"
-msgstr "Hyväksyy QL-kaavat, esim. %s"
+msgid "Accepts QL Patterns e.g. %s."
+msgstr "Hyväksyy QL-kaavat, esim. %s."
 
 #: ../quodlibet/ext/events/mqtt.py:62
 msgid "MQTT Publisher"
@@ -2305,8 +2305,8 @@ msgstr "Toistetaan:"
 
 #: ../quodlibet/ext/events/telepathy_status.py:124
 #, python-format
-msgid "Status text when a song is started. Accepts QL Patterns e.g. %s"
-msgstr "Tilaviesti, kun kappaleen toisto alkaa. Hyväksyy QL-kaavoja, kuten %s"
+msgid "Status text when a song is started. Accepts QL Patterns e.g. %s."
+msgstr "Tilaviesti, kun kappaleen toisto alkaa. Hyväksyy QL-kaavoja, kuten %s."
 
 #: ../quodlibet/ext/events/telepathy_status.py:140
 msgid "Paused:"
@@ -2314,10 +2314,10 @@ msgstr "Keskeytetty:"
 
 #: ../quodlibet/ext/events/telepathy_status.py:141
 #, python-format
-msgid "Status text when a song is paused. Accepts QL Patterns e.g. %s"
+msgid "Status text when a song is paused. Accepts QL Patterns e.g. %s."
 msgstr ""
 "Tilaviesti, kun kappaleen toisto on keskeytetty. Hyväksyy QL-kaavoja, kuten "
-"%s"
+"%s."
 
 #: ../quodlibet/ext/events/telepathy_status.py:157
 msgid "Plain text for status when there is no current song"
@@ -3431,7 +3431,7 @@ msgstr "parametri"
 msgid ""
 "If specified, a parameter whose occurrences in the command will be "
 "substituted with a user-supplied value, e.g. by using 'PARAM' all instances "
-"of '{PARAM}' in your command will have the value prompted for when run"
+"of '{PARAM}' in your command will have the value prompted for when run."
 msgstr ""
 "Jos määritetty, komennossa olevat esiintymät korvataan käyttäjän antamalla "
 "arvolla. Esim. parametrin nimellä ”PARAM” kaikki ”{PARAM}”-ilmentymät "
@@ -5539,7 +5539,7 @@ msgstr ""
 #: ../quodlibet/qltk/prefs.py:598
 msgid ""
 "A set of separators to use when splitting tag values in the tag editor. The "
-"list is space-separated"
+"list is space-separated."
 msgstr ""
 "Erotinmerkit, joita käytetään jaettaessa tunnisteiden arvoja osiin. Erota "
 "merkit välilyönnillä toisistaan."

--- a/quodlibet/po/fr.po
+++ b/quodlibet/po/fr.po
@@ -1847,8 +1847,8 @@ msgstr "Préférences"
 
 #: quodlibet/ext/events/mqtt.py:54
 #, python-format
-msgid "Accepts QL Patterns e.g. %s"
-msgstr "Accepte les modèles de QL, p. ex. %s"
+msgid "Accepts QL Patterns e.g. %s."
+msgstr "Accepte les modèles de QL, p. ex. %s."
 
 #: quodlibet/ext/events/mqtt.py:60
 msgid "MQTT Publisher"
@@ -2349,10 +2349,10 @@ msgstr "En cours de lecture :"
 
 #: quodlibet/ext/events/telepathy_status.py:129
 #, python-format
-msgid "Status text when a song is started. Accepts QL Patterns e.g. %s"
+msgid "Status text when a song is started. Accepts QL Patterns e.g. %s."
 msgstr ""
 "Texte de statut lorsqu'un morceau est lancé. Accepte les modèles de QL, p. "
-"ex. %s"
+"ex. %s."
 
 #: quodlibet/ext/events/telepathy_status.py:145
 msgid "Paused:"
@@ -2360,10 +2360,10 @@ msgstr "En pause :"
 
 #: quodlibet/ext/events/telepathy_status.py:146
 #, python-format
-msgid "Status text when a song is paused. Accepts QL Patterns e.g. %s"
+msgid "Status text when a song is paused. Accepts QL Patterns e.g. %s."
 msgstr ""
 "Texte de statut lorsqu'un morceau est mis en pause. Accepte les modèles de "
-"QL, p. ex. %s"
+"QL, p. ex. %s."
 
 #: quodlibet/ext/events/telepathy_status.py:162
 msgid "Plain text for status when there is no current song"
@@ -3495,7 +3495,7 @@ msgstr "Paramètre"
 msgid ""
 "If specified, a parameter whose occurrences in the command will be "
 "substituted with a user-supplied value, e.g. by using 'PARAM' all instances "
-"of '{PARAM}' in your command will have the value prompted for when run"
+"of '{PARAM}' in your command will have the value prompted for when run."
 msgstr ""
 "Si spécifié, un paramètre dont les occurrences dans la commande seront "
 "remplacées par une valeur fournie par l'utilisateur, par exemple en "
@@ -5636,10 +5636,10 @@ msgstr ""
 #: quodlibet/qltk/prefs.py:608
 msgid ""
 "A set of separators to use when splitting tag values in the tag editor. The "
-"list is space-separated"
+"list is space-separated."
 msgstr ""
 "Un ensemble de séparateurs à utiliser lors de la division des valeurs de "
-"balises dans l'éditeur de balises. La liste est séparée par des espaces"
+"balises dans l'éditeur de balises. La liste est séparée par des espaces."
 
 #: quodlibet/qltk/prefs.py:618
 msgid ""

--- a/quodlibet/po/he.po
+++ b/quodlibet/po/he.po
@@ -1769,7 +1769,7 @@ msgstr "העדפות"
 
 #: quodlibet/ext/events/mqtt.py:54
 #, python-format
-msgid "Accepts QL Patterns e.g. %s"
+msgid "Accepts QL Patterns e.g. %s."
 msgstr "מתקבלים דפוסי קוודליבט, כלומר %s"
 
 #: quodlibet/ext/events/mqtt.py:60
@@ -2263,7 +2263,7 @@ msgstr "מושמע:"
 
 #: quodlibet/ext/events/telepathy_status.py:129
 #, python-format
-msgid "Status text when a song is started. Accepts QL Patterns e.g. %s"
+msgid "Status text when a song is started. Accepts QL Patterns e.g. %s."
 msgstr "מלל מצב בעת השמעת שיר. תומך בדפוסי QL לדוגמה %s"
 
 #: quodlibet/ext/events/telepathy_status.py:145
@@ -2272,7 +2272,7 @@ msgstr "מושהה:"
 
 #: quodlibet/ext/events/telepathy_status.py:146
 #, python-format
-msgid "Status text when a song is paused. Accepts QL Patterns e.g. %s"
+msgid "Status text when a song is paused. Accepts QL Patterns e.g. %s."
 msgstr "מלל מצב בעת השהיית שיר. תומך בדפוסי QL לדוגמה %s"
 
 #: quodlibet/ext/events/telepathy_status.py:162
@@ -3310,7 +3310,7 @@ msgstr "מְאַפְיֵן"
 msgid ""
 "If specified, a parameter whose occurrences in the command will be substituted "
 "with a user-supplied value, e.g. by using 'PARAM' all instances of '{PARAM}' in "
-"your command will have the value prompted for when run"
+"your command will have the value prompted for when run."
 msgstr ""
 "במידה והוגדר, פרמטר שהמופע שלו בפקודה יוחלף עם ערך שסופק על ידי המשתמש, לדוגמה "
 "בהזנת '{PARAM}' כל המופעים של '{PARAM}' בפקודה יקבלו את הערך הנחוץ בעת ההפעלה"
@@ -5296,7 +5296,7 @@ msgstr "שמירת שינויים בתגים ללא בקשת אישור בעת �
 #: quodlibet/qltk/prefs.py:608
 msgid ""
 "A set of separators to use when splitting tag values in the tag editor. The list "
-"is space-separated"
+"is space-separated."
 msgstr ""
 "סדרת תווי הפרדה לשימוש בעת פיצול ערכים בעורך התגים. ערכי הרשימה מופרדים בפסיקים"
 

--- a/quodlibet/po/nb.po
+++ b/quodlibet/po/nb.po
@@ -1782,8 +1782,8 @@ msgstr "Innstillinger"
 
 #: ../quodlibet/ext/events/mqtt.py:51
 #, python-format
-msgid "Accepts QL Patterns e.g. %s"
-msgstr "Tillater QL-mønstre som f.eks. %s"
+msgid "Accepts QL Patterns e.g. %s."
+msgstr "Tillater QL-mønstre som f.eks. %s."
 
 #: ../quodlibet/ext/events/mqtt.py:57
 msgid "MQTT Publisher"
@@ -2284,8 +2284,8 @@ msgstr "Spiller:"
 
 #: ../quodlibet/ext/events/telepathy_status.py:124
 #, python-format
-msgid "Status text when a song is started. Accepts QL Patterns e.g. %s"
-msgstr "Statustekst når du starter en låt. Godtar QL-mønstre som f.eks. %s"
+msgid "Status text when a song is started. Accepts QL Patterns e.g. %s."
+msgstr "Statustekst når du starter en låt. Godtar QL-mønstre som f.eks. %s."
 
 #: ../quodlibet/ext/events/telepathy_status.py:140
 msgid "Paused:"
@@ -2293,9 +2293,9 @@ msgstr "Pauset:"
 
 #: ../quodlibet/ext/events/telepathy_status.py:141
 #, python-format
-msgid "Status text when a song is paused. Accepts QL Patterns e.g. %s"
+msgid "Status text when a song is paused. Accepts QL Patterns e.g. %s."
 msgstr ""
-"Statustekst når du setter en låt på pause. Godtar QL-mønstre som f.eks. %s"
+"Statustekst når du setter en låt på pause. Godtar QL-mønstre som f.eks. %s."
 
 #: ../quodlibet/ext/events/telepathy_status.py:157
 msgid "Plain text for status when there is no current song"
@@ -3415,11 +3415,11 @@ msgstr "parameter"
 msgid ""
 "If specified, a parameter whose occurrences in the command will be "
 "substituted with a user-supplied value, e.g. by using 'PARAM' all instances "
-"of '{PARAM}' in your command will have the value prompted for when run"
+"of '{PARAM}' in your command will have the value prompted for when run."
 msgstr ""
 "Hvis dette er valgt, blir en parameter i kommandoen erstattet med selvvalgt "
 "verdi. For eksempel: bruk «PARAM»  for å bli bedt om verdier for alle "
-"forekomster av «{PARAM}» i en kommando"
+"forekomster av «{PARAM}» i en kommando."
 
 #: ../quodlibet/ext/songsmenu/custom_commands.py:56
 msgid "pattern"
@@ -5490,10 +5490,10 @@ msgstr ""
 #: ../quodlibet/qltk/prefs.py:598
 msgid ""
 "A set of separators to use when splitting tag values in the tag editor. The "
-"list is space-separated"
+"list is space-separated."
 msgstr ""
 "Liste over skilletegn som skal brukes ved oppdeling av taggverdier. Selve "
-"lista bruker mellomrom som skilletegn"
+"lista bruker mellomrom som skilletegn."
 
 #: ../quodlibet/qltk/prefs.py:621
 msgid "Tags"

--- a/quodlibet/po/nl.po
+++ b/quodlibet/po/nl.po
@@ -2461,7 +2461,7 @@ msgstr "Wordt afgespeeld:"
 
 #: ../quodlibet/ext/events/telepathy_status.py:123
 #, python-format
-msgid "Status text when a song is started. Accepts QL Patterns e.g. %s"
+msgid "Status text when a song is started. Accepts QL Patterns e.g. %s."
 msgstr ""
 "Statustekst wanneer een liedje wordt gestart. Quod Libet-patronen zoals %s "
 "worden aanvaard."
@@ -2472,7 +2472,7 @@ msgstr "Gepauzeerd:"
 
 #: ../quodlibet/ext/events/telepathy_status.py:140
 #, python-format
-msgid "Status text when a song is paused. Accepts QL Patterns e.g. %s"
+msgid "Status text when a song is paused. Accepts QL Patterns e.g. %s."
 msgstr ""
 "Statustekst wanneer een liedje is gepauzeerd. Quod Libet-patronen zoals %s "
 "worden aanvaard."
@@ -3366,12 +3366,12 @@ msgstr "parameter"
 msgid ""
 "If specified, a parameter whose occurrences in the command will be "
 "substituted with a user-supplied value, e.g. by using 'PARAM' all instances "
-"of '{PARAM}' in your command will have the value prompted for when run"
+"of '{PARAM}' in your command will have the value prompted for when run."
 msgstr ""
 "Indien opgegeven: een parameter waarvan de verschijningen in het commando "
 "vervangen zullen worden door een waarde opgegeven door de gebruiker, bv. "
 "door 'PARAM' te gebruiken zullen alle voorkomens van '{PARAM}' in je "
-"commando de opgegeven waarde hebben wanneer het commando wordt uitgevoerd"
+"commando de opgegeven waarde hebben wanneer het commando wordt uitgevoerd."
 
 #: ../quodlibet/ext/songsmenu/custom_commands.py:55
 msgid "pattern"

--- a/quodlibet/po/pl.po
+++ b/quodlibet/po/pl.po
@@ -1765,8 +1765,8 @@ msgstr "Preferencje"
 
 #: quodlibet/ext/events/mqtt.py:56
 #, python-format
-msgid "Accepts QL Patterns e.g. %s"
-msgstr "Przyjmuje wzorce QL, np. %s"
+msgid "Accepts QL Patterns e.g. %s."
+msgstr "Przyjmuje wzorce QL, np. %s."
 
 #: quodlibet/ext/events/mqtt.py:62
 msgid "MQTT Publisher"
@@ -2271,9 +2271,9 @@ msgstr "Odtwarzanie:"
 
 #: quodlibet/ext/events/telepathy_status.py:130
 #, python-format
-msgid "Status text when a song is started. Accepts QL Patterns e.g. %s"
+msgid "Status text when a song is started. Accepts QL Patterns e.g. %s."
 msgstr ""
-"Tekst stanu, kiedy utwór jest rozpoczynany. Przyjmuje wzorce QL, np. %s"
+"Tekst stanu, kiedy utwór jest rozpoczynany. Przyjmuje wzorce QL, np. %s."
 
 #: quodlibet/ext/events/telepathy_status.py:146
 msgid "Paused:"
@@ -2281,8 +2281,8 @@ msgstr "Wstrzymano:"
 
 #: quodlibet/ext/events/telepathy_status.py:147
 #, python-format
-msgid "Status text when a song is paused. Accepts QL Patterns e.g. %s"
-msgstr "Tekst stanu, kiedy utwór jest wstrzymany. Przyjmuje wzorce QL, np. %s"
+msgid "Status text when a song is paused. Accepts QL Patterns e.g. %s."
+msgstr "Tekst stanu, kiedy utwór jest wstrzymany. Przyjmuje wzorce QL, np. %s."
 
 #: quodlibet/ext/events/telepathy_status.py:163
 msgid "Plain text for status when there is no current song"
@@ -3392,11 +3392,11 @@ msgstr "parametr"
 msgid ""
 "If specified, a parameter whose occurrences in the command will be "
 "substituted with a user-supplied value, e.g. by using 'PARAM' all instances "
-"of '{PARAM}' in your command will have the value prompted for when run"
+"of '{PARAM}' in your command will have the value prompted for when run."
 msgstr ""
 "Jeśli podano, to parametr, którego wystąpienia w poleceniu będą zastępowane "
 "wartością podaną przez użytkownika, np. za pomocą „PARAM” wszystkie kopie "
-"„{PARAM}” w poleceniu będą prosiły o podanie wartości podczas wykonywania"
+"„{PARAM}” w poleceniu będą prosiły o podanie wartości podczas wykonywania."
 
 #: quodlibet/ext/songsmenu/custom_commands.py:56
 msgid "pattern"
@@ -5492,10 +5492,10 @@ msgstr ""
 #: quodlibet/qltk/prefs.py:598
 msgid ""
 "A set of separators to use when splitting tag values in the tag editor. The "
-"list is space-separated"
+"list is space-separated."
 msgstr ""
 "Zestaw separatorów do użycia podczas rozdzielania wartości etykiet "
-"w edytorze etykiet. Lista jest rozdzielana spacjami"
+"w edytorze etykiet. Lista jest rozdzielana spacjami."
 
 #: quodlibet/qltk/prefs.py:621
 msgid "Tags"

--- a/quodlibet/po/pt.po
+++ b/quodlibet/po/pt.po
@@ -1821,8 +1821,8 @@ msgstr "Preferências"
 
 #: quodlibet/ext/events/mqtt.py:54
 #, python-format
-msgid "Accepts QL Patterns e.g. %s"
-msgstr "Aceita padrões QL. Por exemplo, %s"
+msgid "Accepts QL Patterns e.g. %s."
+msgstr "Aceita padrões QL. Por exemplo, %s."
 
 #: quodlibet/ext/events/mqtt.py:60
 msgid "MQTT Publisher"
@@ -2327,10 +2327,10 @@ msgstr "Reproduzindo:"
 
 #: quodlibet/ext/events/telepathy_status.py:129
 #, python-format
-msgid "Status text when a song is started. Accepts QL Patterns e.g. %s"
+msgid "Status text when a song is started. Accepts QL Patterns e.g. %s."
 msgstr ""
 "Mensagem de status quando uma música começa a ser reproduzida. Aceita "
-"padrões QL. Por exemplo, %s"
+"padrões QL. Por exemplo, %s."
 
 #: quodlibet/ext/events/telepathy_status.py:145
 msgid "Paused:"
@@ -2338,10 +2338,10 @@ msgstr "Pausado:"
 
 #: quodlibet/ext/events/telepathy_status.py:146
 #, python-format
-msgid "Status text when a song is paused. Accepts QL Patterns e.g. %s"
+msgid "Status text when a song is paused. Accepts QL Patterns e.g. %s."
 msgstr ""
 "Mensagem de status quando uma música está pausada. Aceita padrões QL. Por "
-"exemplo, %s"
+"exemplo, %s."
 
 #: quodlibet/ext/events/telepathy_status.py:162
 msgid "Plain text for status when there is no current song"
@@ -3484,12 +3484,12 @@ msgstr "parâmetro"
 msgid ""
 "If specified, a parameter whose occurrences in the command will be "
 "substituted with a user-supplied value, e.g. by using 'PARAM' all instances "
-"of '{PARAM}' in your command will have the value prompted for when run"
+"of '{PARAM}' in your command will have the value prompted for when run."
 msgstr ""
 "Se especificado, um parâmetro cujas ocorrências serão substituídas por um "
 "valor especificado pelo usuário.\n"
 "Por exemplo, se o parâmetro for \"PARAM\", todas as instâncias de "
-"\"{PARAM}\" no seu comando terão o valor providenciado pelo usuário"
+"\"{PARAM}\" no seu comando terão o valor providenciado pelo usuário."
 
 #: quodlibet/ext/songsmenu/custom_commands.py:55
 msgid "pattern"
@@ -5618,10 +5618,10 @@ msgstr ""
 #: quodlibet/qltk/prefs.py:608
 msgid ""
 "A set of separators to use when splitting tag values in the tag editor. The "
-"list is space-separated"
+"list is space-separated."
 msgstr ""
 "Um conjunto de separadores usados para separar valores de etiqueta no editor "
-"de etiquetas. Esta lista é separada por espaços"
+"de etiquetas. Esta lista é separada por espaços."
 
 #: quodlibet/qltk/prefs.py:618
 msgid ""

--- a/quodlibet/po/ru.po
+++ b/quodlibet/po/ru.po
@@ -2301,9 +2301,9 @@ msgstr "Воспроизведение:"
 
 #: ../quodlibet/ext/events/telepathy_status.py:124
 #, python-format
-msgid "Status text when a song is started. Accepts QL Patterns e.g. %s"
+msgid "Status text when a song is started. Accepts QL Patterns e.g. %s."
 msgstr ""
-"Текст статуса при запуске трека. Принимает QL шаблоны, например %s"
+"Текст статуса при запуске трека. Принимает QL шаблоны, например %s."
 
 #: ../quodlibet/ext/events/telepathy_status.py:140
 msgid "Paused:"
@@ -2311,9 +2311,9 @@ msgstr "Пауза:"
 
 #: ../quodlibet/ext/events/telepathy_status.py:141
 #, python-format
-msgid "Status text when a song is paused. Accepts QL Patterns e.g. %s"
+msgid "Status text when a song is paused. Accepts QL Patterns e.g. %s."
 msgstr ""
-"Текст статуса при паузе песни. Принимает QL шаблоны, например %s"
+"Текст статуса при паузе песни. Принимает QL шаблоны, например %s."
 
 #: ../quodlibet/ext/events/telepathy_status.py:157
 msgid "Plain text for status when there is no current song"
@@ -3413,7 +3413,7 @@ msgstr "параметр"
 msgid ""
 "If specified, a parameter whose occurrences in the command will be "
 "substituted with a user-supplied value, e.g. by using 'PARAM' all instances "
-"of '{PARAM}' in your command will have the value prompted for when run"
+"of '{PARAM}' in your command will have the value prompted for when run."
 msgstr ""
 "Если указано, параметр вхождения которого, в команде, будут заменены "
 "пользовательским значением, например, с помощью параметра 'PARAM' все "
@@ -5512,7 +5512,7 @@ msgstr ""
 #: ../quodlibet/qltk/prefs.py:598
 msgid ""
 "A set of separators to use when splitting tag values in the tag editor. The "
-"list is space-separated"
+"list is space-separated."
 msgstr ""
 "Список разделителей (через пробел), которые будут использоваться для "
 "разделения тегов"

--- a/quodlibet/quodlibet/ext/events/mqtt.py
+++ b/quodlibet/quodlibet/ext/events/mqtt.py
@@ -51,7 +51,7 @@ class Config(object):
     EMPTY_STATUS = ""
 
 
-_ACCEPTS_PATTERNS = (_("Accepts QL Patterns e.g. %s") %
+_ACCEPTS_PATTERNS = (_("Accepts QL Patterns e.g. %s.") %
                      monospace(escape('<~artist~title>')))
 
 

--- a/quodlibet/quodlibet/ext/events/telepathy_status.py
+++ b/quodlibet/quodlibet/ext/events/telepathy_status.py
@@ -127,7 +127,7 @@ class TelepathyStatusPlugin(EventPlugin, PluginConfigMixin):
                       self.CFG_PAT_PLAYING)
         lbl = Gtk.Label(label=_("Playing:"))
         entry.set_tooltip_markup(_("Status text when a song is started. "
-                                 "Accepts QL Patterns e.g. %s")
+                                 "Accepts QL Patterns e.g. %s.")
                                  % util.monospace(
                                         util.escape("<~artist~title>")))
         lbl.set_mnemonic_widget(entry)
@@ -144,7 +144,7 @@ class TelepathyStatusPlugin(EventPlugin, PluginConfigMixin):
                       self.CFG_PAT_PAUSED)
         lbl = Gtk.Label(label=_("Paused:"))
         entry.set_tooltip_markup(_("Status text when a song is paused. "
-                                   "Accepts QL Patterns e.g. %s")
+                                   "Accepts QL Patterns e.g. %s.")
                                    % util.monospace(
                                         util.escape("<~artist~title>")))
         lbl.set_mnemonic_widget(entry)

--- a/quodlibet/quodlibet/ext/songsmenu/custom_commands.py
+++ b/quodlibet/quodlibet/ext/songsmenu/custom_commands.py
@@ -50,7 +50,7 @@ class Command(JSONObject):
                              "the command will be substituted with a "
                              "user-supplied value, e.g. by using 'PARAM' "
                              "all instances of '{PARAM}' in your command will "
-                             "have the value prompted for when run")),
+                             "have the value prompted for when run.")),
 
         "pattern": Field(_("pattern"),
                          _("The QL pattern, e.g. <~filename>, to use to "

--- a/quodlibet/quodlibet/qltk/prefs.py
+++ b/quodlibet/quodlibet/qltk/prefs.py
@@ -607,7 +607,7 @@ class PreferencesWindow(UniqueWindow):
             split_entry.set_tooltip_text(
                 _("A set of separators to use when splitting tag values "
                   "in the tag editor. "
-                  "The list is space-separated"))
+                  "The list is space-separated."))
             split_entry.props.expand = True
 
             sub_entry = UndoEntry()


### PR DESCRIPTION
See discussion in #3209. The second commit tries to retain existing translations, similar to #3215.