### PR TITLE
Closes #1769: Allow multiple entries for cover files

### DIFF
--- a/quodlibet/quodlibet/util/cover/built_in.py
+++ b/quodlibet/quodlibet/util/cover/built_in.py
@@ -1,5 +1,6 @@
 # Copyright 2013 Simonas Kazlauskas
 #      2015-2018 Nick Boultbee
+#           2019 Joschua Gandert
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/quodlibet/quodlibet/util/cover/built_in.py
+++ b/quodlibet/quodlibet/util/cover/built_in.py
@@ -107,7 +107,7 @@ class FilesystemCover(CoverSourcePlugin):
                     # Use literal filename if globbing causes errors
                     path = os.path.join(base, filename)
 
-                    # We check this here, so we can search for alternative 
+                    # We check this here, so we can search for alternative
                     # files in case no preferred file was found.
                     if os.path.isfile(path):
                         images.append((score, path))

--- a/quodlibet/quodlibet/util/cover/built_in.py
+++ b/quodlibet/quodlibet/util/cover/built_in.py
@@ -94,8 +94,8 @@ class FilesystemCover(CoverSourcePlugin):
         base = self.song('~dirname')
         images = []
 
-        score = 100
         if config.getboolean("albumart", "force_filename"):
+            score = 100
             for filename in config.get("albumart", "filename").split(","):
                 # Remove white space to avoid confusion (e.g. "name, name2")
                 filename = filename.strip()

--- a/quodlibet/tests/test_util_cover.py
+++ b/quodlibet/tests/test_util_cover.py
@@ -133,6 +133,18 @@ class TCoverManager(TestCase):
 
         self.song['~filename'] = old_song_path
 
+    def test_multiple_entries(self):
+        config.set("albumart", "force_filename", str(True))
+        # the order of these is important, since bar should be
+        # preferred to both 'foo' files
+        # the spaces after the comma and last name are intentional
+        config.set("albumart", "filename", "bar*,foo.png, foo.jpg ")
+
+        for fn in ["foo.jpg", "foo.png", "bar.jpg"]:
+            f = self.add_file(fn)
+            assert path_equal(
+                os.path.abspath(self._find_cover(self.song).name), f)
+
     def test_intelligent(self):
         song = self.song
         song["artist"] = "Q-Man"


### PR DESCRIPTION
Allows multiple entries in preferred cover art filename (Preferences > Browsers > Album Art). Items at start of the comma-separated list have a higher priority than those at end.

Additionally with this change, the normal cover "search" algorithm will start, if the no preferred files were found.

With this change names containing `,`, or spaces at start or end cannot be directly specified anymore, but that shouldn't be a common use case. Of course, any feedback regarding this and the whole change in general is welcome.

Not perfect, but I'll do the user facing changes in #3235. (label rename in settings)