### PR TITLE
Change None to empty string to fix TypeError in missing.py

### DIFF
--- a/quodlibet/ext/query/missing.py
+++ b/quodlibet/ext/query/missing.py
@@ -20,7 +20,7 @@ class MissingQuery(QueryPlugin, PluginConfigMixin):
     usage = "<b><tt>@(missing: artist)</tt></b>"
 
     def search(self, data, body):
-        val = data.get(body.strip() if body else None, None)
+        val = data.get(body.strip() if body else '', None)
         return (val is None
                 or (self.config_get_bool("include_empty", True)
                     and val == ""))


### PR DESCRIPTION
Fixes #3547

Check-list
----------

 * [ x] There is a linked issue discussing the motivations for this feature or bugfix
 * [ ] Unit tests have been added where possible
 * [ ] I've added / updated documentation for any user-facing features.
 * [ x] Performance seems to be comparable or better than current `master`


What this change is adding / fixing
-----------------------------------
None value is problematic for the Album based browsers, using an empty string solves the issue and doesn't change behaviour

