### PR TITLE
macos: bundle.sh: clone from ../.. rather than .., fixing #3393.

### DIFF
--- a/dev-utils/osx_bundle/bundle.sh
+++ b/dev-utils/osx_bundle/bundle.sh
@@ -59,7 +59,7 @@ function main {
 
     # clone this repo and install into the bundle
     CLONE="$QL_OSXBUNDLE_BUNDLE_DEST"/_temp_clone
-    git clone ../ "$CLONE"
+    git clone ../.. "$CLONE"
     (cd "$CLONE"; git checkout "$GIT_TAG")
     jhbuild run "$PYTHON" "$CLONE"/setup.py install \
         --prefix="$APP_PREFIX" \


### PR DESCRIPTION
Check-list
----------

 * [x] There is a linked issue discussing the motivations for this feature or bugfix
    * #3394
 * [x] Unit tests have been added where possible
    * (not applicable)
 * [x] I've added / updated documentation for any user-facing features.
    * (not applicable)
 * [x] Performance seems to be comparable or better than current `master`
    * (not applicable)

What this change is adding / fixing
-----------------------------------
`dev-utils/osx_bundle/bundle.sh` is broken since 227c1e7f9fcf due to repo
reorganization. This patch changes the source path for the `git clone` command
to fix it.