### PR TITLE
Support JACK via Gstreamer

### DIFF
--- a/docs/guide/playback/backends.rst
+++ b/docs/guide/playback/backends.rst
@@ -10,6 +10,14 @@ no backend). Make sure Quod Libet isn't running while you edit the file.
 GStreamer Backend
 -----------------
 
+JACK support
+^^^^^^^^^^^^
+Quod Libet now supports JACK via Gstreamer's ``jackaudiosink``, if available.
+To select this, check the *Use JACK for playback if available* button
+in the *Player* tab of *Preferences*.
+There's also an option to auto-connect (wire up) the Quod Libet output
+to JACK output sinks (e.g. system devices) or not.
+
 Custom Pipelines
 ^^^^^^^^^^^^^^^^
 
@@ -18,7 +26,7 @@ under *File* → *Preferences* → *Playback* → *Output Pipeline*. The
 pipeline syntax is equivalent to what is used in the *gst-launch* utility.
 See ``man gst-launch`` for further information and examples.
 
-In case the custom pipline doesn't contain an audio sink, Quod Libet
+In case the custom pipeline doesn't contain an audio sink, Quod Libet
 will add a default one for you.
 
 

--- a/quodlibet/config.py
+++ b/quodlibet/config.py
@@ -41,6 +41,12 @@ INITIAL: Dict[str, Dict[str, str]] = {
         "gst_device": "",
         "gst_disable_gapless": "false",
 
+        # Use Jack sink (via Gstreamer) if available
+        "gst_use_jack": "false",
+
+        # Usually true is good here, but if you have patchbay configured maybe not...
+        "gst_jack_auto_connect": "true",
+
         "is_playing": "false",
         "restore_playing": "false",
     },

--- a/quodlibet/player/gstbe/prefs.py
+++ b/quodlibet/player/gstbe/prefs.py
@@ -1,5 +1,6 @@
 # Copyright 2004-2011 Joe Wreschnig, Michael Urman, Steven Robertson,
 #           2011-2014 Christoph Reiter
+#                2020 Nick Boultbee
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -23,14 +24,15 @@ class GstPlayerPreferences(Gtk.VBox):
 
         e = UndoEntry()
         e.set_tooltip_text(_("The GStreamer output pipeline used for "
-                "playback. Leave blank for the default pipeline. "
-                "In case the pipeline contains a sink, "
-                "it will be used instead of the default one."))
+                             "playback. Leave blank for the default pipeline. "
+                             "In case the pipeline contains a sink, "
+                             "it will be used instead of the default one."))
 
         e.set_text(config.get('player', 'gst_pipeline'))
 
         def changed(entry):
             config.set('player', 'gst_pipeline', entry.get_text())
+
         e.connect('changed', changed)
 
         pipe_label = Gtk.Label(label=_('_Output pipeline:'))
@@ -60,37 +62,49 @@ class GstPlayerPreferences(Gtk.VBox):
 
         def rebuild_pipeline(*args):
             player._rebuild_pipeline()
+
         apply_button.connect('clicked', rebuild_pipeline)
 
         gapless_button = ConfigCheckButton(
             _('Disable _gapless playback'),
-            "player", "gst_disable_gapless", populate=True)
-        gapless_button.set_alignment(0.0, 0.5)
-        gapless_button.set_tooltip_text(
-            _("Disabling gapless playback can avoid track changing problems "
-              "with some GStreamer versions"))
+            "player", "gst_disable_gapless", populate=True,
+            tooltip=_("Disabling gapless playback can avoid track changing problems "
+                      "with some GStreamer versions"))
 
+        jack_button = ConfigCheckButton(
+            _('Use JACK for playback if available'),
+            "player", "gst_use_jack", populate=True,
+            tooltip="Uses `jackaudiosink` for playbin sink if it can be detected")
+        jack_connect = ConfigCheckButton(
+            _('Auto-connect to JACK output devices'),
+            "player", "gst_jack_auto_connect",
+            populate=True, tooltip="Tells `jackaudiosink` to auto-connect")
+
+        def _jack_toggled(widget: ConfigCheckButton) -> None:
+            jack_connect.set_sensitive(widget.get_active())
+
+        jack_button.connect("clicked", _jack_toggled)
+        _jack_toggled(jack_button)
         widgets = [(pipe_label, e, apply_button),
-                   (buffer_label, scale, None),
-        ]
+                   (buffer_label, scale, None)]
 
-        table = Gtk.Table(n_rows=len(widgets), n_columns=3)
+        table = Gtk.Table(n_rows=len(widgets) + 3, n_columns=3)
         table.set_col_spacings(6)
         table.set_row_spacings(6)
         for i, (left, middle, right) in enumerate(widgets):
             left.set_alignment(0.0, 0.5)
             table.attach(left, 0, 1, i, i + 1,
-                         xoptions=Gtk.AttachOptions.FILL |
-                         Gtk.AttachOptions.SHRINK)
+                         xoptions=Gtk.AttachOptions.FILL | Gtk.AttachOptions.SHRINK)
             if right:
                 table.attach(middle, 1, 2, i, i + 1)
                 table.attach(right, 2, 3, i, i + 1,
-                             xoptions=Gtk.AttachOptions.FILL |
-                             Gtk.AttachOptions.SHRINK)
+                             xoptions=Gtk.AttachOptions.FILL | Gtk.AttachOptions.SHRINK)
             else:
                 table.attach(middle, 1, 3, i, i + 1)
 
         table.attach(gapless_button, 0, 3, 2, 3)
+        table.attach(jack_button, 0, 3, 3, 4)
+        table.attach(jack_connect, 0, 3, 4, 5)
 
         self.pack_start(table, True, True, 0)
 

--- a/quodlibet/player/gstbe/util.py
+++ b/quodlibet/player/gstbe/util.py
@@ -8,13 +8,36 @@
 
 import collections
 import subprocess
-from typing import Iterable
+from enum import Enum
+from typing import Iterable, Tuple
 from gi.repository import GLib, Gst
 
-from quodlibet import _, print_d
+from quodlibet import _, print_d, config
 from quodlibet.util.string import decode
 from quodlibet.util import is_linux, is_windows
 from quodlibet.player import PlayerError
+
+
+class AudioSinks(Enum):
+    """Relevant Gstreamer sink elements"""
+
+    FAKE = "fakesink"
+
+    DIRECTSOUND = "directsoundsink"
+
+    PULSE = "pulsesink"
+    """from plugins-good"""
+
+    ALSA = "alsasink"
+    """from plugins-base"""
+
+    AUTO = "autoaudiosink"
+    """from plugins-good"""
+
+    JACK = "jackaudiosink"
+    """from plugins-good"""
+
+    WASAPI = "wasapisink"
 
 
 def pulse_is_running():
@@ -22,7 +45,7 @@ def pulse_is_running():
 
     # If we have a pulsesink we can get the server presence through
     # setting the ready state
-    element = Gst.ElementFactory.make("pulsesink", None)
+    element = Gst.ElementFactory.make(AudioSinks.PULSE.value, None)
     if element is not None:
         element.set_state(Gst.State.READY)
         res = element.get_state(0)[0]
@@ -37,6 +60,18 @@ def pulse_is_running():
     except OSError:
         return False
     return True
+
+
+def jack_is_running() -> bool:
+    """:returns: whether Jack is running"""
+
+    element = Gst.ElementFactory.make(AudioSinks.JACK.value, "test sink")
+    if element:
+        element.set_state(Gst.State.READY)
+        res = element.get_state(0)[0]
+        element.set_state(Gst.State.NULL)
+        return res != Gst.StateChangeReturn.FAILURE
+    return False
 
 
 def link_many(elements: Iterable[Gst.Element]) -> None:
@@ -75,34 +110,39 @@ def iter_to_list(func):
     return objects
 
 
-def find_audio_sink():
+def find_audio_sink() -> Tuple[Gst.Element, str]:
     """Get the best audio sink available.
 
     Returns (element, description) or raises PlayerError.
     """
+    def sink_options():
+        # People with Jack running probably want it more than any other options
+        if config.getboolean("player", "gst_use_jack") and jack_is_running():
+            print_d("Using JACK output via Gstreamer")
+            return [AudioSinks.JACK]
+        elif is_windows():
+            return [AudioSinks.Directsound]
+        elif is_linux() and pulse_is_running():
+            return [AudioSinks.PULSE]
+        else:
+            return [
+                AudioSinks.AUTO,
+                AudioSinks.PULSE,
+                AudioSinks.ALSA,
+            ]
 
-    if is_windows():
-        sinks = [
-            "directsoundsink",
-        ]
-    elif is_linux() and pulse_is_running():
-        sinks = [
-            "pulsesink",
-        ]
-    else:
-        sinks = [
-            "autoaudiosink",  # plugins-good
-            "pulsesink",  # plugins-good
-            "alsasink",  # plugins-base
-        ]
-
-    for name in sinks:
-        element = Gst.ElementFactory.make(name, None)
+    options = sink_options()
+    for sink in options:
+        element = Gst.ElementFactory.make(sink.value, "player")
+        if (sink == AudioSinks.JACK
+                and not config.getboolean("player", "gst_jack_auto_connect")):
+            # Disable the auto-connection to outputs (e.g. maybe there's scripting)
+            element.set_property("connect", "none")
         if element is not None:
-            return (element, name)
+            return element, sink.value
     else:
-        details = " (%s)" % ", ".join(sinks) if sinks else ""
-        raise PlayerError(_("No GStreamer audio sink found") + details)
+        details = ', '.join(s.value for s in options) if options else "[]"
+        raise PlayerError(_("No GStreamer audio sink found. Tried: %s") % details)
 
 
 def GStreamerSink(pipeline_desc):
@@ -126,7 +166,7 @@ def GStreamerSink(pipeline_desc):
     if pipe:
         # In case the last element is linkable with a fakesink
         # it is not an audiosink, so we append the default one
-        fake = Gst.ElementFactory.make('fakesink', None)
+        fake = Gst.ElementFactory.make(AudioSinks.FAKE.value, None)
         try:
             link_many([pipe[-1], fake])
         except OSError:

--- a/quodlibet/player/gstbe/util.py
+++ b/quodlibet/player/gstbe/util.py
@@ -121,7 +121,7 @@ def find_audio_sink() -> Tuple[Gst.Element, str]:
             print_d("Using JACK output via Gstreamer")
             return [AudioSinks.JACK]
         elif is_windows():
-            return [AudioSinks.Directsound]
+            return [AudioSinks.DIRECTSOUND]
         elif is_linux() and pulse_is_running():
             return [AudioSinks.PULSE]
         else:

--- a/quodlibet/qltk/ccb.py
+++ b/quodlibet/qltk/ccb.py
@@ -19,8 +19,7 @@ class ConfigCheckButton(Gtk.CheckButton):
 
     def __init__(self, label, section, option, populate=False, tooltip=None,
                  default=None):
-        super().__init__(label=label,
-                                                use_underline=True)
+        super().__init__(label=label, use_underline=True)
 
         if default is None:
             default = config._config.defaults.getboolean(section, option, True)


### PR DESCRIPTION
 * Refactor a bit of sink handling stuff, new enum, etc
 * Detect if Jack is runnable via Gstreamer first (like with Pulse) before using it
 * Add prefs both for JACK support (defaults to off) and JACK auto-connection (defaults on)
 * Add some docs around this

This closes #3447