### PR TITLE
Tag Editor: Add smart replacer for colon delimiters

### DIFF
--- a/quodlibet/qltk/_editutils.py
+++ b/quodlibet/qltk/_editutils.py
@@ -92,10 +92,11 @@ class FilterCheckButton(ConfigCheckButton):
     __gsignals__ = {
         "preview": (GObject.SignalFlags.RUN_LAST, None, ())
         }
+    _tooltip = None
 
     def __init__(self):
         super().__init__(
-            self._label, self._section, self._key)
+            self._label, self._section, self._key, tooltip=self._tooltip)
         try:
             self.set_active(config.getboolean(self._section, self._key))
         except:


### PR DESCRIPTION
 * Detect `Part: name` in tags and replace with a friendlier ` - ` (avoiding excess underscores for Windows etc)
 * Add some tests
 * Add support for tooltips in these (TODO: more tooltips...)
 * Some autoformatting and related updates

This closes #3451

