### PR TITLE
Fix setting pane mode

### DIFF
--- a/quodlibet/browsers/paned/prefs.py
+++ b/quodlibet/browsers/paned/prefs.py
@@ -62,7 +62,7 @@ class ColumnModeSelection(Gtk.VBox):
             selected_mode = ColumnMode.WIDE
         if self.buttons[2].get_active():
             selected_mode = ColumnMode.COLUMNAR
-        config.set("browsers", "pane_mode", selected_mode)
+        config.set("browsers", "pane_mode", int(selected_mode))
         self.browser.set_all_column_mode(selected_mode)
 
 


### PR DESCRIPTION
Check-list
----------

 * [x] There is a linked issue discussing the motivations for this feature or bugfix
 * [ ] Unit tests have been added where possible
 * [ ] I've added / updated documentation for any user-facing features.
 * [x] Performance seems to be comparable or better than current `master`

What this change is adding / fixing
-----------------------------------
When setting `pane_mode` via the GUI, the config file contains something like this:
```
pane_mode = ColumnMode.COLUMNAR
```

This is due to the fact that ColumnMode is an enum and casting it to a string returns the enum name. However, the config code expects an int. Manually setting `pane_mode` to an int in the config file fixes the problem, so we just cast it to an int before setting the config value.

Fixes #3367