### PR TITLE
:new: Add Sonos playlist export plugin

### DIFF
--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -87,6 +87,7 @@ quodlibet/ext/gstreamer/karaoke.py
 quodlibet/ext/gstreamer/mono.py
 quodlibet/ext/gstreamer/pitch.py
 quodlibet/ext/playlist/export_to_folder.py
+quodlibet/ext/playlist/export_to_sonos.py
 quodlibet/ext/playlist/export_to_squeezebox.py
 quodlibet/ext/playlist/remove_duplicates.py
 quodlibet/ext/playlist/shuffle.py

--- a/poetry.lock
+++ b/poetry.lock
@@ -41,7 +41,7 @@ version = "2.8.0"
 pytz = ">=2015.7"
 
 [[package]]
-category = "dev"
+category = "main"
 description = "Python package for providing Mozilla's CA Bundle."
 name = "certifi"
 optional = false
@@ -49,7 +49,7 @@ python-versions = "*"
 version = "2020.6.20"
 
 [[package]]
-category = "dev"
+category = "main"
 description = "Universal encoding detector for Python 2 and 3"
 name = "chardet"
 optional = false
@@ -63,7 +63,7 @@ marker = "sys_platform == \"win32\""
 name = "colorama"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
-version = "0.4.3"
+version = "0.4.4"
 
 [[package]]
 category = "dev"
@@ -103,7 +103,7 @@ description = "Universal feed parser, handles RSS 0.9x, RSS 1.0, RSS 2.0, CDF, A
 name = "feedparser"
 optional = false
 python-versions = ">=3.6"
-version = "6.0.1"
+version = "6.0.2"
 
 [package.dependencies]
 sgmllib3k = "*"
@@ -114,7 +114,7 @@ description = "the modular source code checker: pep8 pyflakes and co"
 name = "flake8"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7"
-version = "3.8.3"
+version = "3.8.4"
 
 [package.dependencies]
 mccabe = ">=0.6.0,<0.7.0"
@@ -126,7 +126,7 @@ python = "<3.8"
 version = "*"
 
 [[package]]
-category = "dev"
+category = "main"
 description = "Internationalized Domain Names in Applications (IDNA)"
 name = "idna"
 optional = false
@@ -148,7 +148,7 @@ marker = "python_version < \"3.8\""
 name = "importlib-metadata"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
-version = "1.7.0"
+version = "2.0.0"
 
 [package.dependencies]
 zipp = ">=0.5"
@@ -284,8 +284,8 @@ category = "main"
 description = "Python interface for cairo"
 name = "pycairo"
 optional = false
-python-versions = ">=3.5, <4"
-version = "1.19.1"
+python-versions = ">=3.6, <4"
+version = "1.20.0"
 
 [[package]]
 category = "dev"
@@ -309,7 +309,7 @@ description = "Pygments is a syntax highlighting package written in Python."
 name = "pygments"
 optional = false
 python-versions = ">=3.5"
-version = "2.7.0"
+version = "2.7.2"
 
 [[package]]
 category = "main"
@@ -373,7 +373,7 @@ python-versions = "*"
 version = "2020.1"
 
 [[package]]
-category = "dev"
+category = "main"
 description = "Python HTTP for Humans."
 name = "requests"
 optional = false
@@ -413,6 +413,18 @@ name = "snowballstemmer"
 optional = false
 python-versions = "*"
 version = "2.0.0"
+
+[[package]]
+category = "main"
+description = "SoCo (Sonos Controller) is a simple library to control Sonos speakers."
+name = "soco"
+optional = true
+python-versions = "*"
+version = "0.19"
+
+[package.dependencies]
+requests = "*"
+xmltodict = "*"
 
 [[package]]
 category = "dev"
@@ -556,16 +568,16 @@ python-versions = "*"
 version = "3.7.4.3"
 
 [[package]]
-category = "dev"
+category = "main"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 name = "urllib3"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
-version = "1.25.10"
+version = "1.25.11"
 
 [package.extras]
 brotli = ["brotlipy (>=0.6.0)"]
-secure = ["certifi", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "pyOpenSSL (>=0.14)", "ipaddress"]
+secure = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "certifi", "ipaddress"]
 socks = ["PySocks (>=1.5.6,<1.5.7 || >1.5.7,<2.0)"]
 
 [[package]]
@@ -575,6 +587,14 @@ name = "wcwidth"
 optional = false
 python-versions = "*"
 version = "0.2.5"
+
+[[package]]
+category = "main"
+description = "Makes working with XML feel like you are working with JSON"
+name = "xmltodict"
+optional = true
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "0.12.0"
 
 [[package]]
 category = "dev"
@@ -592,18 +612,17 @@ marker = "python_version < \"3.8\""
 name = "zipp"
 optional = false
 python-versions = ">=3.6"
-version = "3.1.0"
+version = "3.3.2"
 
 [package.extras]
 docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
-testing = ["jaraco.itertools", "func-timeout"]
+testing = ["pytest (>=3.5,<3.7.3 || >3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pytest-cov", "jaraco.test (>=3.2.0)", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy"]
 
 [extras]
-plugins = ["musicbrainzngs", "pyinotify", "dbus-python"]
+plugins = ["musicbrainzngs", "pyinotify", "dbus-python", "soco"]
 
 [metadata]
-content-hash = "c0a58d3b2735a83810a3daaf34345c632172c8ab03bb4103f32dccba58f690a2"
-lock-version = "1.0"
+content-hash = "9ad01842c6a16bdde8e3a4e76b9b487cf62d44c79c5b5ad3eed834f872e095ea"
 python-versions = "^3.7"
 
 [metadata.files]
@@ -632,8 +651,7 @@ chardet = [
     {file = "chardet-3.0.4.tar.gz", hash = "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae"},
 ]
 colorama = [
-    {file = "colorama-0.4.3-py2.py3-none-any.whl", hash = "sha256:7d73d2a99753107a36ac6b455ee49046802e59d9d076ef8e47b61499fa29afff"},
-    {file = "colorama-0.4.3.tar.gz", hash = "sha256:e96da0d330793e2cb9485e9ddfd918d456036c7149416295932478192f4436a1"},
+    {file = "colorama-0.4.4-py2.py3-none-any.whl", hash = "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2"},
 ]
 coverage = [
     {file = "coverage-5.3-cp27-cp27m-macosx_10_13_intel.whl", hash = "sha256:bd3166bb3b111e76a4f8e2980fa1addf2920a4ca9b2b8ca36a3bc3dedc618270"},
@@ -679,12 +697,12 @@ docutils = [
     {file = "docutils-0.16.tar.gz", hash = "sha256:c2de3a60e9e7d07be26b7f2b00ca0309c207e06c100f9cc2a94931fc75a478fc"},
 ]
 feedparser = [
-    {file = "feedparser-6.0.1-py2.py3-none-any.whl", hash = "sha256:c9b436334258e718e224c5ef8a78088557e0d0382506360f702de10667ffde32"},
-    {file = "feedparser-6.0.1.tar.gz", hash = "sha256:6ca88edcaa43f428345968df903a87f020843eda5e28d7ea24a612158d61e74c"},
+    {file = "feedparser-6.0.2-py3-none-any.whl", hash = "sha256:f596c4b34fb3e2dc7e6ac3a8191603841e8d5d267210064e94d4238737452ddd"},
+    {file = "feedparser-6.0.2.tar.gz", hash = "sha256:1b00a105425f492f3954fd346e5b524ca9cef3a4bbf95b8809470e9857aa1074"},
 ]
 flake8 = [
-    {file = "flake8-3.8.3-py2.py3-none-any.whl", hash = "sha256:15e351d19611c887e482fb960eae4d44845013cc142d42896e9862f775d8cf5c"},
-    {file = "flake8-3.8.3.tar.gz", hash = "sha256:f04b9fcbac03b0a3e58c0ab3a0ecc462e023a9faf046d57794184028123aa208"},
+    {file = "flake8-3.8.4-py2.py3-none-any.whl", hash = "sha256:749dbbd6bfd0cf1318af27bf97a14e28e5ff548ef8e5b1566ccfb25a11e7c839"},
+    {file = "flake8-3.8.4.tar.gz", hash = "sha256:aadae8761ec651813c24be05c6f7b4680857ef6afaae4651a4eccaef97ce6c3b"},
 ]
 idna = [
     {file = "idna-2.10-py2.py3-none-any.whl", hash = "sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0"},
@@ -695,8 +713,8 @@ imagesize = [
     {file = "imagesize-1.2.0.tar.gz", hash = "sha256:b1f6b5a4eab1f73479a50fb79fcf729514a900c341d8503d62a62dbc4127a2b1"},
 ]
 importlib-metadata = [
-    {file = "importlib_metadata-1.7.0-py2.py3-none-any.whl", hash = "sha256:dc15b2969b4ce36305c51eebe62d418ac7791e9a157911d58bfb1f9ccd8e2070"},
-    {file = "importlib_metadata-1.7.0.tar.gz", hash = "sha256:90bb658cdbbf6d1735b6341ce708fc7024a3e14e99ffdc5783edea9f9b077f83"},
+    {file = "importlib_metadata-2.0.0-py2.py3-none-any.whl", hash = "sha256:cefa1a2f919b866c5beb7c9f7b0ebb4061f30a8a9bf16d609b000e2dfaceb9c3"},
+    {file = "importlib_metadata-2.0.0.tar.gz", hash = "sha256:77a540690e24b0305878c37ffd421785a6f7e53c8b5720d211b211de8d0e95da"},
 ]
 jinja2 = [
     {file = "Jinja2-2.11.2-py2.py3-none-any.whl", hash = "sha256:f0a4641d3cf955324a89c04f3d94663aa4d638abe8f733ecd3582848e1c37035"},
@@ -730,11 +748,6 @@ markupsafe = [
     {file = "MarkupSafe-1.1.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:ba59edeaa2fc6114428f1637ffff42da1e311e29382d81b339c1817d37ec93c6"},
     {file = "MarkupSafe-1.1.1-cp37-cp37m-win32.whl", hash = "sha256:b00c1de48212e4cc9603895652c5c410df699856a2853135b3967591e4beebc2"},
     {file = "MarkupSafe-1.1.1-cp37-cp37m-win_amd64.whl", hash = "sha256:9bf40443012702a1d2070043cb6291650a0841ece432556f784f004937f0f32c"},
-    {file = "MarkupSafe-1.1.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:6788b695d50a51edb699cb55e35487e430fa21f1ed838122d722e0ff0ac5ba15"},
-    {file = "MarkupSafe-1.1.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:cdb132fc825c38e1aeec2c8aa9338310d29d337bebbd7baa06889d09a60a1fa2"},
-    {file = "MarkupSafe-1.1.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:13d3144e1e340870b25e7b10b98d779608c02016d5184cfb9927a9f10c689f42"},
-    {file = "MarkupSafe-1.1.1-cp38-cp38-win32.whl", hash = "sha256:596510de112c685489095da617b5bcbbac7dd6384aeebeda4df6025d0256a81b"},
-    {file = "MarkupSafe-1.1.1-cp38-cp38-win_amd64.whl", hash = "sha256:e8313f01ba26fbbe36c7be1966a7b7424942f670f38e666995b88d012765b9be"},
     {file = "MarkupSafe-1.1.1.tar.gz", hash = "sha256:29872e92839765e546828bb7754a68c418d927cd064fd4708fab9fe9c8bb116b"},
 ]
 mccabe = [
@@ -790,7 +803,15 @@ py = [
     {file = "py-1.9.0.tar.gz", hash = "sha256:9ca6883ce56b4e8da7e79ac18787889fa5206c79dcc67fb065376cd2fe03f342"},
 ]
 pycairo = [
-    {file = "pycairo-1.19.1.tar.gz", hash = "sha256:2c143183280feb67f5beb4e543fd49990c28e7df427301ede04fc550d3562e84"},
+    {file = "pycairo-1.20.0-cp36-cp36m-win32.whl", hash = "sha256:e5a3433690c473e073a9917dc8f1fc7dc8b9af7b201bf372894b8ad70d960c6d"},
+    {file = "pycairo-1.20.0-cp36-cp36m-win_amd64.whl", hash = "sha256:a942614923b88ae75c794506d5c426fba9c46a055d3fdd3b8db7046b75c079cc"},
+    {file = "pycairo-1.20.0-cp37-cp37m-win32.whl", hash = "sha256:8cfa9578b745fb9cf2915ec580c2c50ebc2da00eac2cf4c4b54b63aa19da4b77"},
+    {file = "pycairo-1.20.0-cp37-cp37m-win_amd64.whl", hash = "sha256:273a33c56aba724ec42fe1d8f94c86c2e2660c1277470be9b04e5113d7c5b72d"},
+    {file = "pycairo-1.20.0-cp38-cp38-win32.whl", hash = "sha256:2088100a099c09c5e90bf247409ce6c98f51766b53bd13f96d6aac7addaa3e66"},
+    {file = "pycairo-1.20.0-cp38-cp38-win_amd64.whl", hash = "sha256:ceb1edcbeb48dabd5fbbdff2e4b429aa88ddc493d6ebafe78d94b050ac0749e2"},
+    {file = "pycairo-1.20.0-cp39-cp39-win32.whl", hash = "sha256:57a768f4edc8a9890d98070dd473a812ac3d046cef4bc1c817d68024dab9a9b4"},
+    {file = "pycairo-1.20.0-cp39-cp39-win_amd64.whl", hash = "sha256:57166119e424d71eccdba6b318bd731bdabd17188e2ba10d4f315f7bf16ace3f"},
+    {file = "pycairo-1.20.0.tar.gz", hash = "sha256:5695a10cb7f9ae0d01f665b56602a845b0a8cb17e2123bfece10c2e58552468c"},
 ]
 pycodestyle = [
     {file = "pycodestyle-2.6.0-py2.py3-none-any.whl", hash = "sha256:2295e7b2f6b5bd100585ebcb1f616591b652db8a741695b3d8f5d28bdc934367"},
@@ -801,8 +822,8 @@ pyflakes = [
     {file = "pyflakes-2.2.0.tar.gz", hash = "sha256:35b2d75ee967ea93b55750aa9edbbf72813e06a66ba54438df2cfac9e3c27fc8"},
 ]
 pygments = [
-    {file = "Pygments-2.7.0-py3-none-any.whl", hash = "sha256:2df50d16b45b977217e02cba6c8422aaddb859f3d0570a88e09b00eafae89c6e"},
-    {file = "Pygments-2.7.0.tar.gz", hash = "sha256:2594e8fdb06fef91552f86f4fd3a244d148ab24b66042036e64f29a291515048"},
+    {file = "Pygments-2.7.2-py3-none-any.whl", hash = "sha256:88a0bbcd659fcb9573703957c6b9cff9fab7295e6e76db54c9d00ae42df32773"},
+    {file = "Pygments-2.7.2.tar.gz", hash = "sha256:381985fcc551eb9d37c52088a32914e00517e57f4a21609f48141ba08e193fa0"},
 ]
 pygobject = [
     {file = "PyGObject-3.38.0.tar.gz", hash = "sha256:051b950f509f2e9f125add96c1493bde987c527f7a0c15a1f7b69d6d1c3cd8e6"},
@@ -836,6 +857,10 @@ six = [
 snowballstemmer = [
     {file = "snowballstemmer-2.0.0-py2.py3-none-any.whl", hash = "sha256:209f257d7533fdb3cb73bdbd24f436239ca3b2fa67d56f6ff88e86be08cc5ef0"},
     {file = "snowballstemmer-2.0.0.tar.gz", hash = "sha256:df3bac3df4c2c01363f3dd2cfa78cce2840a79b9f1c2d2de9ce8d31683992f52"},
+]
+soco = [
+    {file = "soco-0.19-py2.py3-none-any.whl", hash = "sha256:f26e40e5d36e558ff7e6a121c684413d7e23ee1393e4cfe5ce98a5659e696831"},
+    {file = "soco-0.19.tar.gz", hash = "sha256:93e1f3de65c94199b7013a2b7098e0e697846621454a92495d2ac36d9050ec35"},
 ]
 sphinx = [
     {file = "Sphinx-3.2.1-py3-none-any.whl", hash = "sha256:ce6fd7ff5b215af39e2fcd44d4a321f6694b4530b6f2b2109b64d120773faea0"},
@@ -902,17 +927,21 @@ typing-extensions = [
     {file = "typing_extensions-3.7.4.3.tar.gz", hash = "sha256:99d4073b617d30288f569d3f13d2bd7548c3a7e4c8de87db09a9d29bb3a4a60c"},
 ]
 urllib3 = [
-    {file = "urllib3-1.25.10-py2.py3-none-any.whl", hash = "sha256:e7983572181f5e1522d9c98453462384ee92a0be7fac5f1413a1e35c56cc0461"},
-    {file = "urllib3-1.25.10.tar.gz", hash = "sha256:91056c15fa70756691db97756772bb1eb9678fa585d9184f24534b100dc60f4a"},
+    {file = "urllib3-1.25.11-py2.py3-none-any.whl", hash = "sha256:f5321fbe4bf3fefa0efd0bfe7fb14e90909eb62a48ccda331726b4319897dd5e"},
+    {file = "urllib3-1.25.11.tar.gz", hash = "sha256:8d7eaa5a82a1cac232164990f04874c594c9453ec55eef02eab885aa02fc17a2"},
 ]
 wcwidth = [
     {file = "wcwidth-0.2.5-py2.py3-none-any.whl", hash = "sha256:beb4802a9cebb9144e99086eff703a642a13d6a0052920003a230f3294bbe784"},
     {file = "wcwidth-0.2.5.tar.gz", hash = "sha256:c4d647b99872929fdb7bdcaa4fbe7f01413ed3d98077df798530e5b04f116c83"},
 ]
+xmltodict = [
+    {file = "xmltodict-0.12.0-py2.py3-none-any.whl", hash = "sha256:8bbcb45cc982f48b2ca8fe7e7827c5d792f217ecf1792626f808bf41c3b86051"},
+    {file = "xmltodict-0.12.0.tar.gz", hash = "sha256:50d8c638ed7ecb88d90561beedbf720c9b4e851a9fa6c47ebd64e99d166d8a21"},
+]
 xvfbwrapper = [
     {file = "xvfbwrapper-0.2.9.tar.gz", hash = "sha256:bcf4ae571941b40254faf7a73432dfc119ad21ce688f1fdec533067037ecfc24"},
 ]
 zipp = [
-    {file = "zipp-3.1.0-py3-none-any.whl", hash = "sha256:aa36550ff0c0b7ef7fa639055d797116ee891440eac1a56f378e2d3179e0320b"},
-    {file = "zipp-3.1.0.tar.gz", hash = "sha256:c599e4d75c98f6798c509911d08a22e6c021d074469042177c8c86fb92eefd96"},
+    {file = "zipp-3.3.2-py3-none-any.whl", hash = "sha256:50a4ef266c31c9409627b46012e206382eb8d23f46fbd358065a8335cfbf7d8f"},
+    {file = "zipp-3.3.2.tar.gz", hash = "sha256:adf8f2ed8f614ced567d849cae9d183cef6cfd27c77a5cae7a28029be0c2b7a7"},
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,10 +25,11 @@ pygobject = "^3.34.0"
 musicbrainzngs = { version = "0.*", optional = true }
 pyinotify = { version = "*", optional = true }
 dbus-python = { version = "*", optional = true }
+soco = { version = "^0.19", optional = true }
 
 [tool.poetry.extras]
 # Use with poetry install -E plugins
-plugins = ["musicbrainzngs", "pyinotify", "dbus-python", "paho-mqtt"]
+plugins = ["musicbrainzngs", "pyinotify", "dbus-python", "paho-mqtt", "soco"]
 
 [tool.poetry.dev-dependencies]
 pytest = '^5.0'

--- a/quodlibet/ext/playlist/export_to_sonos.py
+++ b/quodlibet/ext/playlist/export_to_sonos.py
@@ -1,0 +1,244 @@
+# Copyright 2020 Nick Boultbee
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+
+import quodlibet
+
+try:
+    from soco import SoCo, SoCoException
+    from soco.data_structures import (DidlMusicTrack, DidlPlaylistContainer,
+                                      DidlItem)
+except ImportError:
+    raise quodlibet.plugins.MissingModulePluginException("soco")
+
+from typing import Text, Optional, Dict, Tuple, Collection
+from gi.repository import Gtk
+from quodlibet import _
+from quodlibet import app
+from quodlibet import qltk
+from quodlibet.formats import AudioFile
+from quodlibet.plugins.playlist import PlaylistPlugin
+from quodlibet.qltk import Icons, Dialog
+from quodlibet.qltk.notif import Task
+from quodlibet.util import copool
+from quodlibet.util.dprint import print_d, print_w
+from quodlibet.util.string.filter import remove_punctuation
+
+try:
+    import soco
+except ImportError:
+    raise quodlibet.plugins.MissingModulePluginException("soco")
+
+PlaylistID = Text
+ID = Text
+Name = Text
+SonosPlaylistDict = Dict[PlaylistID, Name]
+
+
+class ComboBoxEntry(Gtk.ComboBox):
+    def __init__(self, choices: Dict[Text, Text], tooltip_markup=None):
+        super().__init__(
+            model=Gtk.ListStore(str, str),
+            entry_text_column=1,
+            has_entry=True)
+        self._fill_model(choices)
+        if tooltip_markup:
+            self.get_child().set_tooltip_markup(tooltip_markup)
+
+    def _fill_model(self, choices: Dict[Text, Text]):
+        self.clear()
+        render = Gtk.CellRendererText()
+        self.pack_start(render, True)
+        self.add_attribute(render, 'text', 1)
+
+        model = self.get_model()
+        for id_, name in choices.items():
+            model.append(row=[id_, name])
+        self.set_model(model)
+
+        comp = Gtk.EntryCompletion()
+        comp.set_model(self.get_model())
+        comp.set_text_column(1)
+        self.get_child().set_completion(comp)
+
+    def get_chosen(self) -> Tuple[Optional[ID], Name]:
+        tree_iter = self.get_active_iter()
+        if tree_iter is not None:
+            model = self.get_model()
+            id_, name = model[tree_iter][:2]
+            return id_, name
+        entry = self.get_child()
+        return None, entry.get_text()
+
+    def set_text(self, text: Text):
+        model = self.get_model()
+        for i, (id_, value) in enumerate(model):
+            if value == text:
+                self.set_active(i)
+                print_d(f"Text matched existing playlist: {id_} ({value!r})")
+                return
+
+        return self.get_child().set_text(text)
+
+
+class GetSonosPlaylistDialog(Dialog):
+
+    def __init__(self, choices: SonosPlaylistDict):
+        super().__init__(title="Which Sonos Playlist?", transient_for=None)
+        self.options = choices
+
+        self.set_border_width(6)
+        self.set_resizable(True)
+        self.add_button(_("_Cancel"), Gtk.ResponseType.CANCEL)
+        self.add_button(_("OK"), Gtk.ResponseType.OK)
+        self.vbox.set_spacing(6)
+        self.set_default_response(Gtk.ResponseType.OK)
+
+        box = Gtk.VBox(spacing=6)
+        label = Gtk.Label(
+            label=_("Type a new playlist name,\n"
+                    "or choose an existing Sonos playlist to overwrite"))
+        box.set_border_width(6)
+        label.set_line_wrap(True)
+        label.set_justify(Gtk.Justification.CENTER)
+        box.pack_start(label, True, True, 0)
+
+        self._combo = ComboBoxEntry(choices)
+        box.pack_start(self._combo, False, False, 0)
+
+        self.vbox.pack_start(box, True, True, 0)
+        self.get_child().show_all()
+
+    def run(self, text: Optional[Text] = None) \
+            -> Optional[Tuple[Optional[Name], Text]]:
+        self.show()
+        if text:
+            self._combo.set_text(text)
+        self._combo.grab_focus()
+        resp = super().run()
+        try:
+            return (self._combo.get_chosen() if resp == Gtk.ResponseType.OK
+                    else None)
+        finally:
+            self.destroy()
+
+
+class SonosPlaylistPlugin(PlaylistPlugin):
+    PLUGIN_ID = "Export to Sonos Playlist"
+    PLUGIN_NAME = _(u"Export to Sonos Playlist")
+    PLUGIN_DESC = _("Exports a playlist to Sonos playlist, "
+                    "provided both share a directory structure.")
+    PLUGIN_ICON = Icons.NETWORK_WORKGROUP
+    REQUIRES_ACTION = True
+
+    DEBUG = False
+
+    MAX_RESULTS_PER_SEARCH = 10
+    """Request this many max results, for each search to then filter in code"""
+
+    def __init__(self, playlists=None, library=None):
+        super().__init__(playlists, library)
+        self.__cancel = False
+        self.device: Optional[SoCo] = None
+
+    def __cancel_add(self):
+        """Tell the copool to stop (adding songs)"""
+        self.__cancel = True
+
+    @classmethod
+    def _score(cls, t: DidlMusicTrack, song: AudioFile) -> float:
+        d = t.to_dict()
+        try:
+            person = song.list("~people")[0]
+        except IndexError:
+            person = None
+        album = song("album")
+        score = (int(remove_punctuation(t.title).lower()
+                     == remove_punctuation(song("title")).lower())
+                 + int(bool(person) and person in d.values())
+                 + int(bool(album) and album in d.get("album", "")))
+        if cls.DEBUG:
+            print_d("%.1f for %s (%s)" % (score, t.title, d))
+        return score
+
+    def __add_songs(self, task: Task, songs: Collection[AudioFile],
+                    spl: DidlPlaylistContainer):
+        """Generator for copool to add songs to the temp playlist"""
+        assert self.device
+        task_total = float(len(songs))
+        print_d("Adding %d song(s) to Sonos playlist. "
+                "This might take a while..." % task_total)
+        for i, song in enumerate(songs):
+            if self.__cancel:
+                print_d("Cancelled Sonos export")
+                return
+            lib = self.device.music_library
+
+            # Exact title gets the best results it seems; some problems with ’
+            search_term = song("title")
+            assert search_term
+            results = lib.get_tracks(search_term=search_term,
+                                     max_items=self.MAX_RESULTS_PER_SEARCH)
+            yield
+            total = len(results)
+            if total == 1:
+                track = results[0]
+            elif total > 1:
+                desc = song("~~people~album~title")
+                candidates = [(self._score(t, song), t) for t in results]
+                in_order = sorted(candidates, reverse=True, key=lambda x: x[0])
+                track = in_order[0][1]
+                print_d(f"From {len(results)} choice(s) for {desc!r}, "
+                        f"chose {self.uri_for(track)}")
+            else:
+                print_w("No results for \"%s\"" % search_term)
+                track = None
+            if track:
+                try:
+                    self.device.add_item_to_sonos_playlist(track, spl)
+                except SoCoException as e:
+                    print_w(f"Couldn't add {track} ({e}, skipping")
+            task.update(float(i) / task_total)
+            yield
+        task.update((task_total - 2) / task_total)
+        yield
+        task.finish()
+        print_d(f"Finished export to {spl.title!r}")
+
+    @staticmethod
+    def uri_for(track: DidlItem) -> Text:
+        """More usable elsewhere (on Linux at least)"""
+        return track.get_uri().replace("x-file-cifs", "smb")
+
+    def plugin_playlist(self, playlist):
+        # TODO - only get coordinator nodes, somehow
+        self.device: SoCo = soco.discovery.any_soco()
+        device = self.device
+        if not device:
+            qltk.ErrorMessage(
+                app.window,
+                _("Error finding Sonos device(s)"),
+                _("Error finding Sonos. Please check settings")
+            ).run()
+        else:
+            sonos_pls = device.get_sonos_playlists()
+            pl_id_to_name = {pl.item_id: pl.title for pl in sonos_pls}
+            print_d("Sonos playlists: %s" % pl_id_to_name)
+            ret = GetSonosPlaylistDialog(pl_id_to_name).run(playlist.name)
+            if ret:
+                spl_id, name = ret
+                if spl_id:
+                    spl: DidlPlaylistContainer = next(s for s in sonos_pls
+                                                      if s.item_id == spl_id)
+                    print_w(f"Replacing existing Sonos playlist {spl!r}")
+                    device.remove_sonos_playlist(spl)
+
+                print_d(f"Creating new playlist {name!r}")
+                spl = device.create_sonos_playlist(name)
+                task = Task("Sonos", _("Export to Sonos playlist"),
+                            stop=self.__cancel_add)
+                copool.add(self.__add_songs, task, playlist.songs, spl,
+                           funcid="sonos-playlist-save")


### PR DESCRIPTION
* Add `soco` to dependencies via Poetry
* Playlist plugin that uses this
* Reads current playlists to find a suitable match, or add a new one inline if not.
* Does smart searching / filtering for each track to find best match. Works pretty well for me
* Uses `copool` / `Task` interface with enough yielding for a semi-usable UI whilst export is in progress
* Some reasonable error handling, but not perfect for sure

This fixes #3434
