### PR TITLE
Added New Internal "~library" Tag.

### DIFF
--- a/quodlibet/formats/_audio.py
+++ b/quodlibet/formats/_audio.py
@@ -59,7 +59,8 @@ NUMERIC_ZERO_DEFAULT = {"~#skipcount", "~#playcount", "~#length", "~#bitrate"}
 NUMERIC_ZERO_DEFAULT.update(TIME_TAGS)
 NUMERIC_ZERO_DEFAULT.update(SIZE_TAGS)
 
-FILESYSTEM_TAGS = {"~filename", "~basename", "~dirname", "~mountpoint"}
+FILESYSTEM_TAGS = {"~filename", "~basename", "~dirname", "~mountpoint",
+                   "~library"}
 """Values are bytes in Linux instead of unicode"""
 
 SORT_TO_TAG = dict([(v, k) for (k, v) in TAG_TO_SORT.items()])

--- a/quodlibet/library/libraries.py
+++ b/quodlibet/library/libraries.py
@@ -720,7 +720,7 @@ class FileLibrary(PicklingLibrary):
             return False
 
         # first scan each path for new files
-        paths_to_load = []
+        elements_to_load = []
         for scan_path in paths:
             print_d("Scanning %r." % scan_path)
             desc = _("Scanning %s") % (fsn2text(unexpand(scan_path)))
@@ -738,7 +738,7 @@ class FileLibrary(PicklingLibrary):
                     # already loaded
                     if self.contains_filename(real_path):
                         continue
-                    paths_to_load.append(real_path)
+                    elements_to_load.append((scan_path, real_path))
 
         yield
 
@@ -748,10 +748,11 @@ class FileLibrary(PicklingLibrary):
                 task.copool(cofuncid)
 
             added = []
-            for real_path in task.gen(paths_to_load):
-                item = self.add_filename(real_path, False)
+            for element in task.gen(elements_to_load):
+                item = self.add_filename(element[1], False)
                 if item is not None:
                     added.append(item)
+                    item["~library"] = os.path.basename(element[0])
                     if len(added) > 100 or need_added():
                         self.add(added)
                         added = []


### PR DESCRIPTION
This PR creates a new internal tag, `~library`, which allows users to filter their music by library scan directory. This effectively treats each scan directory as a separate library or music collection.

Quodlibet already allows users to add multiple scan directories and people who are using this feature probably already have their music organized in a way that represents separate logical "libraries." In other words, if their music comes from different places, it's likely to represent a separate collection.

While you could achieve something similar using an explicit, external `collection` tag applied to every song in your library, that's both inconvenient and unnecessary if you already have your songs organized into logical collections on your file system. This can be inferred from the fact that they have been imported from separate scan directories. 

For example, say you have your main music library as `~/Music/Personal Collection` which contains all of your favorite artists. You might also have other folders in your library like `~/Work/Compositions` which contains music that you have made, or `~/Music/Soundtracks` which contains a collection of soundtracks. This is kind of how my personal music collection is organized. With this PR, those different locations will be stored using an internal tag named `~library`, which would have the following values:

```
Personal Collection
Compositions
Soundtracks
```

If the user wants, they can then create a new pane in the panned browser that allows them to filter their music by the associated library or use the search bar.