### PR TITLE
Format date panes (#3346)

### DIFF
--- a/quodlibet/browsers/paned/models.py
+++ b/quodlibet/browsers/paned/models.py
@@ -1,4 +1,5 @@
 # Copyright 2013 Christoph Reiter
+#           2020 Nick Boultbee
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -6,6 +7,8 @@
 # (at your option) any later version.
 
 import re
+from typing import Tuple, Text
+from quodlibet.browsers.paned.util import PaneConfig
 
 from quodlibet import _
 from quodlibet import util
@@ -59,7 +62,7 @@ class SongsEntry(BaseEntry):
     def get_count_text(self, config):
         return config.format_display(self)
 
-    def get_text(self, config):
+    def get_text(self, config: PaneConfig) -> Tuple[bool, Text]:
         if config.has_markup:
             return True, self.key
         else:

--- a/quodlibet/browsers/paned/util.py
+++ b/quodlibet/browsers/paned/util.py
@@ -9,12 +9,12 @@
 import re
 from typing import Tuple, Text, List
 
-from formats import TIME_TAGS
+from quodlibet.formats import TIME_TAGS
 from quodlibet import config
 from quodlibet import util
 from quodlibet.formats import AudioFile
 from quodlibet.pattern import XMLFromMarkupPattern as XMLFromPattern
-from util.string.date import format_date
+from quodlibet.util.string.date import format_date
 
 
 class PaneConfig(object):

--- a/quodlibet/browsers/paned/util.py
+++ b/quodlibet/browsers/paned/util.py
@@ -1,4 +1,5 @@
 # Copyright 2013 Christoph Reiter
+#           2020 Nick Boultbee
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -6,11 +7,14 @@
 # (at your option) any later version.
 
 import re
+from typing import Tuple, Text, List
 
+from formats import TIME_TAGS
 from quodlibet import config
 from quodlibet import util
-
+from quodlibet.formats import AudioFile
 from quodlibet.pattern import XMLFromMarkupPattern as XMLFromPattern
+from util.string.date import format_date
 
 
 class PaneConfig(object):
@@ -25,14 +29,17 @@ class PaneConfig(object):
     """
 
     def __init__(self, row_pattern):
-        parts = re.split(r"(?<!\\):", row_pattern)
-        parts = list(map(lambda p: p.replace(r"\:", ":"), parts))
+        parts = [p.replace(r"\:", ":")
+                 for p in (re.split(r"(?<!\\):", row_pattern))]
 
         is_numeric = lambda s: s[:2] == "~#" and "~" not in s[2:]
         is_pattern = lambda s: '<' in s
         f_round = lambda s: (isinstance(s, float) and "%.2f" % s) or s
 
-        disp = (len(parts) >= 2 and parts[1]) or r"[i](<~#tracks>)[/i]"
+        def is_date(s):
+            return s in TIME_TAGS
+
+        disp = parts[1] if len(parts) >= 2 else r"[i](<~#tracks>)[/i]"
         cat = parts[0]
 
         if is_pattern(cat):
@@ -48,13 +55,19 @@ class PaneConfig(object):
             title = util.tag(cat)
             tags = util.tagsplit(cat)
             has_markup = False
-            if is_numeric(cat):
-
-                def format(song):
+            if is_date(cat):
+                def format(song: AudioFile) -> List[Tuple[Text, Text]]:
+                    fmt = config.gettext("settings",
+                                         "datecolumn_timestamp_format")
+                    date_str = format_date(song(cat), fmt)
+                    return [(date_str, date_str)]
+            elif is_numeric(cat):
+                def format(song: AudioFile) -> List[Tuple[Text, Text]]:
                     v = str(f_round(song(cat)))
                     return [(v, v)]
             else:
-                format = lambda song: song.list_separate(cat)
+                def format(song: AudioFile) -> List[Tuple[Text, Text]]:
+                    return song.list_separate(cat)
 
         if is_pattern(disp):
             try:

--- a/quodlibet/qltk/songlistcolumns.py
+++ b/quodlibet/qltk/songlistcolumns.py
@@ -1,6 +1,6 @@
 # Copyright 2005 Joe Wreschnig
 #           2012 Christoph Reiter
-#      2011-2014 Nick Boultbee
+#      2011-2020 Nick Boultbee
 #           2014 Jan Path
 #
 # This program is free software; you can redistribute it and/or modify
@@ -8,12 +8,10 @@
 # the Free Software Foundation; either version 2 of the License, or
 # (at your option) any later version.
 
-import time
-import datetime
-
 from gi.repository import Gtk, Pango, GLib, Gio
 from senf import fsnative, fsn2text
 
+from quodlibet.util.string.date import format_date
 from quodlibet import _
 from quodlibet import util
 from quodlibet import config
@@ -86,7 +84,6 @@ def _highlight_current_cell(cr, background_area, cell_area, flags):
 
 
 class SongListCellAreaBox(Gtk.CellAreaBox):
-
     highlight = False
 
     def do_render(self, context, widget, cr, background_area, cell_area,
@@ -275,30 +272,8 @@ class DateColumn(WideTextColumn):
         if not stamp:
             cell.set_property('text', _("Never"))
         else:
-            try:
-                date = datetime.datetime.fromtimestamp(stamp).date()
-            except (OverflowError, ValueError, OSError):
-                text = u""
-            else:
-                format_setting = config.gettext("settings",
-                                      "datecolumn_timestamp_format")
-
-                # use format configured in Advanced Preferences
-                if format_setting:
-                    format_ = format_setting
-                # use default behaviour-format
-                else:
-                    today = datetime.datetime.now().date()
-                    days = (today - date).days
-                    if days == 0:
-                        format_ = "%X"
-                    elif days < 7:
-                        format_ = "%A"
-                    else:
-                        format_ = "%x"
-
-                stamp = time.localtime(stamp)
-                text = time.strftime(format_, stamp)
+            fmt = config.gettext("settings", "datecolumn_timestamp_format")
+            text = format_date(stamp, fmt)
             cell.set_property('text', text)
 
 

--- a/quodlibet/util/string/date.py
+++ b/quodlibet/util/string/date.py
@@ -1,0 +1,34 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+
+from datetime import datetime
+from time import localtime, strftime
+from typing import Text, Optional
+
+
+def format_date(stamp: float, format_setting: Optional[Text] = None) -> Text:
+    """Formats a date either with the default format,
+     or the passed strftime-compatible format string"""
+    try:
+        date = datetime.fromtimestamp(stamp).date()
+    except (OverflowError, ValueError, OSError):
+        text = u""
+    else:
+        if format_setting:
+            format_ = format_setting
+        # use default behaviour-format
+        else:
+            today = datetime.now().date()
+            days = (today - date).days
+            if days == 0:
+                format_ = "%X"
+            elif days < 7:
+                format_ = "%A"
+            else:
+                format_ = "%x"
+
+        stamp = localtime(stamp)
+        text = strftime(format_, stamp)
+    return text

--- a/quodlibet/util/string/date.py
+++ b/quodlibet/util/string/date.py
@@ -8,11 +8,11 @@ from time import localtime, strftime
 from typing import Text, Optional
 
 
-def format_date(stamp: float, format_setting: Optional[Text] = None) -> Text:
+def format_date(seconds: float, format_setting: Optional[Text] = None) -> Text:
     """Formats a date either with the default format,
      or the passed strftime-compatible format string"""
     try:
-        date = datetime.fromtimestamp(stamp).date()
+        date = datetime.fromtimestamp(seconds).date()
     except (OverflowError, ValueError, OSError):
         text = u""
     else:
@@ -29,6 +29,6 @@ def format_date(stamp: float, format_setting: Optional[Text] = None) -> Text:
             else:
                 format_ = "%x"
 
-        stamp = localtime(stamp)
+        stamp = localtime(seconds)
         text = strftime(format_, stamp)
     return text

--- a/tests/test_browsers_paned.py
+++ b/tests/test_browsers_paned.py
@@ -4,6 +4,7 @@
 # (at your option) any later version.
 
 from tests import TestCase
+from util.string.date import format_date
 from .helper import realized
 
 from gi.repository import Gtk
@@ -190,11 +191,14 @@ class TPaneConfig(TestCase):
         self.failIf(p.has_markup)
 
     def test_numeric(self):
+        a_date_format = "%Y-%m-%d"
+        config.set("settings", "datecolumn_timestamp_format", a_date_format)
         p = PaneConfig("~#lastplayed")
         self.failUnlessEqual(p.title, "Last Played")
         self.failUnlessEqual(p.tags, {"~#lastplayed"})
 
-        self.failUnlessEqual(p.format(SONGS[0]), [("0", "0")])
+        zero_date = format_date(0, a_date_format)
+        self.failUnlessEqual(p.format(SONGS[0]), [(zero_date, zero_date)])
         self.failIf(p.has_markup)
 
     def test_tied(self):

--- a/tests/test_browsers_paned.py
+++ b/tests/test_browsers_paned.py
@@ -4,7 +4,6 @@
 # (at your option) any later version.
 
 from tests import TestCase
-from util.string.date import format_date
 from .helper import realized
 
 from gi.repository import Gtk
@@ -22,6 +21,7 @@ from quodlibet.browsers.paned.prefs import PreferencesButton, ColumnMode
 from quodlibet.browsers.paned.pane import Pane
 from quodlibet.formats import AudioFile
 from quodlibet.util.collection import Collection
+from quodlibet.util.string.date import format_date
 from quodlibet.library import SongLibrary, SongLibrarian
 
 SONGS = [


### PR DESCRIPTION
Paned browser: format time tags (#3346)

 * Extract date logic from `DateColumn`
 * Tidy / add typing to existing code, a bit.
 * If pane config looks datelike, use a date formatter


Check-list
----------

 * [x] There is a linked issue discussing the motivations for this feature or bugfix
 * [x] Unit tests have been added where possible
