### PR TITLE
Ignoring characters in queries.

### DIFF
--- a/quodlibet/quodlibet/config.py
+++ b/quodlibet/quodlibet/config.py
@@ -112,6 +112,9 @@ INITIAL = {
         # "global" filter for SearchBar
         "background": "",
 
+        # characters ignored in queries
+        "ignored_characters": "",
+
         # album list
         "albums": "",
 

--- a/quodlibet/quodlibet/config.py
+++ b/quodlibet/quodlibet/config.py
@@ -1,7 +1,7 @@
 # Copyright 2004-2008 Joe Wreschnig
 #           2009-2017 Nick Boultbee
 #           2011-2014 Christoph Reiter
-#                2018 Peter Strulo
+#           2018-2019 Peter Strulo
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/quodlibet/quodlibet/ext/events/advanced_preferences.py
+++ b/quodlibet/quodlibet/ext/events/advanced_preferences.py
@@ -1,5 +1,6 @@
-# Copyright 2015 Christoph Reiter
-#        2016-17 Nick Boultbee
+# Copyright 2015    Christoph Reiter
+#           2016-17 Nick Boultbee
+#           2019    Peter Strulo
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -163,6 +164,12 @@ class AdvancedPreferences(EventPlugin):
                 "settings", "pangocairo_force_fontconfig",
                 "Force Use Fontconfig Backend:",
                 "It's not the default on win/macOS (restart required)"))
+
+        rows.append(
+            text_config(
+                "browsers", "ignored_characters",
+                "Ignored characters: ",
+                "Characters to ignore in queries"))
 
         for (row, (label, entry, button)) in enumerate(rows):
             label.set_alignment(1.0, 0.5)

--- a/quodlibet/quodlibet/qltk/prefs.py
+++ b/quodlibet/quodlibet/qltk/prefs.py
@@ -267,7 +267,6 @@ class PreferencesWindow(UniqueWindow):
 
             def create_search_frame():
                 vb = Gtk.VBox(spacing=6)
-
                 hb = Gtk.HBox(spacing=6)
                 l = Gtk.Label(label=_("_Global filter:"))
                 l.set_use_underline(True)
@@ -280,21 +279,6 @@ class PreferencesWindow(UniqueWindow):
                 hb.pack_start(l, False, True, 0)
                 hb.pack_start(e, True, True, 0)
                 vb.pack_start(hb, False, True, 0)
-
-                hb = Gtk.HBox(spacing=6)
-                l = Gtk.Label(label=_("_Ignored characters:"))
-                l.set_use_underline(True)
-                entry = UndoEntry()
-                entry.set_tooltip_text(
-                    _("Characters to ignore in search queries"))
-                entry.set_text(config.get("browsers", "ignored_characters"))
-                entry.connect('changed', self._entry,
-                              'ignored_characters', 'browsers')
-                l.set_mnemonic_widget(entry)
-                hb.pack_start(l, False, True, 0)
-                hb.pack_start(entry, True, True, 0)
-                vb.pack_start(hb, False, True, 0)
-
                 # Translators: The heading of the preference group, no action
                 return qltk.Frame(C_("heading", "Search"), child=vb)
 

--- a/quodlibet/quodlibet/qltk/prefs.py
+++ b/quodlibet/quodlibet/qltk/prefs.py
@@ -267,6 +267,7 @@ class PreferencesWindow(UniqueWindow):
 
             def create_search_frame():
                 vb = Gtk.VBox(spacing=6)
+
                 hb = Gtk.HBox(spacing=6)
                 l = Gtk.Label(label=_("_Global filter:"))
                 l.set_use_underline(True)
@@ -279,6 +280,21 @@ class PreferencesWindow(UniqueWindow):
                 hb.pack_start(l, False, True, 0)
                 hb.pack_start(e, True, True, 0)
                 vb.pack_start(hb, False, True, 0)
+
+                hb = Gtk.HBox(spacing=6)
+                l = Gtk.Label(label=_("_Ignored characters:"))
+                l.set_use_underline(True)
+                entry = UndoEntry()
+                entry.set_tooltip_text(
+                    _("Characters to ignore in search queries"))
+                entry.set_text(config.get("browsers", "ignored_characters"))
+                entry.connect('changed', self._entry,
+                              'ignored_characters', 'browsers')
+                l.set_mnemonic_widget(entry)
+                hb.pack_start(l, False, True, 0)
+                hb.pack_start(entry, True, True, 0)
+                vb.pack_start(hb, False, True, 0)
+
                 # Translators: The heading of the preference group, no action
                 return qltk.Frame(C_("heading", "Search"), child=vb)
 

--- a/quodlibet/quodlibet/query/_query.py
+++ b/quodlibet/quodlibet/query/_query.py
@@ -7,7 +7,7 @@
 # the Free Software Foundation; either version 2 of the License, or
 # (at your option) any later version.
 
-from quodlibet import print_d
+from quodlibet import print_d, config
 from quodlibet.util.dprint import frame_info
 from . import _match as match
 from ._match import error, Node, False_
@@ -70,6 +70,8 @@ class Query(Node):
             pass
 
         if not set("#=").intersection(string):
+            for c in config.get("browsers", "ignored_characters"):
+                string = string.replace(c, "")
             parts = ["/%s/d" % re_escape(s) for s in string.split()]
             string = "&(" + ",".join(parts) + ")"
             self.string = string

--- a/quodlibet/quodlibet/query/_query.py
+++ b/quodlibet/quodlibet/query/_query.py
@@ -1,6 +1,7 @@
 # Copyright 2004-2005 Joe Wreschnig, Michael Urman
 #           2015-2018 Nick Boultbee,
-#                2016 Ryan Dellenbaugh
+#                2016 Ryan Dellenbaugh,
+#                2019 Peter Strulo
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/quodlibet/tests/test_query.py
+++ b/quodlibet/tests/test_query.py
@@ -498,6 +498,15 @@ class TQuery(TestCase):
         self.failUnless(Query("#(date > 0004)").search(self.s1))
         self.failUnless(Query("#(date > 0000)").search(self.s1))
 
+    def test_ignore_characters(self):
+        try:
+            config.set("browsers", "ignored_characters", "-")
+            self.failUnless(Query("Foo the Bar - mu").search(self.s2))
+            config.set("browsers", "ignored_characters", "1234")
+            self.failUnless(Query("4Fo13o 2th2e3 4Bar4").search(self.s2))
+        finally:
+            config.reset("browsers", "ignored_characters")
+
 
 class TQuery_get_type(TestCase):
     def test_red(self):


### PR DESCRIPTION
Closes #3198 

I've erred on the side of caution and only done the ignoring on text queries.

I've also gone for a default of no ignoring since I think it's easier to notice that you want to ignore a character than to notice you don't (after having a query inexplicably not work for example).