### PR TITLE
Plugins: don't use `map` / `unmap` `GTK.Menu` signals

### DIFF
--- a/quodlibet/quodlibet/ext/songsmenu/bookmarks.py
+++ b/quodlibet/quodlibet/ext/songsmenu/bookmarks.py
@@ -1,5 +1,5 @@
 # Copyright 2006 Joe Wreschnig, 2010 Christoph Reiter
-#           2016 Nick Boultbee
+#           2016, 2020 Nick Boultbee
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -29,7 +29,7 @@ class Bookmarks(SongsMenuPlugin):
     def __init__(self, songs, *args, **kwargs):
         super(Bookmarks, self).__init__(songs, *args, **kwargs)
         self.__menu = Gtk.Menu()
-        self.__menu.connect('map', self.__create_children, songs)
+        self.__create_children(self.__menu, songs)
         self.set_submenu(self.__menu)
 
     class FakePlayer(object):

--- a/quodlibet/quodlibet/ext/songsmenu/embedded.py
+++ b/quodlibet/quodlibet/ext/songsmenu/embedded.py
@@ -1,5 +1,5 @@
 # Copyright 2013 Christoph Reiter
-#     2013, 2016 Nick Boultbee
+#     2013,2016,2020 Nick Boultbee
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -32,8 +32,7 @@ class EditEmbedded(SongsMenuPlugin):
     def __init__(self, songs, *args, **kwargs):
         super(EditEmbedded, self).__init__(songs, *args, **kwargs)
         self.__menu = Gtk.Menu()
-        self.__menu.connect('map', self.__map, songs)
-        self.__menu.connect('unmap', self.__unmap)
+        self._init_submenu_items(self.__menu, songs)
         self.set_submenu(self.__menu)
 
     def __remove_images(self, menu_item, songs):
@@ -77,7 +76,7 @@ class EditEmbedded(SongsMenuPlugin):
         win.destroy()
         self.plugin_finish()
 
-    def __map(self, menu, songs):
+    def _init_submenu_items(self, menu, songs):
         remove_item = MenuItem(_("_Remove all Images"), "edit-delete")
         remove_item.connect('activate', self.__remove_images, songs)
         menu.append(remove_item)
@@ -87,10 +86,7 @@ class EditEmbedded(SongsMenuPlugin):
         menu.append(set_item)
 
         menu.show_all()
-
-    def __unmap(self, menu):
-        for child in self.__menu.get_children():
-            self.__menu.remove(child)
+        return menu
 
     def plugin_songs(self, songs):
         return True


### PR DESCRIPTION
...not sure when these stopped working, but they don't seem to and doing standard initialisation works fine here (and is used in other places).

This fixes #3291
