### PR TITLE
Support for mock-confirmer for ConfirmationPrompt (and example of usage)

### DIFF
--- a/quodlibet/browsers/playlists/util.py
+++ b/quodlibet/browsers/playlists/util.py
@@ -7,13 +7,13 @@
 
 import os
 
-from gi.repository import Gtk
 from senf import uri2fsn, fsnative, fsn2text, path2fsn, bytes2fsn, text2fsn
 
 import quodlibet
 from quodlibet import _, print_d
-from quodlibet import formats, qltk
+from quodlibet import formats
 from quodlibet.qltk import Icons
+from quodlibet.qltk.msg import ConfirmationPrompt
 from quodlibet.qltk.getstring import GetStringDialog
 from quodlibet.qltk.wlw import WaitLoadWindow
 from quodlibet.util import escape
@@ -28,20 +28,28 @@ if not os.path.isdir(PLAYLISTS):
     mkdir(PLAYLISTS)
 
 
-class ConfirmRemovePlaylistDialog(qltk.Message):
-    def __init__(self, parent, playlist):
-        title = (_("Are you sure you want to delete the playlist '%s'?")
-                 % escape(playlist.name))
-        description = (_("All information about the selected playlist "
-                         "will be deleted and can not be restored."))
+def confirm_remove_playlist_dialog_invoke(
+    parent, playlist, Confirmer=ConfirmationPrompt):
+    """Creates and invokes a confirmation dialog that asks the user whether or not
+       to go forth with the deletion of the selected playlist.
 
-        super().__init__(
-            Gtk.MessageType.WARNING, parent, title, description,
-            Gtk.ButtonsType.NONE)
+       Confirmer needs to accept the arguments for constructing a dialog,
+       have a run-method returning a response, and have a RESPONSE_INVOKE
+       attribute.
 
-        self.add_button(_("_Cancel"), Gtk.ResponseType.CANCEL)
-        self.add_icon_button(_("_Delete"), Icons.EDIT_DELETE,
-                             Gtk.ResponseType.YES)
+       returns the result of comparing the result of run to RESPONSE_INVOKE
+    """
+    title = (_("Are you sure you want to delete the playlist '%s'?")
+             % escape(playlist.name))
+    description = (_("All information about the selected playlist "
+                     "will be deleted and can not be restored."))
+    ok_text = _("_Delete")
+    ok_icon = Icons.EDIT_DELETE
+
+    dialog = Confirmer(parent, title, description, ok_text, ok_icon)
+    prompt = dialog.run()
+    response = (prompt == Confirmer.RESPONSE_INVOKE)
+    return response
 
 
 class GetPlaylistName(GetStringDialog):

--- a/quodlibet/qltk/msg.py
+++ b/quodlibet/qltk/msg.py
@@ -19,8 +19,7 @@ class Message(Gtk.MessageDialog, Dialog):
     """A message dialog that destroys itself after it is run, uses
     markup, and defaults to an 'OK' button."""
 
-    def __init__(
-        self, kind, parent, title, description, buttons=Gtk.ButtonsType.OK):
+    def __init__(self, kind, parent, title, description, buttons=Gtk.ButtonsType.OK):
         parent = get_top_parent(parent)
         text = ("<span weight='bold' size='larger'>%s</span>\n\n%s"
                 % (title, description))
@@ -82,17 +81,14 @@ class ConfirmationPrompt(WarningMessage):
     """Dialog to confirm actions, given a parent, title, description, and
        OK-button text"""
 
-    RESPONSE_INVOKE = 1
+    RESPONSE_INVOKE = Gtk.ResponseType.YES
 
-    def __init__(self, parent, title, description, ok_button_text):
-        super().__init__(
-            get_top_parent(parent),
-            title, description,
-            buttons=Gtk.ButtonsType.NONE)
+    def __init__(self, parent, title, description, ok_button_text,
+                 ok_button_icon=Icons.SYSTEM_RUN):
+        super().__init__(parent, title, description, buttons=Gtk.ButtonsType.NONE)
 
         self.add_button(_("_Cancel"), Gtk.ResponseType.CANCEL)
-        self.add_icon_button(ok_button_text, Icons.SYSTEM_RUN,
-                             self.RESPONSE_INVOKE)
+        self.add_icon_button(ok_button_text, ok_button_icon, self.RESPONSE_INVOKE)
         self.set_default_response(Gtk.ResponseType.CANCEL)
 
 


### PR DESCRIPTION
PlaylistsBrowser now has a Confirmer parameter which is passed to dialog-creation helper functions. The dialog instantiates Confirmer and calls its run method, then compares the response-type run returned to the stored accept-RESPONSE_TYPE in Confirmer.

Also changed one more instance of a prompt to use ConfirmationPrompt
instead of a duplicated manually constructed one.

Also gave ConfirmationPrompt an icon-paramater for the ok-button (default as what it already had).

ConfirmationPrompt now uses the enum Gtk.ResponseType.YES as opposed
to a hardcoded 1.

Minor style cleanup now that line lengths of 88 characters are fine.

Check-list
----------

 * [x] There is a linked issue discussing the motivations for this feature or bugfix
 * [x] Unit tests have been added where possible
 * [x] I've added / updated documentation for any user-facing features.
 * [x] Performance seems to be comparable or better than current `master`


What this change is adding / fixing
-----------------------------------
Steps towards making the monkeypatching discussed in #2746 unnecessary to achieve the same. See also #2453.

There should be *no* functional changes with these commits, only code-cleanliness and the possibility for a confirmer.