### PR TITLE
Restyle the search query

### DIFF
--- a/quodlibet/config.py
+++ b/quodlibet/config.py
@@ -230,10 +230,10 @@ INITIAL: Dict[str, Dict[str, str]] = {
         "plugins_window_on_top": "false",
 
         # search bar font style (#3647)
-        "monospace_query": "true",
+        "monospace_query": "false",
 
         # size to apply to query box, in any Pango CSS units (e.g. '100%', '1rem')
-        "query_font_size": "115%",
+        "query_font_size": "100%",
 
         # Amount of colour to apply to validating text entries
         # (0.0 = no colour, 1.0 = full colour)

--- a/quodlibet/config.py
+++ b/quodlibet/config.py
@@ -228,6 +228,16 @@ INITIAL: Dict[str, Dict[str, str]] = {
 
         # Whether the plugin window appears on top of others
         "plugins_window_on_top": "false",
+
+        # search bar font style (#3647)
+        "monospace_query": "true",
+
+        # size to apply to query box, in any Pango CSS units (e.g. '100%', '1rem')
+        "query_font_size": "115%",
+
+        # Amount of colour to apply to validating text entries
+        # (0.0 = no colour, 1.0 = full colour)
+        "validator_colorise": "0.4"
     },
 
     "rename": {

--- a/quodlibet/ext/events/advanced_preferences.py
+++ b/quodlibet/ext/events/advanced_preferences.py
@@ -147,6 +147,16 @@ class AdvancedPreferences(EventPlugin):
                  "the window always are visible or get hidden when not in use "
                  "(restart required)")),
             boolean_config(
+                "settings", "monospace_query",
+                "Use monospace font for search input:",
+                "Helps readability of code-like queries, but looks less consistent "
+                "(restart required)"),
+            text_config(
+                "settings", "query_font_size",
+                "Search input font size",
+                "Size to apply to the search query entry, "
+                "in any Pango CSS units, e.g. '100%', '1rem'. (restart required)"),
+            boolean_config(
                 "settings", "pangocairo_force_fontconfig",
                 "Force Use Fontconfig Backend:",
                 "It's not the default on win/macOS (restart required)"),

--- a/quodlibet/qltk/cbes.py
+++ b/quodlibet/qltk/cbes.py
@@ -9,14 +9,14 @@
 import os
 from typing import Dict
 
-from gi.repository import Gtk, Pango, GObject
+from gi.repository import Gtk, Pango, GObject, GLib
 
-from quodlibet import _
+from quodlibet import _, config
 from quodlibet import qltk
 from quodlibet.qltk.views import RCMHintedTreeView
 from quodlibet.qltk.util import GSignals
 from quodlibet.util import connect_obj, escape
-from quodlibet.qltk import entry
+from quodlibet.qltk import entry, add_css
 from quodlibet.qltk import Icons
 
 
@@ -293,7 +293,14 @@ class ComboBoxEntrySave(Gtk.ComboBox):
         new_entry = entry.ValidatingEntry(validator)
         clone_css_classes(old_entry, new_entry)
         old_entry.destroy()
+        use_mono = config.getboolean("settings", "monospace_query")
+        font = "font-family: monospace; " if use_mono else ""
+        size = escape(config.gettext("settings", "query_font_size"))
+        add_css(new_entry, f"entry {{ {font} font-size: {size} }}")
         self.add(new_entry)
+        if validator:
+            # Call once more to ensure correct theme colours
+            GLib.idle_add(new_entry._set_color, None, validator)
 
         connect_obj(self, 'destroy', self.set_model, None)
         connect_obj(self, 'changed', self.__changed, model, validator, title)

--- a/quodlibet/qltk/color.py
+++ b/quodlibet/qltk/color.py
@@ -1,0 +1,18 @@
+# Copyright 2020 Nick Boultbee
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+
+from gi.repository import Gdk
+
+
+def mix(src: Gdk.RGBA, dest: Gdk.RGBA, ratio: float) -> Gdk.RGBA:
+    """Mixes two Gdk colours into a result"""
+    ratio = min(1.0, max(0.0, ratio))
+    inv = 1.0 - ratio
+    return Gdk.RGBA(inv * src.red + ratio * dest.red,
+                    inv * src.green + ratio * dest.green,
+                    inv * src.blue + ratio * dest.blue,
+                    inv * src.alpha + ratio * dest.alpha)

--- a/quodlibet/qltk/entry.py
+++ b/quodlibet/qltk/entry.py
@@ -13,6 +13,7 @@ from gi.repository import Gtk, GObject, Gdk, Gio, Pango
 
 from quodlibet import _, config
 from quodlibet.qltk import is_accel, add_fake_accel
+from quodlibet.qltk.color import mix
 from quodlibet.qltk.x import SeparatorMenuItem, MenuItem
 from quodlibet.qltk import Icons
 
@@ -262,14 +263,6 @@ class ValidatingEntryMixin(Gtk.Widget):
         return col
 
     def _set_color(self, _widget, validator):
-        def mix(src: Gdk.RGBA, dest: Gdk.RGBA, ratio: float):
-            ratio = min(1.0, max(0.0, ratio))
-            inv = 1.0 - ratio
-            return Gdk.RGBA(inv * src.red + ratio * dest.red,
-                            inv * src.green + ratio * dest.green,
-                            inv * src.blue + ratio * dest.blue,
-                            inv * src.alpha + ratio * dest.alpha)
-
         value = validator(self.get_text())
         default = self._default_color()
         amount = config.getfloat("settings", "validator_colorise")


### PR DESCRIPTION
 * Use monospace by default (#3467)
 * ...but controlled by prefs boolean, which is now exposed in advanced prefs :up:
 * Validators: use colours that adapt according to the default (from theme) (#3515) by mixing them together. Makes for some interesting colours but I definitely prefer it, and it's now configurable too.
 * Increase the font size by default. I tried _many_ looks here and despite initial weirdness this default feels like a good balance between usability and awkwardness, especially given how important the searches are in QL...
 * But make _this_ configurable too, with another advanced prefs linking, so that users can change this back
 * TODO: some kind of docs around this?

## Before
### Light
![Screenshot from 2020-12-06 16-24-51](https://user-images.githubusercontent.com/3322808/101285889-a1fed800-37df-11eb-826a-c0cdc9c9cfce.png)
![Screenshot from 2020-12-06 16-24-48](https://user-images.githubusercontent.com/3322808/101285892-a2976e80-37df-11eb-91e2-0f744a778d55.png)

### Dark
![Screenshot from 2020-12-06 16-24-31](https://user-images.githubusercontent.com/3322808/101285893-a2976e80-37df-11eb-8f02-bd7733f1aee2.png)
![Screenshot from 2020-12-06 16-24-24](https://user-images.githubusercontent.com/3322808/101285894-a3300500-37df-11eb-9031-1388aaaad1bf.png)

## After
### Light
![Screenshot from 2020-12-05 19-48-13](https://user-images.githubusercontent.com/3322808/101285762-d920b980-37de-11eb-84a6-3ac18bca947d.png)
![Screenshot from 2020-12-05 19-47-51](https://user-images.githubusercontent.com/3322808/101285763-d9b95000-37de-11eb-8f7f-06f39cc01404.png)
![Screenshot from 2020-12-05 19-47-45](https://user-images.githubusercontent.com/3322808/101285764-d9b95000-37de-11eb-9819-10ab04e86038.png)

### Dark
![Screenshot from 2020-12-06 16-22-34](https://user-images.githubusercontent.com/3322808/101285833-46344f00-37df-11eb-9686-d1fd10a10b5a.png)
![Screenshot from 2020-12-06 16-14-03](https://user-images.githubusercontent.com/3322808/101285760-d7ef8c80-37de-11eb-848e-147b157343c9.png)
![Screenshot from 2020-12-06 16-13-53](https://user-images.githubusercontent.com/3322808/101285761-d8882300-37de-11eb-853d-8ad04a34d676.png)


Closes #3515, #3467 
