### PR TITLE
unix: Don't unlink FIFO on write failure

### DIFF
--- a/quodlibet/util/fifo.py
+++ b/quodlibet/util/fifo.py
@@ -35,19 +35,11 @@ def _write_fifo(fifo_path, data):
     assert isinstance(data, bytes)
 
     # This will raise if the FIFO doesn't exist or there is no reader
+    fifo = os.open(fifo_path, os.O_WRONLY | os.O_NONBLOCK)
     try:
-        fifo = os.open(fifo_path, os.O_WRONLY | os.O_NONBLOCK)
+        os.close(fifo)
     except OSError:
-        try:
-            os.unlink(fifo_path)
-        except OSError:
-            pass
-        raise
-    else:
-        try:
-            os.close(fifo)
-        except OSError:
-            pass
+        pass
 
     try:
         # This is a total abuse of Python! Hooray!
@@ -57,11 +49,6 @@ def _write_fifo(fifo_path, data):
             signal.signal(signal.SIGALRM, signal.SIG_IGN)
             f.write(data)
     except (OSError, IOError, TypeError):
-        # Unable to write to the fifo. Removing it.
-        try:
-            os.unlink(fifo_path)
-        except OSError:
-            pass
         raise EnvironmentError("Couldn't write to fifo %r" % fifo_path)
 
 


### PR DESCRIPTION
Check-list
----------

 * [x] There is a linked issue discussing the motivations for this feature or bugfix
 * [ ] Unit tests have been added where possible
 * [ ] I've added / updated documentation for any user-facing features.
 * [ ] Performance seems to be comparable or better than current `master`


What this change is adding / fixing
-----------------------------------

If one were to think of the relationship between writer and reader as client and server, a write deleting the reader's FIFO is the equivalent of a client killing the server's listening socket.
For that reason the client won't unlinking the FIFO when an error happens.

I haven't been able to track down exactly how the error is triggered that enters the try/catch, but it happens once in a while.
A second PR could monitor the control FIFO for when it's deleted by some external actor and recreate it, but that's out of the scope of this PR.

Related to #3442 - Remote socket keeps dying after some time