### PR TITLE
Support moving library folders (scandirs)

### DIFF
--- a/docs/guide/overview.rst
+++ b/docs/guide/overview.rst
@@ -152,6 +152,16 @@ library automatically. Add more folders if you wish.
 Depending on the size of your music collection, it may take a few minutes
 to perform the initial scan.
 
+Note in newer versions, you can now *move* a library folder using the button
+in the *Library* tab of *Preferences*.
+This attempts to move any given music root folder (aka *scan directory*)
+to a new path, migrating (but not copying) all the tracks that are in the
+library under that path, preserving their library timestamps,
+as well as playlists containing them.
+
+Make sure you **take backups** (of files and QL metadata) before attempting
+any of these operations (especially the first time)!
+
 
 Plugins
 -------
@@ -162,3 +172,6 @@ Plugins
 
 The image above shows the plugin manager, from where you can enable /
 disable / configure all available plugins.
+
+Note in newer versions of Quod Libet you can filter by type of plugin,
+and view problems with loading plugins (e.g. missing Python modules) here, too.

--- a/quodlibet/library/librarians.py
+++ b/quodlibet/library/librarians.py
@@ -1,5 +1,5 @@
 # Copyright 2006 Joe Wreschnig
-#     2012, 2016 Nick Boultbee
+#      2012-2020 Nick Boultbee
 #           2014 Christoph Reiter
 #
 # This program is free software; you can redistribute it and/or modify
@@ -12,10 +12,12 @@ Librarians for libraries.
 """
 
 import itertools
+from typing import Generator
 
 from gi.repository import GObject
 
 from quodlibet.util.dprint import print_d
+from senf import fsnative
 
 
 class Librarian(GObject.GObject):
@@ -136,6 +138,13 @@ class Librarian(GObject.GObject):
             from_.handler_unblock(self.__signals[from_][1])
             to.handler_unblock(self.__signals[to][0])
 
+    def move_root(self, old_root: fsnative, new_root: fsnative) -> Generator:
+        if old_root == new_root:
+            print_d("Not moving to same root")
+        for library in self.libraries.values():
+            if hasattr(library, "move_root"):
+                yield from library.move_root(old_root, new_root)
+
 
 class SongLibrarian(Librarian):
     """A librarian for SongLibraries."""
@@ -171,7 +180,6 @@ class SongLibrarian(Librarian):
             if changed is None:
                 library._changed({song})
             else:
-                print_d(f"Delaying changed signal for {library!r}")
                 changed.add(song)
 
     def reload(self, item, changed=None, removed=None):

--- a/quodlibet/library/libraries.py
+++ b/quodlibet/library/libraries.py
@@ -16,7 +16,6 @@ least useful but most content-agnostic.
 import os
 import shutil
 import time
-from os.path import realpath
 from pathlib import Path
 from typing import Set, Optional, Generator
 

--- a/quodlibet/library/libraries.py
+++ b/quodlibet/library/libraries.py
@@ -16,26 +16,23 @@ least useful but most content-agnostic.
 import os
 import shutil
 import time
-from os.path import realpath
-from pathlib import Path
-from typing import Set, Optional, Generator
+from typing import Set, Optional
 
 from gi.repository import GObject
-from senf import fsn2text, fsnative, expanduser
 
 from quodlibet import _
+from quodlibet import formats
+from quodlibet import util
 from quodlibet.formats import (MusicFile, AudioFileError, load_audio_files,
-                               dump_audio_files, SerializationError, AudioFile)
-from quodlibet.query import Query
+                               dump_audio_files, SerializationError)
 from quodlibet.qltk.notif import Task
+from quodlibet.query import Query
 from quodlibet.util.atomic import atomic_save
 from quodlibet.util.collection import Album
 from quodlibet.util.collections import DictMixin
-from quodlibet import util
-from quodlibet import formats
 from quodlibet.util.dprint import print_d, print_w
-from quodlibet.util.path import (unexpand, mkdir, normalize_path, ishidden,
-                                 ismount)
+from quodlibet.util.path import unexpand, mkdir, normalize_path, ishidden, ismount
+from senf import fsn2text, fsnative
 
 
 class Library(GObject.GObject, DictMixin):

--- a/quodlibet/library/libraries.py
+++ b/quodlibet/library/libraries.py
@@ -856,10 +856,8 @@ class FileLibrary(PicklingLibrary):
                 path = Path(key)
                 if old_path in path.parents:
                     # TODO: more Pathlib-friendly dir replacement...
-                    new_key = normalize_path(key.replace(str(old_path),
-                                                         str(new_path),
-                                                         1),
-                                             canonicalise=False)
+                    new_key = key.replace(str(old_path), str(new_path), 1)
+                    new_key = normalize_path(new_key, canonicalise=False)
                     if new_key == key:
                         print_w(f"Substitution failed for {key!r}")
                     if self.move_song(song, new_key):

--- a/quodlibet/library/libraries.py
+++ b/quodlibet/library/libraries.py
@@ -837,13 +837,13 @@ class FileLibrary(PicklingLibrary):
           4. Move audio files: old_root -> new_path
 
         """
-        old_root = Path(realpath(old_root)).expanduser()
-        new_root = Path(new_root).expanduser()
-        if not old_root.is_dir():
-            raise ValueError(f"Source {old_root!r} is not a directory")
-        if not new_root.is_dir():
-            raise ValueError(f"Destination {new_root!r} is not a directory")
-        print_d(f"{self._name}: checking {len(self.values())} item(s) for {old_root!r}")
+        old_path = Path(realpath(old_root)).expanduser()
+        new_path = Path(new_root).expanduser()
+        if not old_path.is_dir():
+            raise ValueError(f"Source {old_path!r} is not a directory")
+        if not new_path.is_dir():
+            raise ValueError(f"Destination {new_path!r} is not a directory")
+        print_d(f"{self._name}: checking {len(self.values())} item(s) for {old_path!r}")
         missing: Set[AudioFile] = set()
         changed = set()
         total = len(self)
@@ -855,9 +855,10 @@ class FileLibrary(PicklingLibrary):
                 task.update(i / total)
                 key = song.key
                 path = Path(key)
-                if old_root in path.parents:
-                    new_key = normalize_path(key.replace(str(old_root),
-                                                         str(new_root),
+                if old_path in path.parents:
+                    # TODO: more Pathlib-friendly dir replacement...
+                    new_key = normalize_path(key.replace(str(old_path),
+                                                         str(new_path),
                                                          1),
                                              canonicalise=False)
                     if new_key == key:
@@ -873,7 +874,7 @@ class FileLibrary(PicklingLibrary):
             self.changed(changed)
             if missing:
                 print_w(f"Couldn't find {len(list(missing))} files: {missing}")
-        print_d(f"Done moving to {new_root!r}.")
+        print_d(f"Done moving to {new_path!r}.")
 
     def move_song(self, song: AudioFile, new_path: fsnative) -> bool:
         """Updates the location of a song, without touching the file.

--- a/quodlibet/library/libraries.py
+++ b/quodlibet/library/libraries.py
@@ -853,7 +853,7 @@ class FileLibrary(PicklingLibrary):
             yield
             for i, song in enumerate(list(self.values())):
                 task.update(i / total)
-                key = song.key
+                key = normalize_path(song.key)
                 path = Path(key)
                 if old_path in path.parents:
                     # TODO: more Pathlib-friendly dir replacement...

--- a/quodlibet/library/libraries.py
+++ b/quodlibet/library/libraries.py
@@ -837,8 +837,8 @@ class FileLibrary(PicklingLibrary):
           4. Move audio files: old_root -> new_path
 
         """
-        old_root = Path(realpath(expanduser(old_root)))
-        new_root = Path(expanduser(new_root))  # type: ignore
+        old_root = Path(realpath(old_root)).expanduser()
+        new_root = Path(new_root).expanduser()
         if not old_root.is_dir():
             raise ValueError(f"Source {old_root!r} is not a directory")
         if not new_root.is_dir():

--- a/quodlibet/library/libraries.py
+++ b/quodlibet/library/libraries.py
@@ -581,7 +581,7 @@ class FileLibrary(PicklingLibrary):
             # We're going to reload; this could change the key.  So
             # remove the item if it's currently in.
             try:
-                del (self._contents[item.key])
+                del self._contents[item.key]
             except KeyError:
                 present = False
             else:
@@ -657,7 +657,7 @@ class FileLibrary(PicklingLibrary):
         for i, (point, items) in task.list(enumerate(self._masked.items())):
             if ismount(point):
                 self._contents.update(items)
-                del (self._masked[point])
+                del self._masked[point]
                 self.emit('added', list(items.values()))
                 yield True
 

--- a/quodlibet/library/libraries.py
+++ b/quodlibet/library/libraries.py
@@ -837,8 +837,8 @@ class FileLibrary(PicklingLibrary):
           4. Move audio files: old_root -> new_path
 
         """
-        old_path = Path(realpath(old_root)).expanduser()
-        new_path = Path(new_root).expanduser()
+        old_path = Path(normalize_path(old_root, canonicalise=True)).expanduser()
+        new_path = Path(normalize_path(new_root)).expanduser()
         if not old_path.is_dir():
             raise ValueError(f"Source {old_path!r} is not a directory")
         if not new_path.is_dir():

--- a/quodlibet/library/libraries.py
+++ b/quodlibet/library/libraries.py
@@ -34,7 +34,7 @@ from quodlibet.util.collection import Album
 from quodlibet.util.collections import DictMixin
 from quodlibet.util.dprint import print_d, print_w
 from quodlibet.util.path import unexpand, mkdir, normalize_path, ishidden, ismount
-from senf import fsn2text, fsnative, expanduser
+from senf import fsn2text, fsnative
 
 
 class Library(GObject.GObject, DictMixin):

--- a/tests/test_library_libraries.py
+++ b/tests/test_library_libraries.py
@@ -434,8 +434,8 @@ class TFileLibrary(TLibrary):
 
         # Run it by draining the generator
         list(self.library.move_root(root, str(new_root)))
+        assert Path(in_song("~dirname")) == new_root, "directory wasn't updated"
         assert Path(in_song("~filename")) == new_root / "in file.mp3"
-        assert Path(in_song("~dirname")) == new_root, "~dirname wasn't updated"
         assert Path(out_song("~dirname")) == other_root, f"{out_song} was wrongly moved"
 
 

--- a/tests/test_library_libraries.py
+++ b/tests/test_library_libraries.py
@@ -15,6 +15,7 @@ from quodlibet.library.libraries import (Library, PicklingMixin, SongLibrary,
                                          FileLibrary, AlbumLibrary,
                                          SongFileLibrary, iter_paths)
 from quodlibet.util import connect_obj, is_windows
+from quodlibet.util.path import normalize_path
 from senf import fsnative
 from tests import TestCase, get_data_path, mkstemp, mkdtemp, skipIf
 from .helper import capture_output, get_temp_copy
@@ -420,11 +421,12 @@ class TFileLibrary(TLibrary):
         in_song.sanitize()
         out_song = AudioFile({"~filename": "/tmp/otherdir/file.mp3", "title": "Quux"})
         out_song.sanitize()
-        assert in_song("~dirname") == "/tmp/subdir"
-        assert out_song("~dirname") == "/tmp/otherdir"
+        root = normalize_path("/tmp/subdir", True)
+        assert in_song("~dirname") == root
+        assert out_song("~dirname") == normalize_path("/tmp/otherdir", True)
         self.library.add([out_song, in_song])
         new_root = Path(mkdtemp())
-        list(self.library.move_root("/tmp/subdir", str(new_root)))
+        list(self.library.move_root(root, str(new_root)))
         assert Path(in_song("~filename")) == new_root / "file.mp3"
         assert Path(in_song("~dirname")) == new_root
         assert out_song("~dirname") == "/tmp/otherdir", f"{out_song} was wrongly moved!"

--- a/tests/test_library_libraries.py
+++ b/tests/test_library_libraries.py
@@ -114,7 +114,7 @@ class TLibrary(TestCase):
     def test_add(self):
         self.library.add(self.Frange(12))
         self.failUnlessEqual(self.added, self.Frange(12))
-        del (self.added[:])
+        del self.added[:]
         self.library.add(self.Frange(12, 24))
         self.failUnlessEqual(self.added, self.Frange(12, 24))
 
@@ -343,7 +343,7 @@ class TSongLibrary(TLibrary):
 
     def test_tag_values(self):
         self.library.add(self.Frange(30))
-        del (self.added[:])
+        del self.added[:]
         self.failUnlessEqual(
             sorted(self.library.tag_values(10)), list(range(10)))
         self.failUnlessEqual(sorted(self.library.tag_values(0)), [])

--- a/tests/test_library_libraries.py
+++ b/tests/test_library_libraries.py
@@ -418,7 +418,7 @@ class TFileLibrary(TLibrary):
         self.assertFalse(removed)
 
     def test_move_root(self):
-        root = Path(mkdtemp())
+        root = Path(normalize_path(mkdtemp(), True))
         other_root = Path(normalize_path(mkdtemp(), True))
         new_root = Path(normalize_path(mkdtemp(), True))
         in_song = AudioFile({"~filename": str(root / "file.mp3"), "title": "In"})

--- a/tests/test_library_libraries.py
+++ b/tests/test_library_libraries.py
@@ -15,6 +15,7 @@ from quodlibet.library.libraries import (Library, PicklingMixin, SongLibrary,
                                          FileLibrary, AlbumLibrary,
                                          SongFileLibrary, iter_paths)
 from quodlibet.util import connect_obj, is_windows
+from quodlibet.util.path import normalize_path
 from senf import fsnative
 from tests import TestCase, get_data_path, mkstemp, mkdtemp, skipIf
 from .helper import capture_output, get_temp_copy
@@ -418,8 +419,8 @@ class TFileLibrary(TLibrary):
 
     def test_move_root(self):
         root = Path(mkdtemp())
-        other_root = Path(mkdtemp())
-        new_root = Path(mkdtemp())
+        other_root = Path(normalize_path(mkdtemp(), True))
+        new_root = Path(normalize_path(mkdtemp(), True))
         in_song = AudioFile({"~filename": str(root / "file.mp3"), "title": "In"})
         in_song.sanitize()
         out_song = AudioFile({"~filename": str(other_root / "file.mp3"),

--- a/tests/test_library_libraries.py
+++ b/tests/test_library_libraries.py
@@ -15,7 +15,6 @@ from quodlibet.library.libraries import (Library, PicklingMixin, SongLibrary,
                                          FileLibrary, AlbumLibrary,
                                          SongFileLibrary, iter_paths)
 from quodlibet.util import connect_obj, is_windows
-from quodlibet.util.path import normalize_path
 from senf import fsnative
 from tests import TestCase, get_data_path, mkstemp, mkdtemp, skipIf
 from .helper import capture_output, get_temp_copy
@@ -45,6 +44,7 @@ class FakeSong(Fake):
 class AlbumSong(AudioFile):
     """A mock AudioFile belong to one of three albums,
     based on a single number"""
+
     def __init__(self, num, album=None):
         super().__init__()
         self["~filename"] = fsnative(u"file_%d.mp3" % (num + 1))
@@ -113,7 +113,7 @@ class TLibrary(TestCase):
     def test_add(self):
         self.library.add(self.Frange(12))
         self.failUnlessEqual(self.added, self.Frange(12))
-        del(self.added[:])
+        del (self.added[:])
         self.library.add(self.Frange(12, 24))
         self.failUnlessEqual(self.added, self.Frange(12, 24))
 
@@ -251,9 +251,9 @@ def FakeAudioFileRange(*args):
 
 
 class TPicklingMixin(TestCase):
-
     class PicklingMockLibrary(PicklingMixin, Library):
         """A library-like class that implements enough to test PicklingMixin"""
+
         def __init__(self):
             super().__init__(name="Mock")
             self._contents = {}
@@ -300,7 +300,7 @@ class TPicklingMixin(TestCase):
             library = self.Library()
             library.load(filename)
             for (k, v), (k2, v2) in zip(
-                    sorted(self.library.items()), sorted(library.items())):
+                sorted(self.library.items()), sorted(library.items())):
                 assert k == k2
                 assert v.key == v2.key
         finally:
@@ -342,7 +342,7 @@ class TSongLibrary(TLibrary):
 
     def test_tag_values(self):
         self.library.add(self.Frange(30))
-        del(self.added[:])
+        del (self.added[:])
         self.failUnlessEqual(
             sorted(self.library.tag_values(10)), list(range(10)))
         self.failUnlessEqual(sorted(self.library.tag_values(0)), [])
@@ -417,19 +417,25 @@ class TFileLibrary(TLibrary):
         self.assertFalse(removed)
 
     def test_move_root(self):
-        in_song = AudioFile({"~filename": "/tmp/subdir/file.mp3", "title": "Foo Bar"})
-        in_song.sanitize()
-        out_song = AudioFile({"~filename": "/tmp/otherdir/file.mp3", "title": "Quux"})
-        out_song.sanitize()
-        root = normalize_path("/tmp/subdir", True)
-        assert in_song("~dirname") == root
-        assert out_song("~dirname") == normalize_path("/tmp/otherdir", True)
-        self.library.add([out_song, in_song])
+        root = Path(mkdtemp())
+        other_root = Path(mkdtemp())
         new_root = Path(mkdtemp())
+        in_song = AudioFile({"~filename": str(root / "file.mp3"), "title": "In"})
+        in_song.sanitize()
+        out_song = AudioFile({"~filename": str(other_root / "file.mp3"),
+                              "title": "Out"})
+        # Make sure they exists
+        in_song.sanitize()
+        out_song.sanitize()
+        assert Path(in_song("~dirname")) == root, "test setup wrong"
+        assert Path(out_song("~dirname")) == other_root, "test setup wrong"
+        self.library.add([out_song, in_song])
+
+        # Run it by draining the generator
         list(self.library.move_root(root, str(new_root)))
         assert Path(in_song("~filename")) == new_root / "file.mp3"
-        assert Path(in_song("~dirname")) == new_root
-        assert out_song("~dirname") == "/tmp/otherdir", f"{out_song} was wrongly moved!"
+        assert Path(in_song("~dirname")) == new_root, "~dirname wasn't updated"
+        assert Path(out_song("~dirname")) == other_root, f"{out_song} was wrongly moved"
 
 
 class TSongFileLibrary(TSongLibrary):
@@ -465,6 +471,7 @@ class TSongFileLibrary(TSongLibrary):
 
             def error():
                 raise AudioFileError
+
             new.reload = error
             new._valid = False
             changed, removed = self.library._load_item(new)
@@ -568,9 +575,9 @@ class TAlbumLibrary(TestCase):
         self._sigs = [
             connect_obj(self.underlying, 'added', list.extend, self.added),
             connect_obj(self.underlying,
-                'changed', list.extend, self.changed),
+                        'changed', list.extend, self.changed),
             connect_obj(self.underlying,
-                'removed', list.extend, self.removed),
+                        'removed', list.extend, self.removed),
         ]
 
         self.library = AlbumLibrary(self.underlying)
@@ -675,21 +682,21 @@ class TAlbumLibrarySignals(TestCase):
         self.lib.add([AlbumSong(1, "a1")])
         self.lib.add([AlbumSong(5, "a1")])
         self.failUnlessEqual(self.received,
-            ["added", "a_added", "added", "a_changed"])
+                             ["added", "a_added", "added", "a_changed"])
 
     def test_remove(self):
         songs = [AlbumSong(1, "a1"), AlbumSong(2, "a1"), AlbumSong(4, "a2")]
         self.lib.add(songs)
         self.lib.remove(songs[:2])
         self.failUnlessEqual(self.received,
-            ["added", "a_added", "removed", "a_removed"])
+                             ["added", "a_added", "removed", "a_removed"])
 
     def test_change(self):
         songs = [AlbumSong(1, "a1"), AlbumSong(2, "a1"), AlbumSong(4, "a2")]
         self.lib.add(songs)
         self.lib.changed(songs)
         self.failUnlessEqual(self.received,
-            ["added", "a_added", "changed", "a_changed"])
+                             ["added", "a_added", "changed", "a_changed"])
 
     def tearDown(self):
         for s in self._asigs:

--- a/tests/test_library_libraries.py
+++ b/tests/test_library_libraries.py
@@ -434,7 +434,8 @@ class TFileLibrary(TLibrary):
 
         # Run it by draining the generator
         list(self.library.move_root(root, str(new_root)))
-        assert Path(in_song("~dirname")) == new_root, "directory wasn't updated"
+        msg = f"Dir wasn't updated in {root!r} -> {new_root!r} for {in_song.key}"
+        assert Path(in_song("~dirname")) == new_root, msg
         assert Path(in_song("~filename")) == new_root / "in file.mp3"
         assert Path(out_song("~dirname")) == other_root, f"{out_song} was wrongly moved"
 

--- a/tests/test_library_libraries.py
+++ b/tests/test_library_libraries.py
@@ -421,9 +421,9 @@ class TFileLibrary(TLibrary):
         root = Path(normalize_path(mkdtemp(), True))
         other_root = Path(normalize_path(mkdtemp(), True))
         new_root = Path(normalize_path(mkdtemp(), True))
-        in_song = AudioFile({"~filename": str(root / "file.mp3"), "title": "In"})
+        in_song = AudioFile({"~filename": str(root / "in file.mp3"), "title": "In"})
         in_song.sanitize()
-        out_song = AudioFile({"~filename": str(other_root / "file.mp3"),
+        out_song = AudioFile({"~filename": str(other_root / "out file.mp3"),
                               "title": "Out"})
         # Make sure they exists
         in_song.sanitize()
@@ -434,7 +434,7 @@ class TFileLibrary(TLibrary):
 
         # Run it by draining the generator
         list(self.library.move_root(root, str(new_root)))
-        assert Path(in_song("~filename")) == new_root / "file.mp3"
+        assert Path(in_song("~filename")) == new_root / "in file.mp3"
         assert Path(in_song("~dirname")) == new_root, "~dirname wasn't updated"
         assert Path(out_song("~dirname")) == other_root, f"{out_song} was wrongly moved"
 


### PR DESCRIPTION
 * Add a `move_dir()` (generator) method to `FileLibrary`
 * ...and to `Librarian` likewise
 * Add a button in Preferences -> Library to select an individual scandir to migrate
 * This then calls a Task that runs in the background
 * Add some tests around this
 * Add a little bit of documentation around this
 * TODO: more real-world testing, but it consistently seems to work for me locally, with fairly simple scenarios though

 This fixes #1939