### PR TITLE
Closes #946: Rename cover filename option

### DIFF
--- a/quodlibet/quodlibet/qltk/prefs.py
+++ b/quodlibet/quodlibet/qltk/prefs.py
@@ -318,10 +318,11 @@ class PreferencesWindow(UniqueWindow):
             hb = Gtk.HBox(spacing=3)
 
             preferred_image_filename_tooltip = _(
-                "The album art image file to use when available "
-                "(supports wildcards)")
+                "The album art image file(s) to use when available "
+                "(supports wildcards). If you want to supply more "
+                "than one, separate them with commas.)
 
-            cb = CCB(_("_Preferred image filename:"),
+            cb = CCB(_("_Preferred image filename(s):"),
                      'albumart', 'force_filename', populate=True,
                      tooltip=preferred_image_filename_tooltip)
             hb.pack_start(cb, False, True, 0)

--- a/quodlibet/quodlibet/qltk/prefs.py
+++ b/quodlibet/quodlibet/qltk/prefs.py
@@ -316,16 +316,18 @@ class PreferencesWindow(UniqueWindow):
             vb.pack_start(cb, False, True, 0)
 
             hb = Gtk.HBox(spacing=3)
-            cb = CCB(_("_Fixed image filename:"),
+
+            preferred_image_filename_tooltip = _(
+                "The album art image file to use when available "
+                "(supports wildcards)")
+
+            cb = CCB(_("_Preferred image filename:"),
                      'albumart', 'force_filename', populate=True,
-                     tooltip=_("The single image filename to use if "
-                               "selected"))
+                     tooltip=preferred_image_filename_tooltip)
             hb.pack_start(cb, False, True, 0)
 
             entry = UndoEntry()
-            entry.set_tooltip_text(
-                    _("The album art image file to use when forced"
-                      " (supports wildcards)"))
+            entry.set_tooltip_text(preferred_image_filename_tooltip)
             entry.set_text(config.get("albumart", "filename"))
             entry.connect('changed', self.__changed_text, 'filename')
             # Disable entry when not forcing

--- a/quodlibet/quodlibet/qltk/prefs.py
+++ b/quodlibet/quodlibet/qltk/prefs.py
@@ -320,7 +320,7 @@ class PreferencesWindow(UniqueWindow):
             preferred_image_filename_tooltip = _(
                 "The album art image file(s) to use when available "
                 "(supports wildcards). If you want to supply more "
-                "than one, separate them with commas.)
+                "than one, separate them with commas.")
 
             cb = CCB(_("_Preferred image filename(s):"),
                      'albumart', 'force_filename', populate=True,


### PR DESCRIPTION
Label changed from fixed to preferred image filename(s). Also updated the tooltip and used it for both label and entry.

