### PR TITLE
Fixed documentation URLs

### DIFF
--- a/docs/bugs_repo.rst
+++ b/docs/bugs_repo.rst
@@ -12,7 +12,7 @@ Bug Tracker / Git Repo
 We use the GitHub bug tracker:
 
 * List of existing issues: https://github.com/quodlibet/quodlibet/issues
-* Create a new issue: https://github.com/quodlibet/quodlibet/issues/new
+* Create a new issue: https://github.com/quodlibet/quodlibet/issues/new/choose
 
 
 .. _gitrepo:

--- a/docs/contact.rst
+++ b/docs/contact.rst
@@ -9,7 +9,7 @@ concerns us specifically. If you contact just us, it means no one else can
 help you, and we can be really bad about replying to email.
 
 If you have a question or want to report a bug please `open a new issue
-<https://github.com/quodlibet/quodlibet/issues/new>`_ on the GitHub issue
+<https://github.com/quodlibet/quodlibet/issues/new/choose>`_ on the GitHub issue
 tracker.
 
 If you want to address the wider Quod Libet community consider sending a mail

--- a/docs/development/plugins.rst
+++ b/docs/development/plugins.rst
@@ -79,8 +79,8 @@ Tips:
 
 * The best way to find out what is possible is to read the documentation of 
   the `plugin base classes
-  <https://github.com/quodlibet/quodlibet/tree/master/quodlibet/quodlibet/plugins>`_ .
+  <https://github.com/quodlibet/quodlibet/tree/master/quodlibet/plugins>`_ .
 
 * The easiest way to get started creating a new plugin is to look for `existing plugins
-  <https://github.com/quodlibet/quodlibet/tree/master/quodlibet/quodlibet/ext>`_ that do
+  <https://github.com/quodlibet/quodlibet/tree/master/quodlibet/ext>`_ that do
   something similar to what you want.


### PR DESCRIPTION
Check-list
----------

 * [ ] There is a linked issue discussing the motivations for this feature or bugfix
 * [ ] Unit tests have been added where possible
 * [ ] I've added / updated documentation for any user-facing features.
 * [x] Performance seems to be comparable or better than current `master`


What this change is adding / fixing
-----------------------------------
Fixed a couple of 404 links.
And modified existing links to the creation of a new issue to the "type picker" so that a new user that is creating a bug/feature_request via that link can use the proper template, otherwise the current link bypasses that.

