### PR TITLE
Fix non-splitter EditTags plugins (#3468)

### DIFF
--- a/tests/test_qltk_edittags.py
+++ b/tests/test_qltk_edittags.py
@@ -1,25 +1,40 @@
 # Copyright 2012 Christoph Reiter
+#           2020 Nick Boultbee
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation; either version 2 of the License, or
 # (at your option) any later version.
+from unittest.mock import Mock
 
-from tests import TestCase
-
-from quodlibet.qltk.edittags import SplitValues, SplitDisc, SplitTitle, \
-    SplitArranger, AddTagDialog, AudioFileGroup
-from quodlibet.formats import AudioFile
-from quodlibet.library import SongLibrary
 import quodlibet.config
+from quodlibet import app
+from quodlibet.formats import AudioFile
+from quodlibet.plugins.editing import EditTagsPlugin
+from quodlibet.qltk.edittags import (SplitValues, SplitDisc, SplitTitle,
+                                     SplitArranger, AddTagDialog,
+                                     AudioFileGroup, EditTags, ListEntry,
+                                     Comment, EditTagsPluginHandler)
+from quodlibet.qltk.properties import SongProperties
+from tests import TestCase, init_fake_app, destroy_fake_app
+
+
+class DummyEditPlugin(EditTagsPlugin):
+    activations = []
+
+    def activated(self, tag, value):
+        self.activations.append((tag, value))
+        return super().activated(tag, value)
 
 
 class TEditTags(TestCase):
     def setUp(self):
+        init_fake_app()
         quodlibet.config.init()
 
     def tearDown(self):
         quodlibet.config.quit()
+        destroy_fake_app()
 
     def test_items(self):
         SplitValues("foo", "bar").destroy()
@@ -28,8 +43,36 @@ class TEditTags(TestCase):
         SplitArranger("foo", "bar").destroy()
 
     def test_addtag_dialog(self):
-        lib = SongLibrary()
-        AddTagDialog(None, ["artist"], lib).destroy()
+        AddTagDialog(None, ["artist"], app.library).destroy()
+
+    def test_edit_tags_starts(self):
+        props = SongProperties(app.library, [], quodlibet.app.window)
+        EditTags(props, app.library)
+
+    def test_edit_tags_popup_menu(self):
+        song = AudioFile({"~filename": "/dev/null", "artist": "Person",
+                          "album": "Dj Bars of FOO"})
+        props = SongProperties(app.library, [song], app.window)
+        box = EditTags(props, app.library)
+
+        # Add a fake plugin
+        plugin_cls = DummyEditPlugin
+        box.handler = Mock(EditTagsPluginHandler)
+        box.handler.plugins = [plugin_cls]
+        model = box._view.get_model()
+
+        # Make sure there's a row
+        tag, value = "artist", song("artist")
+        entry = ListEntry(tag, Comment(value))
+        model.append(row=[entry])
+
+        box._group_info = AudioFileGroup([song])
+        box._view.select_by_func(lambda _: True)
+        # Prevent weird mouse stuff failing in tests
+        box._view.ensure_popup_selection = lambda: False
+        box._popup_menu(box._view, props)
+        box.show()
+        assert plugin_cls.activations == [(tag, value)]
 
 
 class GroupSong(AudioFile):


### PR DESCRIPTION
 * Non-splitting `EditTagsPlugins` had stopped working
 * Add a base type for splitter plugins (wrapping `EditTagsPlugin`), and make sure that the existing ones extend this and actually thus extend the plugin features that they make use of (`_order`, `activated()` etc)
 * Separate out the splitters and the plugins, extracting a common method
 * A little bit of related refactoring of logic - less `min(foo + [1])` and more `any` / `all` (reads nicer)
 * Also, don't dynamically recreate and sort the list of plugins on every right-click, but once at class init
 * Add typing where touching things
 * Add some tests around exercising more of EditTags (in particular popups): [this was pretty untested](https://codecov.io/gh/quodlibet/quodlibet/src/master/quodlibet/qltk/edittags.py)
 * This meant exposing `__popup_menu`, and `__songinfo`, now renamed to `_group_info` to lint better and indicate its type more

This fixes #3468

