### PR TITLE
operon: multiple file edit

### DIFF
--- a/data/operon.1
+++ b/data/operon.1
@@ -195,7 +195,7 @@ Shows all tags in a text editor and will apply any changes made to the text to
 the tags. \fIoperon\fP will use the editor specified in the VISUAL or EDITOR
 environment variables and if those are not set fall back to \(aqnano\(aq.
 .sp
-operon edit [\-h] [\-\-dry\-run] <file>
+operon edit [\-h] [\-\-dry\-run] <file>...
 .INDENT 0.0
 .TP
 .B \-h\fP,\fB  \-\-help

--- a/docs/guide/commands/operon.rst
+++ b/docs/guide/commands/operon.rst
@@ -168,7 +168,7 @@ Shows all tags in a text editor and will apply any changes made to the text to
 the tags. *operon* will use the editor specified in the VISUAL or EDITOR
 environment variables and if those are not set fall back to 'nano'.
 
-operon edit [-h] [--dry-run] <file>
+operon edit [-h] [--dry-run] <file>...
 
 -h, --help
     Display help and exit

--- a/quodlibet/operon/commands.py
+++ b/quodlibet/operon/commands.py
@@ -9,13 +9,14 @@
 # RenameCommand
 # FillTracknumberCommand
 
+import ast
 import os
 import re
 import shutil
 import subprocess
 import tempfile
 
-from senf import fsn2text
+from senf import fsn2text, text2fsn
 
 from quodlibet import _
 from quodlibet import util
@@ -155,9 +156,7 @@ class CopyCommand(Command):
 class EditCommand(Command):
     NAME = "edit"
     DESCRIPTION = _("Edit tags in a text editor")
-    USAGE = "[--dry-run] <file>"
-
-    # TODO: support editing multiple files
+    USAGE = "[--dry-run] <file> [<files>]"
 
     def _add_options(self, p):
         p.add_option("--dry-run", action="store_true",
@@ -165,19 +164,22 @@ class EditCommand(Command):
 
     def _song_to_text(self, song):
         # to text
-        lines = []
+        lines = [
+            u"File: %r" % fsn2text(song("~filename")),
+            u"",
+        ]
         for key in sorted(song.realkeys(), key=sortkey):
             for value in song.list(key):
-                lines.append(u"%s=%s" % (key, value))
+                lines.append(u"  %s=%s" % (key, value))
 
-        lines += [
+        return u"\n".join(lines + [u""])
+
+    def _songs_to_text(self, songs):
+        header = [
+            u"# Lines before the first 'File:' statement, or lines that are empty or start with '#' will be ignored.",
             u"",
-            u"#" * 80,
-            u"# Lines that are empty or start with '#' will be ignored",
-            u"# File: %r" % fsn2text(song("~filename")),
         ]
-
-        return u"\n".join(lines)
+        return u"\n".join(header + [self._song_to_text(song) for song in songs])
 
     def _text_to_song(self, text, song):
         assert isinstance(text, str)
@@ -188,7 +190,7 @@ class EditCommand(Command):
             if not line.strip() or line.startswith(u"#"):
                 continue
             try:
-                key, value = line.split(u"=", 1)
+                key, value = line.strip().split(u"=", 1)
             except ValueError:
                 continue
 
@@ -215,14 +217,29 @@ class EditCommand(Command):
                 self.log("Add %s=%s" % (key, value))
                 song.add(key, value)
 
+    def _text_to_songs(self, text, songs):
+        text = re.sub("^#.*", "", text, 0, re.MULTILINE) # remove comments
+        text = re.sub("(\r?\n){2,}", "\n", text.strip()) # remove empty lines
+        _, *texts = re.split("^File:\s+", text, 0, re.MULTILINE)
+
+        for text in texts:
+            filename, *lines = text.splitlines()
+            filename = text2fsn(ast.literal_eval(filename))
+            text = u"\n".join(lines)
+
+            song = next((song for song in songs if song("~filename") == filename), None)
+            if not song:
+                raise CommandError("No match for %r." % (filename))
+
+            self.log("Update song: %r" % (filename))
+            self._text_to_song(text, song)
+
     def _execute(self, options, args):
         if len(args) < 1:
             raise CommandError(_("Not enough arguments"))
-        elif len(args) > 1:
-            raise CommandError(_("Too many arguments"))
 
-        song = self.load_song(args[0])
-        dump = self._song_to_text(song).encode("utf-8")
+        songs = [self.load_song(path) for path in args]
+        dump = self._songs_to_text(songs).encode("utf-8")
 
         # write to tmp file
         fd, path = tempfile.mkstemp(suffix=".txt")
@@ -272,10 +289,10 @@ class EditCommand(Command):
 
         if options.dry_run:
             self.verbose = True
-        self._text_to_song(text, song)
+        self._text_to_songs(text, songs)
 
         if not options.dry_run:
-            self.save_songs([song])
+            self.save_songs(songs)
 
 
 @Command.register

--- a/quodlibet/operon/commands.py
+++ b/quodlibet/operon/commands.py
@@ -176,7 +176,8 @@ class EditCommand(Command):
 
     def _songs_to_text(self, songs):
         header = [
-            u"# Lines before the first 'File:' statement, or lines that are empty or start with '#' will be ignored.",
+            u"# Lines before the first 'File:' statement, or"
+            u" lines that are empty or start with '#' will be ignored.",
             u"",
         ]
         return u"\n".join(header + [self._song_to_text(song) for song in songs])
@@ -218,9 +219,9 @@ class EditCommand(Command):
                 song.add(key, value)
 
     def _text_to_songs(self, text, songs):
-        text = re.sub("^#.*", "", text, 0, re.MULTILINE) # remove comments
-        text = re.sub("(\r?\n){2,}", "\n", text.strip()) # remove empty lines
-        _, *texts = re.split("^File:\s+", text, 0, re.MULTILINE)
+        text = re.sub(r"^#.*", "", text, 0, re.MULTILINE) # remove comments
+        text = re.sub(r"(\r?\n){2,}", "\n", text.strip()) # remove empty lines
+        _, *texts = re.split(r"^File:\s+", text, 0, re.MULTILINE)
 
         for text in texts:
             filename, *lines = text.splitlines()

--- a/tests/test_operon.py
+++ b/tests/test_operon.py
@@ -387,6 +387,34 @@ class TOperonEdit(TOperonBase):
         self.s.reload()
         self.assertFalse(self.s.realkeys())
 
+    def test_multi_remove_all(self):
+        if os.name == "nt" or sys.platform == "darwin":
+            return
+
+        os.environ["VISUAL"] = "sed -i -n /^File:/p"
+        os.utime(self.f, (42, 42))
+        self.check_true(["edit", self.f, self.f2], False, False)
+
+        # all should be gone on both files
+        self.s.reload()
+        self.assertFalse(self.s.realkeys())
+        self.s2.reload()
+        self.assertFalse(self.s2.realkeys())
+
+    def test_multi_edit(self):
+        if os.name == "nt" or sys.platform == "darwin":
+            return
+
+        os.environ["VISUAL"] = "sed -i '/^File:/a comment=multi edited'"
+        os.utime(self.f, (42, 42))
+        self.check_true(["edit", self.f, self.f2], False, False)
+
+        # all should be gone on both files
+        self.s.reload()
+        self.failUnlessEqual(self.s["comment"], "multi edited")
+        self.s2.reload()
+        self.failUnlessEqual(self.s2["comment"], "multi edited")
+
 
 class TOperonInfo(TOperonBase):
     # [-t] [-c <c1>,<c2>...] <file>

--- a/tests/test_operon.py
+++ b/tests/test_operon.py
@@ -362,7 +362,7 @@ class TOperonEdit(TOperonBase):
 
         realitems = lambda s: [(k, s[k]) for k in s.realkeys()]
 
-        os.environ["VISUAL"] = "truncate -s 0"
+        os.environ["VISUAL"] = "sed -i -n /^File:/p"
         old_items = realitems(self.s)
         os.utime(self.f, (42, 42))
         e = self.check_true(["edit", "--dry-run", self.f], False, True)[1]
@@ -379,7 +379,7 @@ class TOperonEdit(TOperonBase):
         if os.name == "nt" or sys.platform == "darwin":
             return
 
-        os.environ["VISUAL"] = "truncate -s 0"
+        os.environ["VISUAL"] = "sed -i -n /^File:/p"
         os.utime(self.f, (42, 42))
         self.check_true(["edit", self.f], False, False)
 


### PR DESCRIPTION
Check-list
----------

 * [X] There is a linked issue discussing the motivations for this feature or bugfix (see  #3417)
 * [x] Unit tests have been added where possible
 * [X] I've added / updated documentation for any user-facing features.
 * [X] Performance seems to be comparable or better than current `master`


What this change is adding / fixing
-----------------------------------

Allow editing multiple songs in a single text file with the operon edit command.  Please note: this change has a significant impact on the format of the text file to be edited!

The file is split into sections stating with a "File: .." line, indicating which file is being edited.  All key/value pairs following are interpreted as tags and their values for that file.  These pairs are indented to improve readability.

An example:

```
File: '/Music/Schostakowitsch/String-Quartet-7/01.Allegretto.flac'

  title=Allegretto
  composer=Dimitri Schostakowitsch
  album=String quartet Nr.7, op. 108
  genre=Classical
  tracknumber=1/3

File: '/Music/Schostakowitsch/String-Quartet-7/02.Lento.flac'

  title=Lento
  composer=Dimitri Schostakowitsch
  album=String quartet Nr.7, op. 108
  genre=Classical
  tracknumber=2/3

File: '/Music/Schostakowitsch/String-Quartet-7/03.Allegro.flac'

  title=Allegro
  composer=Dimitri Schostakowitsch
  album=String quartet Nr.7, op. 108
  genre=Classical
  tracknumber=3/3
```