### PR TITLE
formats: Don't return lyrics with embedded nulls

### DIFF
--- a/quodlibet/formats/_audio.py
+++ b/quodlibet/formats/_audio.py
@@ -438,14 +438,16 @@ class AudioFile(dict, ImageContainer):
 
                 # If there are no embedded lyrics, try to read them from
                 # the external file.
-                fn = self.lyric_filename
                 try:
-                    fileobj = open(fn, "rb")
+                    with open(self.lyric_filename, "rb") as fileobj:
+                        print_d("Reading lyrics from %s" % self.lyric_filename)
+                        text = fileobj.read().decode("utf-8", "replace")
+                        # try to skip binary files
+                        if "\0" in text:
+                            return default
+                        return text
                 except EnvironmentError:
                     return default
-                else:
-                    print_d("Reading lyrics from %s" % fn)
-                    return fileobj.read().decode("utf-8", "replace")
             elif key == "filesize":
                 return util.format_size(self("~#filesize", 0))
             elif key == "playlists":


### PR DESCRIPTION
This can happen if we try to interpret a music file itself as a lyrics file.

Fixes #3395