### PR TITLE
Add "Rate" to D-Bus API

### DIFF
--- a/quodlibet/qltk/dbus_.py
+++ b/quodlibet/qltk/dbus_.py
@@ -10,6 +10,7 @@
 from gi.repository import GLib
 from gi.repository import Gio
 
+from quodlibet import commands, app
 from quodlibet.util import dbusutils
 from quodlibet.query import Query
 from quodlibet.qltk.songlist import SongList
@@ -45,6 +46,9 @@ class DBusHandler:
         </method>
         <method name="CurrentSong">
           <arg direction="out" type="a{ss}" />
+        </method>
+        <method name="Rate">
+          <arg direction="in"  type="s" name="rating" />
         </method>
         <method name="Next"></method>
         <method name="Previous"></method>
@@ -162,6 +166,15 @@ class DBusHandler:
 
     def CurrentSong(self):
         return self.__dict(self._player.song)
+
+    def Rate(self, rating: str):
+        """
+        Rates the currently playing song
+
+        :param rating: A value between 0 and 1.
+                       Prefix with +/- to indicate a relative change
+        """
+        commands._rating(app, rating)
 
     def Next(self):
         self._player.next()


### PR DESCRIPTION
This brings the DBus interface closer to the CLI interface
 which has the possibility to rate a currently playing song.

Check-list
----------

 * [x] There is a linked issue discussing the motivations for this feature or bugfix
 * [ ] Unit tests have been added where possible
  - None exist for other methods, so none were added for this one
 * [ ] I've added / updated documentation for any user-facing features.
  - Is documentation necessary / possible for the D-Bus API ?
 * [x] Performance seems to be comparable or better than current `master`


What this change is adding / fixing
-----------------------------------

This is a workaround to #3442 . The major reason I created that issue was because I couldn't rate using keybindings anymore that called the CLI `quodlibet --rating=...`. With the ability to call the same function over D-Bus that issue still persists but become much less relevant to me.

So, here's `net.sacredchao.QuodLibet.Rate(rating: str) -> None` that calls `quodlibet.commands._rating`.