### PR TITLE
Fix weighted shuffle not shuffling when total rating is zero.

### DIFF
--- a/quodlibet/order/reorder.py
+++ b/quodlibet/order/reorder.py
@@ -50,6 +50,9 @@ class OrderWeighted(Reorder, OrderRemembered):
             return None
 
         total_score = sum([song('~#rating') for song in remaining.values()])
+        if total_score == 0:
+            # When all songs are rated zero, fall back to unweighted shuffle
+            return playlist.get_iter((random.choice(list(remaining)),))
         choice = random.random() * total_score
         current = 0.0
         for i, song in remaining.items():


### PR DESCRIPTION
The strategy `OrderWeighted` ("Prefer higher rated" in the UI) uses means that if the sum of the ratings of every song remaining to play is zero (i.e. all songs have rating zero) then the first song will always be chosen.

I've fixed this by falling back to the shuffle strategy used by the normal shuffle when `total_score == 0`.

I've not added tests but I'm not sure it's really possible to test this without mocking `random` or something since the buggy behaviour could just happen by chance.

