### PR TITLE
MQTT authentication

### DIFF
--- a/quodlibet/ext/events/mqtt.py
+++ b/quodlibet/ext/events/mqtt.py
@@ -66,7 +66,8 @@ class MqttPublisherPlugin(EventPlugin, PluginConfigMixin):
 
     def __init__(self) -> None:
         super().__init__()
-        self.song = self.host = self.port = self.username = self.password = self.topic = None
+        self.song = self.host = self.port = self.topic = None
+        self.username = self.password = None
         self.status = Config.EMPTY_STATUS
 
     def on_connect(self, client, userdata, flags, rc):

--- a/quodlibet/ext/events/mqtt.py
+++ b/quodlibet/ext/events/mqtt.py
@@ -21,7 +21,6 @@ _TOTAL_MQTT_ITEMS = 5
 
 try:
     import paho.mqtt.client as mqtt
-    import paho.mqtt.publish as publish
 except ImportError:
     from quodlibet.plugins import MissingModulePluginException
     raise MissingModulePluginException('paho-mqtt')


### PR DESCRIPTION
What this change is adding / fixing
-----------------------------------
Add a username and password field to the MQTT extension and adopt the client to use authentication when these fields are filled in.