### PR TITLE
Add support for TKEY 'Initial Key' column

### DIFF
--- a/quodlibet/formats/_id3.py
+++ b/quodlibet/formats/_id3.py
@@ -66,6 +66,7 @@ class ID3File(AudioFile):
            "TSOC": "composersort",
            "TMED": "media",
            "TCMP": "compilation",
+           "TKEY": "initialkey",
            # TLAN requires an ISO 639-2 language code, check manually
            #"TLAN": "language"
     }

--- a/quodlibet/qltk/songlist.py
+++ b/quodlibet/qltk/songlist.py
@@ -1077,7 +1077,8 @@ class SongList(AllTreeView, SongListDnDMixin, DragScroll,
         menu.append(sep)
 
         trackinfo = """title genre ~title~version ~#track
-            ~#playcount ~#skipcount ~rating ~#length ~playlists""".split()
+            ~#playcount ~#skipcount ~rating ~#length ~playlists
+            bpm initialkey""".split()
         peopleinfo = """artist ~people performer arranger author composer
             conductor lyricist originalartist""".split()
         albuminfo = """album ~album~discsubtitle labelid ~#disc ~#discs

--- a/quodlibet/util/tags.py
+++ b/quodlibet/util/tags.py
@@ -119,6 +119,7 @@ _TAGS = dict((t.name, t) for t in [
     T("originalartist", "us", _("original artist")),
     T("recordingdate", "u", _("recording date")),
     T("releasecountry", "u", _("release country")),
+    T("initialkey", "u", _("initial key")),
 
     # for backwards compat
     T("performers", "ishr", _("performers")),

--- a/tests/test_qltk_songlistcolumns.py
+++ b/tests/test_qltk_songlistcolumns.py
@@ -93,6 +93,11 @@ class TSongListColumns(TestCase):
         text = self._render_column(column, **{"bpm": "123"})
         self.assertEqual(text, "123")
 
+    def test_initialkey(self):
+        column = create_songlist_column("initialkey")
+        text = self._render_column(column, **{"initialkey": "F"})
+        self.assertEqual(text, "F")
+
     def test_custom_datecol_format(self):
         format = "%Y%m%d %H:%M:%S PLAINTEXT"
         quodlibet.config.settext("settings", "datecolumn_timestamp_format",

--- a/tests/test_qltk_songlistcolumns.py
+++ b/tests/test_qltk_songlistcolumns.py
@@ -88,6 +88,11 @@ class TSongListColumns(TestCase):
         column = create_songlist_column("~people")
         self._render_column(column)
 
+    def test_bpm(self):
+        column = create_songlist_column("bpm")
+        text = self._render_column(column, **{"bpm": "123"})
+        self.assertEqual(text, "123")
+
     def test_custom_datecol_format(self):
         format = "%Y%m%d %H:%M:%S PLAINTEXT"
         quodlibet.config.settext("settings", "datecolumn_timestamp_format",


### PR DESCRIPTION
* [ ] There is a linked issue discussing the motivations for this feature or bugfix
 * [X] Unit tests have been added where possible
 * [ ] I've added / updated documentation for any user-facing features.
 * [X] Performance seems to be comparable or better than current `master`

What this change is adding / fixing
-----------------------------------

The id3 TKEY field, for the initial song key (in the music theory sense),
can not be shown in the quodlibet UI AFAICT. This fixes it. It's
called initialkey/Initial Key to be more explicit about what it is
tracking.

Since I was in the area, I added some tests for BPM column rendering,
and added both BPM and initialkey to the column selector UI