### PR TITLE
ext/inhibit: Add option to inhibit suspend

### DIFF
--- a/quodlibet/quodlibet/ext/events/inhibit.py
+++ b/quodlibet/quodlibet/ext/events/inhibit.py
@@ -1,4 +1,5 @@
 # Copyright 2011 Christoph Reiter <reiter.christoph@gmail.com>
+# Copyright 2020 Antigone <mail@antigone.xyz>
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -14,9 +15,11 @@ if os.name == "nt" or sys.platform == "darwin":
 
 from gi.repository import Gio
 from gi.repository import GLib
+from gi.repository import Gtk
 
 from quodlibet import _
 from quodlibet import app
+from quodlibet import config
 from quodlibet.qltk import Icons
 from quodlibet.plugins.events import EventPlugin
 
@@ -37,12 +40,20 @@ class InhibitFlags(object):
     IDLE = 1 << 3
 
 
+class InhibitStrings(object):
+    SUSPEND = "inhibit_suspend"
+    IDLE = "inhibit_idle"
+
+
 class SessionInhibit(EventPlugin):
     PLUGIN_ID = "screensaver_inhibit"
-    PLUGIN_NAME = _("Inhibit Screensaver")
-    PLUGIN_DESC = _("Prevents the GNOME screensaver from activating while"
-                    " a song is playing.")
+    PLUGIN_NAME = _("Inhibit Screensaver/Suspend")
+    PLUGIN_DESC = _("On a GNOME desktop, when a song is playing, prevents"
+                    " either the screensaver from activating, or prevents the"
+                    " computer from suspending.")
     PLUGIN_ICON = Icons.PREFERENCES_DESKTOP_SCREENSAVER
+
+    CONFIG_MODE = PLUGIN_ID + "_mode"
 
     DBUS_NAME = "org.gnome.SessionManager"
     DBUS_INTERFACE = "org.gnome.SessionManager"
@@ -71,7 +82,9 @@ class SessionInhibit(EventPlugin):
 
     def plugin_on_unpaused(self):
         xid = get_toplevel_xid()
-        flags = InhibitFlags.IDLE
+        mode = config.get("plugins", self.CONFIG_MODE, InhibitStrings.IDLE)
+        flags = InhibitFlags.SUSPEND if mode == InhibitStrings.SUSPEND \
+                                     else InhibitFlags.IDLE
 
         try:
             dbus_proxy = self.__get_dbus_proxy()
@@ -91,3 +104,27 @@ class SessionInhibit(EventPlugin):
             self.__cookie = None
         except GLib.Error:
             pass
+
+    def PluginPreferences(self, parent):
+        def changed(combo):
+            index = combo.get_active()
+            mode = InhibitStrings.SUSPEND if index == 1 \
+                                          else InhibitStrings.IDLE
+            config.set("plugins", self.CONFIG_MODE, mode)
+            if not app.player.paused:
+                self.plugin_on_paused()
+                self.plugin_on_unpaused()
+
+        mode = config.get("plugins", self.CONFIG_MODE, InhibitStrings.IDLE)
+
+        hb = Gtk.HBox(spacing=6)
+        hb.set_border_width(6)
+        # Translators: Inhibiting Mode
+        hb.pack_start(Gtk.Label(label=_("Mode:")), False, True, 0)
+        combo = Gtk.ComboBoxText()
+        combo.append_text(_("Inhibit Screensaver"))
+        combo.append_text(_("Inhibit Suspend"))
+        combo.set_active(1 if mode == InhibitStrings.SUSPEND else 0)
+        combo.connect('changed', changed)
+        hb.pack_start(combo, True, True, 0)
+        return hb


### PR DESCRIPTION
ext/inhibit: Add option to inhibit either

- screensaver (default, as before) or
- suspend (new).

Resolves #2665.

Check-list
----------

 * [x] There is a linked issue discussing the motivations for this feature or bugfix
 * [x] Unit tests have been added where possible
 * [x] I've added / updated documentation for any user-facing features.
 * [x] Performance seems to be comparable or better than current `master`


What this change is adding / fixing
-----------------------------------
    ext/inhibit: Add option to inhibit suspend (as requested through #2665)
