### PR TITLE
Prefs: Fix ending punctuation in tooltip

### DIFF
--- a/quodlibet/po/cs.po
+++ b/quodlibet/po/cs.po
@@ -5370,7 +5370,7 @@ msgstr "Uložit změny tagů bez potvrzení v případě úpravy více tagů naj
 #: ../quodlibet/qltk/prefs.py:588
 msgid ""
 "A set of separators to use when splitting tag values in the tag editor. The "
-"list is space-separated"
+"list is space-separated."
 msgstr ""
 "Seznam oddělovačů pro rozdělování hodnot tagů. Položky jsou odděleny mezerou."
 

--- a/quodlibet/po/da.po
+++ b/quodlibet/po/da.po
@@ -5503,10 +5503,10 @@ msgstr "Gem ændringer til tags uden bekræftelse når flere filer redigeres"
 #: ../quodlibet/qltk/prefs.py:598
 msgid ""
 "A set of separators to use when splitting tag values in the tag editor. The "
-"list is space-separated"
+"list is space-separated."
 msgstr ""
 "Et sæt af separatorer som skal bruges når tag-værdier opdeles i tag-"
-"editoren. Listen er mellemrumssepareret"
+"editoren. Listen er mellemrumssepareret."
 
 #: ../quodlibet/qltk/prefs.py:621
 msgid "Tags"

--- a/quodlibet/po/fi.po
+++ b/quodlibet/po/fi.po
@@ -5539,7 +5539,7 @@ msgstr ""
 #: ../quodlibet/qltk/prefs.py:598
 msgid ""
 "A set of separators to use when splitting tag values in the tag editor. The "
-"list is space-separated"
+"list is space-separated."
 msgstr ""
 "Erotinmerkit, joita käytetään jaettaessa tunnisteiden arvoja osiin. Erota "
 "merkit välilyönnillä toisistaan."

--- a/quodlibet/po/fr.po
+++ b/quodlibet/po/fr.po
@@ -5636,10 +5636,10 @@ msgstr ""
 #: quodlibet/qltk/prefs.py:608
 msgid ""
 "A set of separators to use when splitting tag values in the tag editor. The "
-"list is space-separated"
+"list is space-separated."
 msgstr ""
 "Un ensemble de séparateurs à utiliser lors de la division des valeurs de "
-"balises dans l'éditeur de balises. La liste est séparée par des espaces"
+"balises dans l'éditeur de balises. La liste est séparée par des espaces."
 
 #: quodlibet/qltk/prefs.py:618
 msgid ""

--- a/quodlibet/po/he.po
+++ b/quodlibet/po/he.po
@@ -5296,7 +5296,7 @@ msgstr "שמירת שינויים בתגים ללא בקשת אישור בעת �
 #: quodlibet/qltk/prefs.py:608
 msgid ""
 "A set of separators to use when splitting tag values in the tag editor. The list "
-"is space-separated"
+"is space-separated."
 msgstr ""
 "סדרת תווי הפרדה לשימוש בעת פיצול ערכים בעורך התגים. ערכי הרשימה מופרדים בפסיקים"
 

--- a/quodlibet/po/nb.po
+++ b/quodlibet/po/nb.po
@@ -5490,10 +5490,10 @@ msgstr ""
 #: ../quodlibet/qltk/prefs.py:598
 msgid ""
 "A set of separators to use when splitting tag values in the tag editor. The "
-"list is space-separated"
+"list is space-separated."
 msgstr ""
 "Liste over skilletegn som skal brukes ved oppdeling av taggverdier. Selve "
-"lista bruker mellomrom som skilletegn"
+"lista bruker mellomrom som skilletegn."
 
 #: ../quodlibet/qltk/prefs.py:621
 msgid "Tags"

--- a/quodlibet/po/pl.po
+++ b/quodlibet/po/pl.po
@@ -5492,10 +5492,10 @@ msgstr ""
 #: quodlibet/qltk/prefs.py:598
 msgid ""
 "A set of separators to use when splitting tag values in the tag editor. The "
-"list is space-separated"
+"list is space-separated."
 msgstr ""
 "Zestaw separatorów do użycia podczas rozdzielania wartości etykiet "
-"w edytorze etykiet. Lista jest rozdzielana spacjami"
+"w edytorze etykiet. Lista jest rozdzielana spacjami."
 
 #: quodlibet/qltk/prefs.py:621
 msgid "Tags"

--- a/quodlibet/po/pt.po
+++ b/quodlibet/po/pt.po
@@ -5618,10 +5618,10 @@ msgstr ""
 #: quodlibet/qltk/prefs.py:608
 msgid ""
 "A set of separators to use when splitting tag values in the tag editor. The "
-"list is space-separated"
+"list is space-separated."
 msgstr ""
 "Um conjunto de separadores usados para separar valores de etiqueta no editor "
-"de etiquetas. Esta lista é separada por espaços"
+"de etiquetas. Esta lista é separada por espaços."
 
 #: quodlibet/qltk/prefs.py:618
 msgid ""

--- a/quodlibet/po/ru.po
+++ b/quodlibet/po/ru.po
@@ -5512,7 +5512,7 @@ msgstr ""
 #: ../quodlibet/qltk/prefs.py:598
 msgid ""
 "A set of separators to use when splitting tag values in the tag editor. The "
-"list is space-separated"
+"list is space-separated."
 msgstr ""
 "Список разделителей (через пробел), которые будут использоваться для "
 "разделения тегов"

--- a/quodlibet/po/ru.po
+++ b/quodlibet/po/ru.po
@@ -5512,7 +5512,7 @@ msgstr ""
 #: ../quodlibet/qltk/prefs.py:598
 msgid ""
 "A set of separators to use when splitting tag values in the tag editor. The "
-"list is space-separated."
+"list is space-separated"
 msgstr ""
 "Список разделителей (через пробел), которые будут использоваться для "
 "разделения тегов"

--- a/quodlibet/quodlibet/qltk/prefs.py
+++ b/quodlibet/quodlibet/qltk/prefs.py
@@ -607,7 +607,7 @@ class PreferencesWindow(UniqueWindow):
             split_entry.set_tooltip_text(
                 _("A set of separators to use when splitting tag values "
                   "in the tag editor. "
-                  "The list is space-separated"))
+                  "The list is space-separated."))
             split_entry.props.expand = True
 
             sub_entry = UndoEntry()


### PR DESCRIPTION
Alternative to #3217, only covering the one tooltip in the prefs window.