### PR TITLE
gettextutil: warn on gettext warnings instead of erroring out

### DIFF
--- a/tests/test_po.py
+++ b/tests/test_po.py
@@ -42,7 +42,7 @@ class MissingTranslationsException(Exception):
 
 @pytest.mark.skipif(not has_gettext_util(), reason="no gettext")
 def test_potfile_format():
-    with gettextutil.create_pot(PODIR, strict=True) as pot_path:
+    with gettextutil.create_pot(PODIR) as pot_path:
         gettextutil.check_pot(pot_path)
 
 
@@ -69,7 +69,7 @@ class TPot(TestCase):
 
     @classmethod
     def setUpClass(cls):
-        with gettextutil.create_pot(PODIR, strict=True) as pot_path:
+        with gettextutil.create_pot(PODIR) as pot_path:
             cls.pot = polib.pofile(pot_path)
 
     def conclude(self, fails, reason):


### PR DESCRIPTION
Seems like gettext also warns for things unrelated to our input, so
this can trigger errors where everything is OK.

To work around that print a warning instead of erroring out in all cases.

Fixes #3539
