### PR TITLE
Refactor ID3 tag writing for readability

### DIFF
--- a/.ci/macos-install.sh
+++ b/.ci/macos-install.sh
@@ -2,9 +2,12 @@
 
 set -e
 
-.ci/retry wget -O ql.dmg https://github.com/quodlibet/quodlibet/releases/download/ci/QuodLibet-latest-v7.dmg
+.ci/retry wget -q -O ql.dmg https://github.com/quodlibet/quodlibet/releases/download/ci/QuodLibet-latest-v7.dmg
 hdiutil attach -noverify -readonly -mountpoint _mount ql.dmg
 cp -R _mount/QuodLibet.app "$TMPDIR/_app"
 hdiutil detach -force _mount
 RUN="$TMPDIR/_app/Contents/MacOS/run"
-$RUN -m pip install flake8 pytest pytest-faulthandler "coverage[toml]"
+
+$RUN -m pip install poetry==1.1
+pwd
+$RUN -m poetry install

--- a/.ci/macos-install.sh
+++ b/.ci/macos-install.sh
@@ -2,12 +2,9 @@
 
 set -e
 
-.ci/retry wget -q -O ql.dmg https://github.com/quodlibet/quodlibet/releases/download/ci/QuodLibet-latest-v7.dmg
+.ci/retry wget -O ql.dmg https://github.com/quodlibet/quodlibet/releases/download/ci/QuodLibet-latest-v7.dmg
 hdiutil attach -noverify -readonly -mountpoint _mount ql.dmg
 cp -R _mount/QuodLibet.app "$TMPDIR/_app"
 hdiutil detach -force _mount
 RUN="$TMPDIR/_app/Contents/MacOS/run"
-
-$RUN -m pip install poetry==1.1
-pwd
-$RUN -m poetry install
+$RUN -m pip install flake8 pytest pytest-faulthandler "coverage[toml]"

--- a/quodlibet/formats/_id3.py
+++ b/quodlibet/formats/_id3.py
@@ -8,7 +8,7 @@
 
 import mutagen.id3
 
-from quodlibet import config, const, print_d
+from quodlibet import config, const, print_w
 from quodlibet import util
 from quodlibet.util.iso639 import ISO_639_2
 from quodlibet.util.path import get_temp_cover_file
@@ -23,10 +23,10 @@ def encoding_for(s):
     return 3 if isascii(s) else 1
 
 
-RG_KEYS = [
+RG_KEYS = {
     "replaygain_track_peak", "replaygain_track_gain",
     "replaygain_album_peak", "replaygain_album_gain",
-]
+}
 
 
 # ID3 is absolutely the worst thing ever.
@@ -313,8 +313,9 @@ class ID3File(AudioFile):
             else:
                 tag.add(Kind(encoding=enc, text=text))
 
-        dontwrite = ["genre", "comment", "musicbrainz_trackid", "lyrics"] \
-            + RG_KEYS + list(self.TXXX_MAP.values())
+        dont_write = (RG_KEYS
+                      | set(self.TXXX_MAP.values())
+                      | {"genre", "comment", "musicbrainz_trackid", "lyrics"})
 
         if "musicbrainz_trackid" in self.realkeys():
             f = mutagen.id3.UFID(
@@ -329,18 +330,19 @@ class ID3File(AudioFile):
             if all([lang in ISO_639_2 for lang in langs]):
                 # Save value(s) to TLAN tag. Guaranteed to be ASCII here
                 tag.add(mutagen.id3.TLAN(encoding=3, text=langs))
-                dontwrite.append("language")
+                dont_write.add("language")
             else:
-                print_d("Not using invalid language code '%s' in TLAN" %
-                        self["language"])
+                print_w(
+                    f"Not using invalid language {self['language']!r} in TLAN")
 
         # Filter out known keys, and ones set not to write [generically].
-        keys_to_write = filter(lambda k: not (k in self.SDI or k in dontwrite),
-                               self.realkeys())
+        dont_write |= self.SDI.keys()
+        keys_to_write = (k for k in self.realkeys()
+                         if k not in dont_write)
         for key in keys_to_write:
             enc = encoding_for(self[key])
             if key.startswith("performer:"):
-                mcl.people.append([key.split(":", 1)[1], self[key]])
+                mcl.people.append((key.split(":", 1)[1], self[key]))
                 continue
 
             f = mutagen.id3.TXXX(


### PR DESCRIPTION
* Use sets (and set operators) for set of tags not to write
* Fix list to be tuple as per rest of collection in `mcl.people`
* Use generator comprehension not lambda + `filter`. Extract constant from comprehension too
* Rename variable for readability
* Invalid country tag is now a warning not info