### PR TITLE
win_installer: pass options to build script on env switch

### DIFF
--- a/win_installer/build.sh
+++ b/win_installer/build.sh
@@ -16,7 +16,7 @@ function main {
 
     # started from the wrong env -> switch
     if [ $(echo "$MSYSTEM" | tr '[A-Z]' '[a-z]') != "$MINGW" ]; then
-        "/${MINGW}.exe" "$0"
+        "/${MINGW}.exe" "$0" "$1"
         exit $?
     fi
 


### PR DESCRIPTION
Check-list
----------

 * [ ] There is a linked issue discussing the motivations for this feature or bugfix
 * [ ] Unit tests have been added where possible
 * [ ] I've added / updated documentation for any user-facing features.
 * [ ] Performance seems to be comparable or better than current `master`


What this change is adding / fixing
-----------------------------------
The Windows installer build script spawns itself, if it's not in the MINGW console. It doesn't pass the original options, though, and builds only from master. Any git tag given as an option is lost.

I have discovered this in my copy of your build script at https://github.com/gkarsay/parlatype/blob/master/build-aux/win32/build.sh and tested it with my copy.
