### PR TITLE
CI: don't run pushes to PR branches twice

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,12 @@
 name: test
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
 
 jobs:
 


### PR DESCRIPTION
...seems to be a known gotcha in Github actions

https://github.community/t/how-to-trigger-an-action-on-push-or-pull-request-but-not-both/16662