### PR TITLE
Support XDG Base Dirs: Electric Boogaloo

### DIFF
--- a/quodlibet/__init__.py
+++ b/quodlibet/__init__.py
@@ -29,7 +29,8 @@ from ._main import get_base_dir, is_release, app, \
 
 
 _, C_, N_, ngettext, npgettext, is_release, init, init_cli, print_e, \
-    get_base_dir, print_w, print_d, get_config_dir, app, set_application_info, \
+    get_base_dir, print_w, print_d, app, set_application_info, \
     init_plugins, enable_periodic_save, run, finish_first_session, \
-    get_image_dir, is_first_session, get_build_description, \
-    get_build_version, get_config_dir, get_data_dir, get_cache_dir, get_runtime_dir
+    get_image_dir, is_first_session, \
+    get_build_description, get_build_version, \
+    get_config_dir, get_data_dir, get_cache_dir, get_runtime_dir

--- a/quodlibet/__init__.py
+++ b/quodlibet/__init__.py
@@ -21,14 +21,15 @@ install_redirect_import_hook()
 from .util.i18n import _, C_, N_, ngettext, npgettext
 from .util.dprint import print_d, print_e, print_w
 from ._init import init_cli, init
-from ._main import get_base_dir, is_release, get_user_dir, app, \
+from ._main import get_base_dir, is_release, app, \
     set_application_info, init_plugins, enable_periodic_save, run, \
     finish_first_session, get_image_dir, is_first_session, \
-    get_build_description, get_build_version, get_cache_dir
+    get_build_description, get_build_version, \
+    get_config_dir, get_data_dir, get_cache_dir, get_runtime_dir
 
 
 _, C_, N_, ngettext, npgettext, is_release, init, init_cli, print_e, \
-    get_base_dir, print_w, print_d, get_user_dir, app, set_application_info, \
+    get_base_dir, print_w, print_d, app, set_application_info, \
     init_plugins, enable_periodic_save, run, finish_first_session, \
     get_image_dir, is_first_session, get_build_description, \
-    get_build_version, get_cache_dir
+    get_build_version, get_config_dir, get_data_dir, get_cache_dir, get_runtime_dir

--- a/quodlibet/__init__.py
+++ b/quodlibet/__init__.py
@@ -29,7 +29,7 @@ from ._main import get_base_dir, is_release, app, \
 
 
 _, C_, N_, ngettext, npgettext, is_release, init, init_cli, print_e, \
-    get_base_dir, print_w, print_d, app, set_application_info, \
+    get_base_dir, print_w, print_d, get_config_dir, app, set_application_info, \
     init_plugins, enable_periodic_save, run, finish_first_session, \
     get_image_dir, is_first_session, get_build_description, \
     get_build_version, get_config_dir, get_data_dir, get_cache_dir, get_runtime_dir

--- a/quodlibet/_main.py
+++ b/quodlibet/_main.py
@@ -247,6 +247,7 @@ def init_plugins(no_plugins=False):
     print_d("Starting plugin manager")
 
     from quodlibet import plugins
+    # FIXME: This should probably go to `~/.local/lib/quodlibet`
     folders = [os.path.join(get_base_dir(), "ext", kind)
                for kind in PLUGIN_DIRS]
     folders.append(os.path.join(get_user_dir(), "plugins"))
@@ -399,7 +400,7 @@ def run(window, before_quit=None):
     # gtk+ on osx is just too crashy
     if not is_osx():
         try:
-            faulthandling.enable(os.path.join(get_user_dir(), "faultdump"))
+            faulthandling.enable(os.path.join(get_cache_dir(), "faultdump"))
         except IOError:
             util.print_exc()
         else:

--- a/quodlibet/_main.py
+++ b/quodlibet/_main.py
@@ -136,8 +136,10 @@ def get_image_dir():
 def get_data_dir():
     """The directory to store things considered user-specific data files"""
 
-    fallback_dir = get_fallback_dir()
-    if fallback_dir:
+    fallback_dir, legacy = get_fallback_dir()
+    if legacy:
+        path = fallback_dir
+    elif fallback_dir:
         path = os.path.join(fallback_dir, "data")
     else:
         path = os.path.join(xdg_get_data_home(), "quodlibet")
@@ -150,8 +152,10 @@ def get_data_dir():
 def get_cache_dir():
     """The directory to store things which can be deleted at any time"""
 
-    fallback_dir = get_fallback_dir()
-    if fallback_dir:
+    fallback_dir, legacy = get_fallback_dir()
+    if legacy:
+        path = fallback_dir
+    elif fallback_dir:
         path = os.path.join(fallback_dir, "cache")
     else:
         path = os.path.join(xdg_get_cache_home(), "quodlibet")
@@ -164,8 +168,10 @@ def get_cache_dir():
 def get_runtime_dir():
     """The directory to store user-specific runtime files and other file objects"""
 
-    fallback_dir = get_fallback_dir()
-    if fallback_dir:
+    fallback_dir, legacy = get_fallback_dir()
+    if legacy:
+        path = fallback_dir
+    elif fallback_dir:
         path = os.path.join(fallback_dir, "runtime")
     else:
         path = os.path.join(xdg_get_runtime_dir(), "quodlibet")
@@ -178,8 +184,10 @@ def get_runtime_dir():
 def get_config_dir():
     """The directory to store user-specific configuration files"""
 
-    fallback_dir = get_fallback_dir()
-    if fallback_dir:
+    fallback_dir, legacy = get_fallback_dir()
+    if legacy:
+        path = fallback_dir
+    elif fallback_dir:
         path = os.path.join(fallback_dir, "config")  # TODO: Maybe without the config?
     else:
         path = os.path.join(xdg_get_config_home(), "quodlibet")
@@ -191,7 +199,7 @@ def get_config_dir():
 @cached_func
 def get_fallback_dir():
     """The fallback for non-Linux and ~/.quodlibet"""
-    USERDIR = None
+    USERDIR, legacy = None, False
 
     if os.name == "nt":
         USERDIR = os.path.join(windows.get_appdata_dir(), "Quod Libet")
@@ -200,7 +208,8 @@ def get_fallback_dir():
     else:  # Linux
         homedir = os.path.join(os.path.expanduser("~"), ".quodlibet")
         if os.path.exists(homedir):
-            USERDIR = homedir
+            # This is a legacy path
+            USERDIR, legacy = homedir, True
 
     # Bruteforce override
     if 'QUODLIBET_USERDIR' in environ:
@@ -211,7 +220,7 @@ def get_fallback_dir():
         USERDIR = os.path.normpath(os.path.join(
             os.path.dirname(path2fsn(sys.executable)), "..", "..", "config"))
 
-    return USERDIR
+    return USERDIR, legacy
 
 
 def is_release():

--- a/quodlibet/_main.py
+++ b/quodlibet/_main.py
@@ -136,9 +136,9 @@ def get_image_dir():
 def get_data_dir():
     """The directory to store things considered user-specific data files"""
 
-    if os.name == "nt" and build.BUILD_TYPE == u"windows-portable":
-        # avoid writing things to the host system for the portable build
-        path = os.path.join(get_config_dir(), "cache")
+    fallback_dir = get_fallback_dir()
+    if fallback_dir:
+        path = os.path.join(fallback_dir, "data")
     else:
         path = os.path.join(xdg_get_data_home(), "quodlibet")
 
@@ -150,9 +150,9 @@ def get_data_dir():
 def get_cache_dir():
     """The directory to store things which can be deleted at any time"""
 
-    if os.name == "nt" and build.BUILD_TYPE == u"windows-portable":
-        # avoid writing things to the host system for the portable build
-        path = os.path.join(get_config_dir(), "cache")
+    fallback_dir = get_fallback_dir()
+    if fallback_dir:
+        path = os.path.join(fallback_dir, "cache")
     else:
         path = os.path.join(xdg_get_cache_home(), "quodlibet")
 
@@ -164,9 +164,9 @@ def get_cache_dir():
 def get_runtime_dir():
     """The directory to store user-specific runtime files and other file objects"""
 
-    if os.name == "nt" and build.BUILD_TYPE == u"windows-portable":
-        # avoid writing things to the host system for the portable build
-        path = os.path.join(get_config_dir(), "runtime")
+    fallback_dir = get_fallback_dir()
+    if fallback_dir:
+        path = os.path.join(fallback_dir, "runtime")
     else:
         path = os.path.join(xdg_get_runtime_dir(), "quodlibet")
 
@@ -178,28 +178,38 @@ def get_runtime_dir():
 def get_config_dir():
     """The directory to store user-specific configuration files"""
 
+    fallback_dir = get_fallback_dir()
+    if fallback_dir:
+        path = os.path.join(fallback_dir, "config")  # TODO: Maybe without the config?
+    else:
+        path = os.path.join(xdg_get_config_home(), "quodlibet")
+
+    mkdir(path, 0o750)
+    return path
+
+
+@cached_func
+def get_fallback_dir():
+    """The fallback for non-Linux and ~/.quodlibet"""
+    USERDIR = None
+
     if os.name == "nt":
         USERDIR = os.path.join(windows.get_appdata_dir(), "Quod Libet")
     elif is_osx():
         USERDIR = os.path.join(os.path.expanduser("~"), ".quodlibet")
-    else:
-        USERDIR = os.path.join(xdg_get_config_home(), "quodlibet")
+    else:  # Linux
+        homedir = os.path.join(os.path.expanduser("~"), ".quodlibet")
+        if os.path.exists(homedir):
+            USERDIR = homedir
 
-        if not os.path.exists(USERDIR):
-            tmp = os.path.join(os.path.expanduser("~"), ".quodlibet")
-            if os.path.exists(tmp):
-                USERDIR = tmp
-
+    # Bruteforce override
     if 'QUODLIBET_USERDIR' in environ:
         USERDIR = environ['QUODLIBET_USERDIR']
 
     if build.BUILD_TYPE == u"windows-portable":
+        # avoid writing things to the host system for the portable build
         USERDIR = os.path.normpath(os.path.join(
             os.path.dirname(path2fsn(sys.executable)), "..", "..", "config"))
-
-    # XXX: users shouldn't assume the dir is there, but we currently do in
-    # some places
-    mkdir(USERDIR, 0o750)
 
     return USERDIR
 

--- a/quodlibet/_main.py
+++ b/quodlibet/_main.py
@@ -268,9 +268,9 @@ def init_plugins(no_plugins=False):
     print_d("Starting plugin manager")
 
     from quodlibet import plugins
-    # FIXME: This should probably go to `~/.local/lib/quodlibet`
     folders = [os.path.join(get_base_dir(), "ext", kind)
                for kind in PLUGIN_DIRS]
+    folders.append(os.path.join(get_fallback_dir(), "plugins"))
     folders.append(os.path.join(get_config_dir(), "plugins"))
     print_d("Scanning folders: %s" % folders)
     pm = plugins.init(folders, no_plugins)

--- a/quodlibet/_main.py
+++ b/quodlibet/_main.py
@@ -16,7 +16,7 @@ from quodlibet import const
 from quodlibet import build
 from quodlibet.util import cached_func, windows, set_process_title, is_osx
 from quodlibet.util.dprint import print_d
-from quodlibet.util.path import mkdir, xdg_get_config_home, xdg_get_cache_home
+from quodlibet.util.path import mkdir, xdg_get_config_home, xdg_get_data_home, xdg_get_cache_home
 
 
 PLUGIN_DIRS = ["editing", "events", "playorder", "songsmenu", "playlist",
@@ -131,8 +131,22 @@ def get_image_dir():
 
 
 @cached_func
+def get_data_dir():
+    """The directory to store things considered user-specific data files"""
+
+    if os.name == "nt" and build.BUILD_TYPE == u"windows-portable":
+        # avoid writing things to the host system for the portable build
+        path = os.path.join(get_user_dir(), "cache")
+    else:
+        path = os.path.join(xdg_get_data_home(), "quodlibet")
+
+    mkdir(path, 0o700)
+    return path
+
+
+@cached_func
 def get_cache_dir():
-    """The directory to store things into which can be deleted at any time"""
+    """The directory to store things which can be deleted at any time"""
 
     if os.name == "nt" and build.BUILD_TYPE == u"windows-portable":
         # avoid writing things to the host system for the portable build

--- a/quodlibet/_main.py
+++ b/quodlibet/_main.py
@@ -166,7 +166,8 @@ def get_cache_dir():
 
 @cached_func
 def get_runtime_dir():
-    """The directory to store user-specific runtime files and other file objects"""
+    """The directory to store user-specific runtime files and other file
+    objects"""
 
     fallback_dir, legacy = get_fallback_dir()
     if legacy:
@@ -188,7 +189,8 @@ def get_config_dir():
     if legacy:
         path = fallback_dir
     elif fallback_dir:
-        path = os.path.join(fallback_dir, "config")  # TODO: Maybe without the config?
+        # TODO: Maybe without the config?
+        path = os.path.join(fallback_dir, "config")
     else:
         path = os.path.join(xdg_get_config_home(), "quodlibet")
 

--- a/quodlibet/_main.py
+++ b/quodlibet/_main.py
@@ -138,7 +138,7 @@ def get_data_dir():
 
     if os.name == "nt" and build.BUILD_TYPE == u"windows-portable":
         # avoid writing things to the host system for the portable build
-        path = os.path.join(get_user_dir(), "cache")
+        path = os.path.join(get_config_dir(), "cache")
     else:
         path = os.path.join(xdg_get_data_home(), "quodlibet")
 
@@ -152,7 +152,7 @@ def get_cache_dir():
 
     if os.name == "nt" and build.BUILD_TYPE == u"windows-portable":
         # avoid writing things to the host system for the portable build
-        path = os.path.join(get_user_dir(), "cache")
+        path = os.path.join(get_config_dir(), "cache")
     else:
         path = os.path.join(xdg_get_cache_home(), "quodlibet")
 
@@ -166,7 +166,7 @@ def get_runtime_dir():
 
     if os.name == "nt" and build.BUILD_TYPE == u"windows-portable":
         # avoid writing things to the host system for the portable build
-        path = os.path.join(get_user_dir(), "runtime")
+        path = os.path.join(get_config_dir(), "runtime")
     else:
         path = os.path.join(xdg_get_runtime_dir(), "quodlibet")
 
@@ -175,8 +175,8 @@ def get_runtime_dir():
 
 
 @cached_func
-def get_user_dir():
-    """Place where QL saves its state, database, config etc."""
+def get_config_dir():
+    """The directory to store user-specific configuration files"""
 
     if os.name == "nt":
         USERDIR = os.path.join(windows.get_appdata_dir(), "Quod Libet")
@@ -250,7 +250,7 @@ def init_plugins(no_plugins=False):
     # FIXME: This should probably go to `~/.local/lib/quodlibet`
     folders = [os.path.join(get_base_dir(), "ext", kind)
                for kind in PLUGIN_DIRS]
-    folders.append(os.path.join(get_user_dir(), "plugins"))
+    folders.append(os.path.join(get_config_dir(), "plugins"))
     print_d("Scanning folders: %s" % folders)
     pm = plugins.init(folders, no_plugins)
     pm.rescan()

--- a/quodlibet/_main.py
+++ b/quodlibet/_main.py
@@ -16,7 +16,9 @@ from quodlibet import const
 from quodlibet import build
 from quodlibet.util import cached_func, windows, set_process_title, is_osx
 from quodlibet.util.dprint import print_d
-from quodlibet.util.path import mkdir, xdg_get_config_home, xdg_get_data_home, xdg_get_cache_home
+from quodlibet.util.path import mkdir, \
+        xdg_get_config_home, xdg_get_data_home, \
+        xdg_get_cache_home, xdg_get_runtime_dir
 
 
 PLUGIN_DIRS = ["editing", "events", "playorder", "songsmenu", "playlist",
@@ -153,6 +155,20 @@ def get_cache_dir():
         path = os.path.join(get_user_dir(), "cache")
     else:
         path = os.path.join(xdg_get_cache_home(), "quodlibet")
+
+    mkdir(path, 0o700)
+    return path
+
+
+@cached_func
+def get_runtime_dir():
+    """The directory to store user-specific runtime files and other file objects"""
+
+    if os.name == "nt" and build.BUILD_TYPE == u"windows-portable":
+        # avoid writing things to the host system for the portable build
+        path = os.path.join(get_user_dir(), "runtime")
+    else:
+        path = os.path.join(xdg_get_runtime_dir(), "quodlibet")
 
     mkdir(path, 0o700)
     return path

--- a/quodlibet/browsers/albums/main.py
+++ b/quodlibet/browsers/albums/main.py
@@ -424,7 +424,7 @@ class AlbumList(Browser, util.InstanceTracker, VisibleUpdate,
     __last_render = None
     __last_render_surface = None
 
-    _PATTERN_FN = os.path.join(quodlibet.get_user_dir(), "album_pattern")
+    _PATTERN_FN = os.path.join(quodlibet.get_data_dir(), "album_pattern")  # TODO: Maybe on the Config folder?
     _DEFAULT_PATTERN_TEXT = DEFAULT_PATTERN_TEXT
 
     name = _("Album List")

--- a/quodlibet/browsers/albums/main.py
+++ b/quodlibet/browsers/albums/main.py
@@ -424,7 +424,8 @@ class AlbumList(Browser, util.InstanceTracker, VisibleUpdate,
     __last_render = None
     __last_render_surface = None
 
-    _PATTERN_FN = os.path.join(quodlibet.get_data_dir(), "album_pattern")  # TODO: Maybe on the Config folder?
+    # TODO: Maybe on the Config folder?
+    _PATTERN_FN = os.path.join(quodlibet.get_data_dir(), "album_pattern")
     _DEFAULT_PATTERN_TEXT = DEFAULT_PATTERN_TEXT
 
     name = _("Album List")

--- a/quodlibet/browsers/audiofeeds.py
+++ b/quodlibet/browsers/audiofeeds.py
@@ -35,7 +35,7 @@ from quodlibet.qltk.x import ScrolledWindow, Align, Button, MenuItem
 from quodlibet.util.picklehelper import pickle_load, pickle_dump, PickleError
 
 
-FEEDS = os.path.join(quodlibet.get_user_dir(), "feeds")
+FEEDS = os.path.join(quodlibet.get_data_dir(), "feeds")
 DND_URI_LIST, DND_MOZ_URL = range(2)
 
 # Migration path for pickle

--- a/quodlibet/browsers/covergrid/main.py
+++ b/quodlibet/browsers/covergrid/main.py
@@ -119,7 +119,8 @@ class CoverGrid(Browser, util.InstanceTracker, VisibleUpdate,
     __last_render = None
     __last_render_surface = None
 
-    _PATTERN_FN = os.path.join(quodlibet.get_data_dir(), "album_pattern")  # TODO: Maybe on the Config folder?
+    # TODO: Maybe on the Config folder?
+    _PATTERN_FN = os.path.join(quodlibet.get_data_dir(), "album_pattern")
     _DEFAULT_PATTERN_TEXT = DEFAULT_PATTERN_TEXT
     STAR = ["~people", "album"]
 

--- a/quodlibet/browsers/covergrid/main.py
+++ b/quodlibet/browsers/covergrid/main.py
@@ -119,7 +119,7 @@ class CoverGrid(Browser, util.InstanceTracker, VisibleUpdate,
     __last_render = None
     __last_render_surface = None
 
-    _PATTERN_FN = os.path.join(quodlibet.get_user_dir(), "album_pattern")
+    _PATTERN_FN = os.path.join(quodlibet.get_data_dir(), "album_pattern")  # TODO: Maybe on the Config folder?
     _DEFAULT_PATTERN_TEXT = DEFAULT_PATTERN_TEXT
     STAR = ["~people", "album"]
 

--- a/quodlibet/browsers/iradio.py
+++ b/quodlibet/browsers/iradio.py
@@ -53,8 +53,8 @@ from quodlibet.qltk.menubutton import MenuButton
 
 STATION_LIST_URL = \
     "https://quodlibet.github.io/radio/radiolist.bz2"
-STATIONS_FAV = os.path.join(quodlibet.get_user_dir(), "stations")
-STATIONS_ALL = os.path.join(quodlibet.get_user_dir(), "stations_all")
+STATIONS_FAV = os.path.join(quodlibet.get_data_dir(), "stations")
+STATIONS_ALL = os.path.join(quodlibet.get_cache_dir(), "stations_all")
 
 # TODO: - Do the update in a thread
 #       - Ranking: reduce duplicate stations (max 3 URLs per station)

--- a/quodlibet/browsers/playlists/main.py
+++ b/quodlibet/browsers/playlists/main.py
@@ -51,7 +51,8 @@ class PlaylistsBrowser(Browser, DisplayPatternMixin):
     priority = 2
     replaygain_profiles = ["track"]
     __last_render = None
-    _PATTERN_FN = os.path.join(quodlibet.get_data_dir(), "playlist_pattern")  # TODO: Maybe on the Config folder?
+    # TODO: Maybe on the Config folder?
+    _PATTERN_FN = os.path.join(quodlibet.get_data_dir(), "playlist_pattern")
     _DEFAULT_PATTERN_TEXT = DEFAULT_PATTERN_TEXT
 
     def pack(self, songpane):

--- a/quodlibet/browsers/playlists/main.py
+++ b/quodlibet/browsers/playlists/main.py
@@ -51,7 +51,7 @@ class PlaylistsBrowser(Browser, DisplayPatternMixin):
     priority = 2
     replaygain_profiles = ["track"]
     __last_render = None
-    _PATTERN_FN = os.path.join(quodlibet.get_user_dir(), "playlist_pattern")
+    _PATTERN_FN = os.path.join(quodlibet.get_data_dir(), "playlist_pattern")  # TODO: Maybe on the Config folder?
     _DEFAULT_PATTERN_TEXT = DEFAULT_PATTERN_TEXT
 
     def pack(self, songpane):

--- a/quodlibet/browsers/playlists/util.py
+++ b/quodlibet/browsers/playlists/util.py
@@ -22,7 +22,7 @@ from quodlibet.util.path import mkdir, uri_is_valid
 
 
 # Directory for playlist files
-PLAYLISTS = os.path.join(quodlibet.get_user_dir(), "playlists")
+PLAYLISTS = os.path.join(quodlibet.get_data_dir(), "playlists")
 assert isinstance(PLAYLISTS, fsnative)
 if not os.path.isdir(PLAYLISTS):
     mkdir(PLAYLISTS)

--- a/quodlibet/config.py
+++ b/quodlibet/config.py
@@ -49,6 +49,7 @@ INITIAL: Dict[str, Dict[str, str]] = {
         "refresh_on_start": "true",
     },
 
+    # TODO: Move this to a separate file in `get_cache_dir`
     # State about the player, to restore on startup
     "memory": {
 

--- a/quodlibet/errorreport/main.py
+++ b/quodlibet/errorreport/main.py
@@ -159,7 +159,7 @@ def errorhook(exc_info=None):
         return
 
     # write error and logs to disk
-    dump_dir = os.path.join(quodlibet.get_user_dir(), "dumps")
+    dump_dir = os.path.join(quodlibet.get_cache_dir(), "dumps")  # TODO: maybe `get_data_dir`?
     dump_to_disk(dump_dir, exc_info)
 
     sentry = get_sentry()

--- a/quodlibet/errorreport/main.py
+++ b/quodlibet/errorreport/main.py
@@ -159,7 +159,8 @@ def errorhook(exc_info=None):
         return
 
     # write error and logs to disk
-    dump_dir = os.path.join(quodlibet.get_cache_dir(), "dumps")  # TODO: maybe `get_data_dir`?
+    # TODO: maybe `get_data_dir`?
+    dump_dir = os.path.join(quodlibet.get_cache_dir(), "dumps")
     dump_to_disk(dump_dir, exc_info)
 
     sentry = get_sentry()

--- a/quodlibet/errorreport/main.py
+++ b/quodlibet/errorreport/main.py
@@ -158,8 +158,7 @@ def errorhook(exc_info=None):
         # Make sure only one of these is active at a time
         return
 
-    # write error and logs to disk
-    # TODO: maybe `get_data_dir`?
+    # write error and logs to disk (cache folder)
     dump_dir = os.path.join(quodlibet.get_cache_dir(), "dumps")
     dump_to_disk(dump_dir, exc_info)
 

--- a/quodlibet/exfalso.py
+++ b/quodlibet/exfalso.py
@@ -23,7 +23,7 @@ def main(argv=None):
 
     import quodlibet
 
-    config_file = os.path.join(quodlibet.get_user_dir(), "config")
+    config_file = os.path.join(quodlibet.get_config_dir(), "config")
     quodlibet.init(config_file=config_file)
 
     from quodlibet.qltk import add_signal_watch

--- a/quodlibet/ext/events/appinfo.py
+++ b/quodlibet/ext/events/appinfo.py
@@ -16,7 +16,8 @@ from quodlibet.qltk import Icons
 from quodlibet.util.path import unexpand
 from quodlibet.plugins.events import EventPlugin
 from quodlibet import formats
-from quodlibet import app, get_user_dir, get_runtime_dir, get_cache_dir
+from quodlibet import app, get_user_dir, get_data_dir, \
+        get_runtime_dir, get_cache_dir
 from quodlibet.util import fver, escape
 from quodlibet.qltk import gtk_version, pygobject_version, get_backend_name, \
     get_font_backend_name
@@ -69,6 +70,13 @@ class AppInformation(EventPlugin):
         grid.insert_row(row)
         l = label_title(_("Configuration Directory"))
         v = label_path(get_user_dir())
+        grid.attach(l, 0, row, 1, 1)
+        grid.attach(v, 1, row, 1, 1)
+        row += 1
+
+        grid.insert_row(row)
+        l = label_title(_("Data Directory"))
+        v = label_path(get_data_dir())
         grid.attach(l, 0, row, 1, 1)
         grid.attach(v, 1, row, 1, 1)
         row += 1

--- a/quodlibet/ext/events/appinfo.py
+++ b/quodlibet/ext/events/appinfo.py
@@ -29,7 +29,7 @@ class AppInformation(EventPlugin):
     PLUGIN_NAME = _("Application Information")
     PLUGIN_DESC = _("Various information about the application and its "
                     "environment.")
-    PLUGIN_CAN_ENABLE = False
+    PLUGIN_CAN_ENABLE = True
     PLUGIN_ICON = Icons.PREFERENCES_SYSTEM
 
     def PluginPreferences(self, *args):

--- a/quodlibet/ext/events/appinfo.py
+++ b/quodlibet/ext/events/appinfo.py
@@ -16,7 +16,7 @@ from quodlibet.qltk import Icons
 from quodlibet.util.path import unexpand
 from quodlibet.plugins.events import EventPlugin
 from quodlibet import formats
-from quodlibet import app, get_user_dir, get_data_dir, \
+from quodlibet import app, get_config_dir, get_data_dir, \
         get_runtime_dir, get_cache_dir
 from quodlibet.util import fver, escape
 from quodlibet.qltk import gtk_version, pygobject_version, get_backend_name, \
@@ -69,7 +69,7 @@ class AppInformation(EventPlugin):
 
         grid.insert_row(row)
         l = label_title(_("Configuration Directory"))
-        v = label_path(get_user_dir())
+        v = label_path(get_config_dir())
         grid.attach(l, 0, row, 1, 1)
         grid.attach(v, 1, row, 1, 1)
         row += 1

--- a/quodlibet/ext/events/appinfo.py
+++ b/quodlibet/ext/events/appinfo.py
@@ -16,7 +16,7 @@ from quodlibet.qltk import Icons
 from quodlibet.util.path import unexpand
 from quodlibet.plugins.events import EventPlugin
 from quodlibet import formats
-from quodlibet import app, get_user_dir, get_cache_dir
+from quodlibet import app, get_user_dir, get_runtime_dir, get_cache_dir
 from quodlibet.util import fver, escape
 from quodlibet.qltk import gtk_version, pygobject_version, get_backend_name, \
     get_font_backend_name
@@ -76,6 +76,13 @@ class AppInformation(EventPlugin):
         grid.insert_row(row)
         l = label_title(_("Cache Directory"))
         v = label_path(get_cache_dir())
+        grid.attach(l, 0, row, 1, 1)
+        grid.attach(v, 1, row, 1, 1)
+        row += 1
+
+        grid.insert_row(row)
+        l = label_title(_("Runtime Directory"))
+        v = label_path(get_runtime_dir())
         grid.attach(l, 0, row, 1, 1)
         grid.attach(v, 1, row, 1, 1)
         row += 1

--- a/quodlibet/ext/events/jep118.py
+++ b/quodlibet/ext/events/jep118.py
@@ -14,7 +14,7 @@ from quodlibet import util
 from quodlibet.qltk import Icons
 from quodlibet.plugins.events import EventPlugin
 
-outfile = os.path.join(quodlibet.get_user_dir(), "jabber")
+outfile = os.path.join(quodlibet.get_cache_dir(), "jabber")
 format = """\
 <tune xmlns='http://jabber.org/protocol/tune'>
  <artist>%s</artist>
@@ -28,7 +28,7 @@ format = """\
 class JEP118(EventPlugin):
     PLUGIN_ID = "JEP-118"
     PLUGIN_NAME = _("JEP-118")
-    PLUGIN_DESC = _("Outputs a Jabber User Tunes file to ~/.quodlibet/jabber.")
+    PLUGIN_DESC = _("Outputs a Jabber User Tunes file to $XDG_CACHE_HOME/jabber")
     PLUGIN_ICON = Icons.DOCUMENT_SAVE
 
     def plugin_on_song_started(self, song):

--- a/quodlibet/ext/events/jep118.py
+++ b/quodlibet/ext/events/jep118.py
@@ -28,7 +28,8 @@ format = """\
 class JEP118(EventPlugin):
     PLUGIN_ID = "JEP-118"
     PLUGIN_NAME = _("JEP-118")
-    PLUGIN_DESC = _("Outputs a Jabber User Tunes file to $XDG_CACHE_HOME/jabber")
+    PLUGIN_DESC = \
+            _("Outputs a Jabber User Tunes file to `$XDG_CACHE_HOME/jabber`.")
     PLUGIN_ICON = Icons.DOCUMENT_SAVE
 
     def plugin_on_song_started(self, song):

--- a/quodlibet/ext/events/qlscrobbler.py
+++ b/quodlibet/ext/events/qlscrobbler.py
@@ -89,7 +89,7 @@ class QLSubmitQueue:
     CLIENT = "qlb"
     CLIENT_VERSION = const.VERSION
     PROTOCOL_VERSION = "1.2"
-    DUMP = os.path.join(quodlibet.get_user_dir(), "scrobbler_cache_v2")
+    DUMP = os.path.join(quodlibet.get_cache_dir(), "scrobbler_cache_v2")
 
     # These objects are shared across instances, to allow other plugins to
     # queue scrobbles in future versions of QL

--- a/quodlibet/ext/events/write_cover.py
+++ b/quodlibet/ext/events/write_cover.py
@@ -20,8 +20,7 @@ from quodlibet.qltk import Icons
 
 
 def get_path():
-    # TODO: get XDG_RUNTIME_DIR
-    default = os.path.join(quodlibet.get_config_dir(), "current.cover")
+    default = os.path.join(quodlibet.get_runtime_dir(), "current.cover")
     return config.get("plugins", __name__, default=default)
 
 

--- a/quodlibet/ext/events/write_cover.py
+++ b/quodlibet/ext/events/write_cover.py
@@ -21,7 +21,7 @@ from quodlibet.qltk import Icons
 
 def get_path():
     # TODO: get XDG_RUNTIME_DIR
-    default = os.path.join(quodlibet.get_user_dir(), "current.cover")
+    default = os.path.join(quodlibet.get_config_dir(), "current.cover")
     return config.get("plugins", __name__, default=default)
 
 

--- a/quodlibet/ext/events/write_cover.py
+++ b/quodlibet/ext/events/write_cover.py
@@ -20,6 +20,7 @@ from quodlibet.qltk import Icons
 
 
 def get_path():
+    # TODO: get XDG_RUNTIME_DIR
     default = os.path.join(quodlibet.get_user_dir(), "current.cover")
     return config.get("plugins", __name__, default=default)
 

--- a/quodlibet/ext/query/savedsearch.py
+++ b/quodlibet/ext/query/savedsearch.py
@@ -11,7 +11,7 @@ from quodlibet import _
 from quodlibet.plugins.query import QueryPlugin, QueryPluginError
 from quodlibet.query import Query
 from quodlibet.query._match import error as QueryError
-from quodlibet import get_user_dir
+from quodlibet import get_data_dir
 
 
 class IncludeSavedSearchQuery(QueryPlugin):
@@ -32,7 +32,7 @@ class IncludeSavedSearchQuery(QueryPlugin):
         if query_path_:
             query_path = query_path_
         else:
-            query_path = os.path.join(get_user_dir(), 'lists', 'queries.saved')
+            query_path = os.path.join(get_data_dir(), 'lists', 'queries.saved')
         try:
             with open(query_path, 'r', encoding="utf-8") as query_file:
                 for query_string in query_file:

--- a/quodlibet/ext/songsmenu/custom_commands.py
+++ b/quodlibet/ext/songsmenu/custom_commands.py
@@ -174,7 +174,7 @@ class CustomCommands(PlaylistPlugin, SongsMenuPlugin, PluginConfigMixin):
     ]
 
     COMS_FILE = os.path.join(
-        quodlibet.get_user_dir(), 'lists', 'customcommands.json')
+        quodlibet.get_data_dir(), 'lists', 'customcommands.json')
 
     _commands = None
     """Commands known to the class"""

--- a/quodlibet/ext/songsmenu/lastfmsync.py
+++ b/quodlibet/ext/songsmenu/lastfmsync.py
@@ -246,7 +246,7 @@ class LastFMSync(SongsMenuPlugin):
                     "Last.fm profile.")
     PLUGIN_ICON = Icons.EMBLEM_SHARED
 
-    CACHE_PATH = os.path.join(quodlibet.get_user_dir(), "lastfmsync.db")
+    CACHE_PATH = os.path.join(quodlibet.get_cache_dir(), "lastfmsync.db")
 
     def runner(self, cache):
         changed = True

--- a/quodlibet/ext/songsmenu/website_search.py
+++ b/quodlibet/ext/songsmenu/website_search.py
@@ -56,7 +56,7 @@ class WebsiteSearch(SongsMenuPlugin):
         ("Go to ~website", "<website>"),
     ]
     PATTERNS_FILE = os.path.join(
-        quodlibet.get_user_dir(), 'lists', 'searchsites')
+        quodlibet.get_data_dir(), 'lists', 'searchsites')
 
     _no_launch = False
 

--- a/quodlibet/main.py
+++ b/quodlibet/main.py
@@ -23,7 +23,7 @@ def main(argv=None):
 
     import quodlibet
 
-    config_file = os.path.join(quodlibet.get_user_dir(), "config")
+    config_file = os.path.join(quodlibet.get_config_dir(), "config")
     quodlibet.init_cli(config_file=config_file)
 
     try:
@@ -161,7 +161,7 @@ def main(argv=None):
     mmkeys_handler.start()
 
     # TODO: get XDG_RUNTIME_DIR
-    current_path = os.path.join(quodlibet.get_user_dir(), "current")
+    current_path = os.path.join(quodlibet.get_config_dir(), "current")
     fsiface = FSInterface(current_path, player)
     remote = Remote(app, cmd_registry)
     try:

--- a/quodlibet/main.py
+++ b/quodlibet/main.py
@@ -160,8 +160,7 @@ def main(argv=None):
     mmkeys_handler = MMKeysHandler(app)
     mmkeys_handler.start()
 
-    # TODO: get XDG_RUNTIME_DIR
-    current_path = os.path.join(quodlibet.get_config_dir(), "current")
+    current_path = os.path.join(quodlibet.get_runtime_dir(), "current")
     fsiface = FSInterface(current_path, player)
     remote = Remote(app, cmd_registry)
     try:

--- a/quodlibet/main.py
+++ b/quodlibet/main.py
@@ -52,7 +52,7 @@ def main(argv=None):
     app.process_name = "quodlibet"
     quodlibet.set_application_info(app)
 
-    library_path = os.path.join(quodlibet.get_user_dir(), "songs")
+    library_path = os.path.join(quodlibet.get_data_dir(), "songs")
 
     print_d("Initializing main library (%s)" % (
             quodlibet.util.path.unexpand(library_path)))
@@ -160,6 +160,7 @@ def main(argv=None):
     mmkeys_handler = MMKeysHandler(app)
     mmkeys_handler.start()
 
+    # TODO: get XDG_RUNTIME_DIR
     current_path = os.path.join(quodlibet.get_user_dir(), "current")
     fsiface = FSInterface(current_path, player)
     remote = Remote(app, cmd_registry)

--- a/quodlibet/main.py
+++ b/quodlibet/main.py
@@ -13,6 +13,7 @@ import os
 from senf import environ, argv as sys_argv
 
 from quodlibet import _
+from quodlibet import config
 from quodlibet.cli import process_arguments, exit_
 from quodlibet.util.dprint import print_d, print_, print_exc
 
@@ -23,6 +24,7 @@ def main(argv=None):
 
     import quodlibet
 
+    config.migrate_legacy_data(move=False)  # TODO: When tested, `move=True`?
     config_file = os.path.join(quodlibet.get_config_dir(), "config")
     quodlibet.init_cli(config_file=config_file)
 
@@ -42,7 +44,6 @@ def main(argv=None):
 
     import quodlibet.player
     import quodlibet.library
-    from quodlibet import config
     from quodlibet import browsers
     from quodlibet import util
 

--- a/quodlibet/qltk/queue.py
+++ b/quodlibet/qltk/queue.py
@@ -32,8 +32,7 @@ from quodlibet.qltk.x import ScrolledWindow, SymbolicIconImage, \
     SmallImageButton, SmallImageToggleButton, MenuItem, RadioMenuItem
 from quodlibet.qltk.songlistcolumns import CurrentColumn
 
-# TODO: get XDG_RUNTIME_DIR
-QUEUE = os.path.join(quodlibet.get_data_dir(), "queue")
+QUEUE = os.path.join(quodlibet.get_runtime_dir(), "queue")
 
 
 class PlaybackStatusIcon(Gtk.Box):

--- a/quodlibet/qltk/queue.py
+++ b/quodlibet/qltk/queue.py
@@ -32,7 +32,8 @@ from quodlibet.qltk.x import ScrolledWindow, SymbolicIconImage, \
     SmallImageButton, SmallImageToggleButton, MenuItem, RadioMenuItem
 from quodlibet.qltk.songlistcolumns import CurrentColumn
 
-QUEUE = os.path.join(quodlibet.get_user_dir(), "queue")
+# TODO: get XDG_RUNTIME_DIR
+QUEUE = os.path.join(quodlibet.get_data_dir(), "queue")
 
 
 class PlaybackStatusIcon(Gtk.Box):

--- a/quodlibet/qltk/quodlibetwindow.py
+++ b/quodlibet/qltk/quodlibetwindow.py
@@ -280,7 +280,6 @@ class TopBar(Gtk.Toolbar):
         self._pattern_box = Gtk.VBox()
 
         # song text
-        # FIXME: this `songinfo` file is not used anywhere?
         info_pattern_path = os.path.join(quodlibet.get_data_dir(), "songinfo")
         text = SongInfo(library.librarian, player, info_pattern_path)
         self._pattern_box.pack_start(Align(text, border=3), True, True, 0)

--- a/quodlibet/qltk/quodlibetwindow.py
+++ b/quodlibet/qltk/quodlibetwindow.py
@@ -579,7 +579,7 @@ class QuodLibetWindow(Window, PersistentWindowMixin, AppWindow):
         accel_group.connect(keyval, mod, 0, scroll_and_jump)
 
         # custom accel map
-        accel_fn = os.path.join(quodlibet.get_user_dir(), "accels")
+        accel_fn = os.path.join(quodlibet.get_config_dir(), "accels")
         Gtk.AccelMap.load(accel_fn)
         # save right away so we fill the file with example comments of all
         # accels

--- a/quodlibet/qltk/quodlibetwindow.py
+++ b/quodlibet/qltk/quodlibetwindow.py
@@ -280,7 +280,8 @@ class TopBar(Gtk.Toolbar):
         self._pattern_box = Gtk.VBox()
 
         # song text
-        info_pattern_path = os.path.join(quodlibet.get_user_dir(), "songinfo")
+        # FIXME: this `songinfo` file is not used anywhere?
+        info_pattern_path = os.path.join(quodlibet.get_data_dir(), "songinfo")
         text = SongInfo(library.librarian, player, info_pattern_path)
         self._pattern_box.pack_start(Align(text, border=3), True, True, 0)
         box.pack_start(self._pattern_box, True, True, 0)

--- a/quodlibet/qltk/renamefiles.py
+++ b/quodlibet/qltk/renamefiles.py
@@ -36,7 +36,7 @@ from quodlibet.util import connect_obj
 from quodlibet.util.path import strip_win32_incompat_from_path
 from quodlibet.util.dprint import print_d, print_e
 
-NBP = os.path.join(quodlibet.get_user_dir(), "lists", "renamepatterns")
+NBP = os.path.join(quodlibet.get_data_dir(), "lists", "renamepatterns")
 NBP_EXAMPLES = """\
 <tracknumber>. <title>
 <tracknumber|<tracknumber>. ><title>

--- a/quodlibet/qltk/searchbar.py
+++ b/quodlibet/qltk/searchbar.py
@@ -50,7 +50,7 @@ class SearchBarBox(Gtk.Box):
 
         if filename is None:
             filename = os.path.join(
-                quodlibet.get_user_dir(), "lists", "queries")
+                quodlibet.get_data_dir(), "lists", "queries")
 
         combo = ComboBoxEntrySave(filename, count=8,
                                   validator=validator,
@@ -280,7 +280,7 @@ class MultiSearchBarBox(LimitSearchBarBox):
         super().__init__(*args, **kwargs)
 
         self.multi_filename = os.path.join(
-            quodlibet.get_user_dir(), "lists", "multiqueries"
+            quodlibet.get_data_dir(), "lists", "multiqueries"
         ) if multi_filename is None else multi_filename
 
         self._old_placeholder = self._entry.get_placeholder_text()

--- a/quodlibet/qltk/tagsfrompath.py
+++ b/quodlibet/qltk/tagsfrompath.py
@@ -34,7 +34,7 @@ from quodlibet.util import connect_obj
 from quodlibet.plugins.editing import TagsFromPathPlugin
 
 
-TBP = os.path.join(quodlibet.get_user_dir(), "lists", "tagpatterns")
+TBP = os.path.join(quodlibet.get_data_dir(), "lists", "tagpatterns")
 TBP_EXAMPLES = """\
 <tracknumber>. <title>
 <tracknumber> - <title>

--- a/quodlibet/remote.py
+++ b/quodlibet/remote.py
@@ -12,7 +12,7 @@ from typing import Type
 from senf import path2fsn, fsn2bytes, bytes2fsn, fsnative
 
 from quodlibet.util import fifo, print_w
-from quodlibet import get_user_dir
+from quodlibet import get_config_dir
 try:
     from quodlibet.util import winpipe
 except ImportError:
@@ -115,7 +115,7 @@ class QuodLibetUnixRemote(RemoteBase):
 
     _FIFO_NAME = "control"
     # TODO: get XDG_RUNTIME_DIR
-    _PATH = os.path.join(get_user_dir(), _FIFO_NAME)
+    _PATH = os.path.join(get_config_dir(), _FIFO_NAME)
 
     def __init__(self, app, cmd_registry):
         self._app = app

--- a/quodlibet/remote.py
+++ b/quodlibet/remote.py
@@ -12,7 +12,7 @@ from typing import Type
 from senf import path2fsn, fsn2bytes, bytes2fsn, fsnative
 
 from quodlibet.util import fifo, print_w
-from quodlibet import get_config_dir
+from quodlibet import get_runtime_dir
 try:
     from quodlibet.util import winpipe
 except ImportError:
@@ -114,8 +114,7 @@ class QuodLibetWinRemote(RemoteBase):
 class QuodLibetUnixRemote(RemoteBase):
 
     _FIFO_NAME = "control"
-    # TODO: get XDG_RUNTIME_DIR
-    _PATH = os.path.join(get_config_dir(), _FIFO_NAME)
+    _PATH = os.path.join(get_runtime_dir(), _FIFO_NAME)
 
     def __init__(self, app, cmd_registry):
         self._app = app

--- a/quodlibet/remote.py
+++ b/quodlibet/remote.py
@@ -114,6 +114,7 @@ class QuodLibetWinRemote(RemoteBase):
 class QuodLibetUnixRemote(RemoteBase):
 
     _FIFO_NAME = "control"
+    # TODO: get XDG_RUNTIME_DIR
     _PATH = os.path.join(get_user_dir(), _FIFO_NAME)
 
     def __init__(self, app, cmd_registry):

--- a/quodlibet/util/path.py
+++ b/quodlibet/util/path.py
@@ -23,6 +23,7 @@ from senf import (fsnative, bytes2fsn, fsn2bytes, expanduser, sep, expandvars,
 from . import windows
 from .environment import is_windows
 from .misc import environ, NamedTemporaryFile
+from .util import print_w
 
 if sys.platform == "darwin":
     from Foundation import NSString
@@ -249,7 +250,7 @@ def xdg_get_runtime_dir():
     else:
         # > fall back to a replacement directory with similar capabilities and
         # > print a warning message
-        # TODO: print a warning message?
+        print_w('Using the cache as runtime directory')
         return xdg_get_cache_home()
 
 

--- a/quodlibet/util/path.py
+++ b/quodlibet/util/path.py
@@ -21,9 +21,9 @@ from senf import (fsnative, bytes2fsn, fsn2bytes, expanduser, sep, expandvars,
                   fsn2text, path2fsn, uri2fsn)
 
 from . import windows
+from . import print_w
 from .environment import is_windows
 from .misc import environ, NamedTemporaryFile
-from .util import print_w
 
 if sys.platform == "darwin":
     from Foundation import NSString

--- a/quodlibet/util/path.py
+++ b/quodlibet/util/path.py
@@ -238,6 +238,21 @@ def xdg_get_config_home():
         return os.path.join(os.path.expanduser("~"), ".config")
 
 
+def xdg_get_runtime_dir():
+    if os.name == "nt":
+        from gi.repository import GLib
+        return glib2fsn(GLib.get_user_runtime_dir())
+
+    data_home = os.getenv("XDG_RUNTIME_DIR")
+    if data_home:
+        return os.path.abspath(data_home)
+    else:
+        # > fall back to a replacement directory with similar capabilities and
+        # > print a warning message
+        # TODO: print a warning message?
+        return xdg_get_cache_home()
+
+
 def parse_xdg_user_dirs(data):
     """Parses xdg-user-dirs and returns a dict of keys and paths.
 

--- a/tests/test___init__.py
+++ b/tests/test___init__.py
@@ -33,7 +33,7 @@ class TQuodlibet(TestCase):
     def test_dirs(self):
         self.assertTrue(isinstance(quodlibet.get_base_dir(), fsnative))
         self.assertTrue(isinstance(quodlibet.get_image_dir(), fsnative))
-        self.assertTrue(isinstance(quodlibet.get_user_dir(), fsnative))
+        self.assertTrue(isinstance(quodlibet.get_config_dir(), fsnative))
         self.assertTrue(isinstance(quodlibet.get_cache_dir(), fsnative))
         self.assertTrue(isinstance(quodlibet.get_data_dir(), fsnative))
 

--- a/tests/test___init__.py
+++ b/tests/test___init__.py
@@ -35,6 +35,7 @@ class TQuodlibet(TestCase):
         self.assertTrue(isinstance(quodlibet.get_image_dir(), fsnative))
         self.assertTrue(isinstance(quodlibet.get_user_dir(), fsnative))
         self.assertTrue(isinstance(quodlibet.get_cache_dir(), fsnative))
+        self.assertTrue(isinstance(quodlibet.get_data_dir(), fsnative))
 
     def test_get_build_description(self):
         quodlibet.get_build_description()


### PR DESCRIPTION
Check-list
----------

 * [x] There is a linked issue discussing the motivations for this feature or bugfix
 * [ ] Unit tests have been added where possible
 * [ ] I've added / updated documentation for any user-facing features.
 * [x] Performance seems to be comparable or better than current `master`


What this change is adding / fixing
-----------------------------------

First up, I'm not too familiar with Quodlibet architecture, but I'm fluent in Python and this seemed like a good first issue.

First pass on #2202 , the XDG Base Dirs: Electric Boogaloo. I followed @op3's battle plan.

This supports the legacy `~/.quodlibet` folder better than the current code(see point 1), and the new configuration is taken from the same location for post-#138, so this doesn't lose data.

At best, you will need to migrate some data from `~/.config` to `~/.local/share`:

- `~/.config/quodlibet/lists` to `~/.local/share/quodlibet/lists`
- `~/.config/quodlibet/playlists` to `~/.local/share/quodlibet/playlists`
- `~/.config/quodlibet/feeds` to `~/.local/share/quodlibet/feeds`
- `~/.config/quodlibet/stations` to `~/.local/share/quodlibet/stations`
- `~/.config/quodlibet/stations_all` to `~/.cache/quodlibet/stations_all`, but if this is not done the Online Radio prompt should kick in and redownload it

After moving these files, clear everything from `~/.config/quodlibet` except `config` and `accels` (this is a better location for this, methinks).
We can also automatically migrate this, or consider having a fallback (to the config folder), but with loud nagging of the user.

This should be mentioned on the release notes.

I haven't look around on the tests not the docs yet.

---

1) By this I mean the current code only considers `~/.quodlibet` if it can't find the XDG directories. It should be the other way around.