### PR TITLE
Library rescan: Yield and signal less often

### DIFF
--- a/quodlibet/library/libraries.py
+++ b/quodlibet/library/libraries.py
@@ -671,13 +671,13 @@ class FileLibrary(PicklingLibrary):
                 # These numbers are pretty empirical. We should yield more
             # often than we emit signals; that way the main loop stays
             # interactive and doesn't get bogged down in updates.
-            if len(changed) > 100:
+            if len(changed) >= 200:
                 self.emit('changed', changed)
                 changed = set()
-            if len(removed) > 100:
+            if len(removed) >= 200:
                 self.emit('removed', removed)
                 removed = set()
-            if len(changed) > 5 or i % 100 == 0:
+            if len(changed) > 20 or i % 200 == 0:
                 yield True
         print_d(f"Removing {len(removed)}, changing {len(changed)}).", self._name)
         if removed:


### PR DESCRIPTION
* Also align with 100 to prevent lots of weird (_101 files changes_) messages
* 10k tracks full rescan would have 100 signals and 2000 yields. Maybe 50 and 500 is enough, especially given faster machines now.
