### PR TITLE
Fix: link to Quod Libet in exported HTML

### DIFF
--- a/quodlibet/ext/songsmenu/html.py
+++ b/quodlibet/ext/songsmenu/html.py
@@ -1,4 +1,5 @@
 # Copyright 2005 Eduardo Gonzalez
+#           2020 Roneel Valambhia
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -23,7 +24,7 @@ HTML = '''<html>
  </style>
 </head>
 <body>
-  <h1>My <a href="http://www.sacredchao.net/quodlibet/">Quod Libet</a>
+  <h1>My <a href="https://quodlibet.readthedocs.io/">Quod Libet</a>
   Playlist</h1>
   <br />
   <table id="songTable">


### PR DESCRIPTION
Check-list
----------

 * [x] There is a linked issue discussing the motivations for this feature or bugfix (Resolves #3504)
 * [ ] Unit tests have been added where possible 
 * [ ] I've added / updated documentation for any user-facing features.
 * [x] Performance seems to be comparable or better than current `master` (Note: didn't actual check)

What this change is adding / fixing
-----------------------------------

Now exported HTML links to [Read the Docs page](http://quodlibet.readthedocs.org/). 

