### PR TITLE
Add FileOperationsPlugin

### DIFF
--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -119,6 +119,7 @@ quodlibet/ext/songsmenu/duplicates.py
 quodlibet/ext/songsmenu/editplaycount.py
 quodlibet/ext/songsmenu/embedded.py
 quodlibet/ext/songsmenu/exact_rating.py
+quodlibet/ext/songsmenu/file_operations.py
 quodlibet/ext/songsmenu/filterall.py
 quodlibet/ext/songsmenu/filterbrowser.py
 quodlibet/ext/songsmenu/fingerprint/__init__.py

--- a/quodlibet/ext/songsmenu/file_operations.py
+++ b/quodlibet/ext/songsmenu/file_operations.py
@@ -1,0 +1,329 @@
+# Copyright 2021 Michał Kaliński
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+
+from abc import ABC, abstractmethod
+import enum
+import functools
+import os
+from queue import SimpleQueue
+import shutil
+from threading import Event, Thread
+from traceback import format_exc
+from typing import (
+    Callable,
+    Iterable,
+    Iterator,
+    List,
+    NamedTuple,
+    Optional,
+    Sequence,
+    Type,
+)
+
+from gi.repository import GLib, Gtk
+
+from quodlibet.plugins.songshelpers import each_song, is_a_file
+from quodlibet.plugins.songsmenu import SongsMenuPlugin
+from quodlibet.qltk import Icons
+from quodlibet.util.i18n import _
+from quodlibet.util.songwrapper import SongWrapper
+
+
+class FileOperationsPlugin(SongsMenuPlugin):
+    PLUGIN_ID = "file-operations"
+    PLUGIN_NAME = _("File Operations")
+    PLUGIN_DESC = _("Adds menu options to copy or move song files. "
+                    "Moved songs remain in library.")
+    PLUGIN_ICON = Icons.EDIT_COPY
+
+    plugin_handles = each_song(is_a_file)
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
+        # Set to CopyOperation just to have any non-None value.
+        # It will be set to user-requested type when submenu item is activated.
+        self.__operation_type: Type[Operation] = CopyOperation
+
+        actions_menu = Gtk.Menu()
+        self.set_submenu(actions_menu)
+
+        copy_item = Gtk.MenuItem(_("Copy"))
+        copy_item.connect("activate", self.__activate_copy)
+        actions_menu.append(copy_item)
+
+        move_item = Gtk.MenuItem(_("Move"))
+        move_item.connect("activate", self.__activate_move)
+        actions_menu.append(move_item)
+
+    def plugin_songs(self, songs):
+        op_params = FileOperationsFileChooser(songs).execute()
+
+        if op_params is None:
+            return
+
+        abort_event = Event()
+        feedback_widget = FeedbackWidget(abort_event, len(songs))
+        feedback_queue = SimpleQueue()
+
+        feedback_worker(
+            FeedbackWorkerArguments(
+                feedback_widget=feedback_widget,
+                feedback_queue=feedback_queue,
+            ),
+        )
+
+        operation_worker(
+            OperationWorkerArguments(
+                operation=self.__operation_type(op_params),
+                feedback_queue=feedback_queue,
+                abort_event=abort_event,
+                finish_callback=self.plugin_finish,
+            ),
+        )
+
+    def __activate_copy(self, _menu_item) -> None:
+        self.__operation_type = CopyOperation
+
+    def __activate_move(self, _menu_item) -> None:
+        self.__operation_type = MoveOperation
+
+
+def _song_filename(song: SongWrapper) -> str:
+    return song("~filename")
+
+
+class OperationParams(NamedTuple):
+    song: SongWrapper
+    target: str
+
+    @property
+    def source(self) -> str:
+        return _song_filename(self.song)
+
+    def __str__(self) -> str:
+        return f"{self.source} --> {self.target}"
+
+
+class FileOperationsFileChooser:
+    def __init__(self, songs: Sequence[SongWrapper]) -> None:
+        self._songs = songs
+
+    def execute(self) -> Optional[List[OperationParams]]:
+        dialog = self._build_dialog()
+        params = None
+
+        try:
+            if dialog.run() == Gtk.ResponseType.OK:
+                target = dialog.get_filename()
+                params = [
+                    OperationParams(song, target)
+                    for song in self._songs
+                ]
+        finally:
+            dialog.destroy()
+
+        return params
+
+    def _build_dialog(self):
+        dialog = Gtk.FileChooserDialog(
+            title=_("Select destination"),
+            buttons=(
+                _("Cancel"),
+                Gtk.ResponseType.CANCEL,
+                _("Save"),
+                Gtk.ResponseType.OK,
+            ),
+        )
+
+        if len(self._songs) == 1:
+            dialog.set_action(Gtk.FileChooserAction.SAVE)
+            dialog.set_current_name(os.path.basename(_song_filename(self._songs[0])))
+        else:
+            dialog.set_action(Gtk.FileChooserAction.SELECT_FOLDER)
+
+        return dialog
+
+
+class MessageKind(enum.Enum):
+    INFO = enum.auto()
+    ERROR = enum.auto()
+    END = enum.auto()
+
+    def with_body(self, body: str) -> "Message":
+        return Message(self, body)
+
+
+class Message(NamedTuple):
+    kind: MessageKind
+    body: str
+
+
+class Operation(ABC):
+    VERB = "-"
+
+    def __init__(self, operations_params: Iterable[OperationParams]) -> None:
+        self._ops_params = operations_params
+
+    def execute(self) -> Iterator[Message]:
+        for op_params in self._ops_params:
+            try:
+                op_params_str = str(op_params)
+                self.do_operation(op_params)
+                yield MessageKind.INFO.with_body(f"{self.VERB}: {op_params_str}")
+            except Exception:
+                yield MessageKind.ERROR.with_body(
+                    f"{_('Error')}: {op_params_str}\n{format_exc()}",
+                )
+                break
+
+    @staticmethod
+    @abstractmethod
+    def do_operation(op_params: OperationParams) -> None:
+        pass
+
+
+class CopyOperation(Operation):
+    VERB = _("Copied")
+
+    @staticmethod
+    def do_operation(op_params: OperationParams) -> None:
+        shutil.copy(op_params.source, op_params.target)
+
+
+class MoveOperation(Operation):
+    VERB = _("Moved")
+
+    @staticmethod
+    def do_operation(op_params: OperationParams) -> None:
+        op_params.song.rename(op_params.target)
+
+
+def _run_in_thread(func):
+    @functools.wraps(func)
+    def thread_wrapper(*args):
+        thread = Thread(target=func, args=args)
+        thread.start()
+        return thread
+
+    return thread_wrapper
+
+
+class OperationWorkerArguments(NamedTuple):
+    operation: Operation
+    feedback_queue: "SimpleQueue[Message]"
+    abort_event: Event
+    finish_callback: Callable[[], None]
+
+
+@_run_in_thread
+def operation_worker(args: OperationWorkerArguments) -> None:
+    for message in args.operation.execute():
+        args.feedback_queue.put(message)
+
+        if args.abort_event.is_set():
+            break
+
+    args.feedback_queue.put(MessageKind.END.with_body(_("Operations finished")))
+    args.finish_callback()
+
+
+def _run_in_idle(func):
+    @functools.wraps(func)
+    def idle_wrapper(*args):
+        GLib.idle_add(func, *args)
+
+    return idle_wrapper
+
+
+class FeedbackWidget:
+    def __init__(self, abort_event: Event, operations_count: int) -> None:
+        self._progress_bar_step = 1 / operations_count
+        self._abort_event = abort_event
+        self._operations_ended = Event()
+
+        self._window = Gtk.Window(
+            type=Gtk.WindowType.TOPLEVEL,
+            title=_("File Operations"),
+        )
+        self._window.set_default_size(800, 600)
+        self._window.connect("destroy", lambda _window: self._abort_event.set())
+
+        box = Gtk.Box(
+            orientation=Gtk.Orientation.VERTICAL,
+            spacing=3,
+            homogeneous=False,
+        )
+        self._window.add(box)
+
+        self._progress_bar = Gtk.ProgressBar(text=None, show_text=True)
+        box.pack_start(self._progress_bar, False, False, 0)
+
+        text_log_scroll = Gtk.ScrolledWindow()
+        box.pack_start(text_log_scroll, True, True, 6)
+
+        self._text_log = Gtk.TextView(
+            cursor_visible=False,
+            editable=False,
+            monospace=True,
+        )
+        text_log_scroll.add(self._text_log)
+
+        self._button = Gtk.Button.new_with_label(_("Abort"))
+        self._button.connect("clicked", self.on_button_clicked)
+        box.pack_start(self._button, False, False, 0)
+
+        self._window.show_all()
+
+    def on_button_clicked(self, _button) -> None:
+        if self._operations_ended.is_set():
+            self._window.destroy()
+        else:
+            self._abort_event.set()
+
+    @_run_in_idle
+    def on_info(self, message: Message) -> None:
+        self._progress_bar.set_fraction(
+            min(self._progress_bar.get_fraction() + self._progress_bar_step, 1),
+        )
+        self._log_line(message.body)
+
+    @_run_in_idle
+    def on_error(self, message: Message) -> None:
+        self._log_line(message.body, "")
+
+    @_run_in_idle
+    def on_end(self, message: Message) -> None:
+        self._operations_ended.set()
+        self._progress_bar.set_fraction(1)
+        self._log_line(message.body)
+        self._button.set_label(_("Close"))
+
+    def _log_line(self, text: str, end: str = "\n") -> None:
+        log_buffer = self._text_log.get_buffer()
+        log_buffer.insert(log_buffer.get_end_iter(), text + end)
+
+
+class FeedbackWorkerArguments(NamedTuple):
+    feedback_queue: "SimpleQueue[Message]"
+    feedback_widget: FeedbackWidget
+
+
+@_run_in_thread
+def feedback_worker(args: FeedbackWorkerArguments) -> None:
+    callbacks = {
+        MessageKind.INFO: args.feedback_widget.on_info,
+        MessageKind.ERROR: args.feedback_widget.on_error,
+        MessageKind.END: args.feedback_widget.on_end,
+    }
+
+    while True:
+        message = args.feedback_queue.get()
+        callbacks[message.kind](message)
+
+        if message.kind is MessageKind.END:
+            break

--- a/tests/plugin/test_file_operations.py
+++ b/tests/plugin/test_file_operations.py
@@ -1,0 +1,284 @@
+# Copyright 2021 Michał Kaliński
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+
+import os
+from queue import SimpleQueue
+from tempfile import TemporaryDirectory
+import time
+from threading import Event
+from typing import NamedTuple
+from unittest.mock import patch, create_autospec, Mock
+
+from quodlibet.formats import AudioFile
+from quodlibet.util.songwrapper import SongWrapper
+from . import PluginTestCase
+
+
+class _OperationSetup(NamedTuple):
+    source: str
+    target: str
+    body: str
+
+
+def _make_song(filename: str) -> SongWrapper:
+    return SongWrapper(AudioFile({"~filename": filename}))
+
+
+def _thread_pause() -> None:
+    time.sleep(0.001)
+
+
+class _BaseCases:
+    class FOTestCase(PluginTestCase):
+        @classmethod
+        def setUpClass(cls):
+            super().setUpClass()
+            cls.mod = cls.modules["file-operations"]
+            cls.kind = cls.plugins["file-operations"].cls
+
+        @classmethod
+        def tearDownClass(cls):
+            del cls.mod
+            del cls.kind
+            super().tearDownClass()
+
+    class OperationTestCase(FOTestCase):
+        OPERATION_CLASS_NAME = "Operation"
+
+        @classmethod
+        def setUpClass(cls):
+            super().setUpClass()
+            cls.operations_setups = [
+                _OperationSetup("a", "b", "abody\n"),
+                _OperationSetup("one", "two", "onebody\n"),
+            ]
+            cls.operation_class = getattr(cls.mod, cls.OPERATION_CLASS_NAME)
+
+        @classmethod
+        def tearDownClass(cls):
+            del cls.operations_setups
+            del cls.operation_class
+            super().tearDownClass()
+
+        def setUp(self):
+            super().setUp()
+            self.temp_dir = TemporaryDirectory()
+            self.temp_dir_name = os.path.basename(self.temp_dir.name)
+            self.operations_params = []
+            self.source_tails = []
+            self.target_tails = []
+
+            for op_setup in self.operations_setups:
+                source_path = os.path.join(self.temp_dir.name, op_setup.source)
+                self.operations_params.append(
+                    self.mod.OperationParams(
+                        _make_song(source_path),
+                        os.path.join(self.temp_dir.name, op_setup.target),
+                    ),
+                )
+                self.source_tails.append(
+                    os.path.join(self.temp_dir_name, op_setup.source)
+                )
+                self.target_tails.append(
+                    os.path.join(self.temp_dir_name, op_setup.target)
+                )
+
+                with open(source_path, "w") as source_file:
+                    source_file.write(op_setup.body)
+
+        def tearDown(self):
+            self.temp_dir.cleanup()
+            del self.temp_dir
+            del self.temp_dir_name
+            del self.operations_params
+            del self.source_tails
+            del self.target_tails
+            super().tearDown()
+
+        def test_operation_yields_success_messages(self):
+            operation = self.operation_class(self.operations_params)
+            messages = operation.execute()
+
+            for message, source_tail, target_tail in zip(
+                messages, self.source_tails, self.target_tails
+            ):
+                self.assertIs(message.kind, self.mod.MessageKind.INFO)
+                self.assertIn(self.operation_class.VERB, message.body)
+                self.assertIn(source_tail, message.body)
+                self.assertIn(target_tail, message.body)
+
+        def test_operation_yields_error_message_and_stops(self):
+            exception_text = "foo bar"
+
+            with patch.object(self.operation_class, "do_operation") as operate_mock:
+                operate_mock.side_effect = Exception(exception_text)
+
+                operation = self.operation_class(self.operations_params)
+                messages = list(operation.execute())
+
+            self.assertEqual(len(messages), 1)
+            message = messages[0]
+            self.assertIs(message.kind, self.mod.MessageKind.ERROR)
+            self.assertIn(self.source_tails[0], message.body)
+            self.assertIn(self.target_tails[0], message.body)
+            self.assertIn(exception_text, message.body)
+
+
+class TFOCopyOperation(_BaseCases.OperationTestCase):
+    OPERATION_CLASS_NAME = "CopyOperation"
+
+    def test_creates_copies_of_songs(self):
+        operation = self.operation_class(self.operations_params)
+        list(operation.execute())
+
+        for op_params in self.operations_params:
+            with open(op_params.target, "r") as target_file, \
+                    open(op_params.source, "r") as source_file:
+                self.assertEqual(target_file.read(), source_file.read())
+
+
+class TFOMoveOperation(_BaseCases.OperationTestCase):
+    OPERATION_CLASS_NAME = "MoveOperation"
+
+    def test_moves_songs(self):
+        # Sources must be cached before operation because they change during move
+        sources = [op.source for op in self.operations_params]
+        operation = self.operation_class(self.operations_params)
+        list(operation.execute())
+
+        for op_params, op_source, op_setup in zip(
+            self.operations_params,
+            sources,
+            self.operations_setups,
+        ):
+            self.assertFalse(os.path.exists(op_source))
+
+            with open(op_params.target, "r") as target_file:
+                self.assertEqual(target_file.read(), op_setup.body)
+
+
+class TFOOperationWorker(_BaseCases.FOTestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.operation_messages = [
+            cls.mod.MessageKind.INFO.with_body("foo"),
+            cls.mod.MessageKind.ERROR.with_body("bar"),
+        ]
+
+    @classmethod
+    def tearDownClass(cls):
+        del cls.operation_messages
+        super().tearDownClass()
+
+    def setUp(self):
+        super().setUp()
+        self.operation_mock = self.mock_operation()
+        self.feedback_queue = SimpleQueue()
+        self.abort_event = Event()
+        self.finish_callback = Mock()
+        self.operation_worker_args = self.mod.OperationWorkerArguments(
+            operation=self.operation_mock,
+            feedback_queue=self.feedback_queue,
+            abort_event=self.abort_event,
+            finish_callback=self.finish_callback,
+        )
+
+    def tearDown(self):
+        del self.operation_mock
+        del self.feedback_queue
+        del self.abort_event
+        del self.finish_callback
+        del self.operation_worker_args
+        super().tearDown()
+
+    @classmethod
+    def mock_operation(cls):
+        operation = create_autospec(cls.mod.Operation, instance=True)
+        operation.execute.return_value = cls.operation_messages_generator()
+        return operation
+
+    @classmethod
+    def operation_messages_generator(cls):
+        for message in cls.operation_messages:
+            _thread_pause()
+            yield message
+
+    def drain_queue(self):
+        while not self.feedback_queue.empty():
+            yield self.feedback_queue.get()
+
+    def test_puts_execute_messages_in_feedback_queue(self):
+        thread = self.mod.operation_worker(self.operation_worker_args)
+        thread.join()
+        messages = list(self.drain_queue())
+
+        self.assertEqual(messages[:-1], self.operation_messages)
+        self.assertIs(messages[-1].kind, self.mod.MessageKind.END)
+
+    def test_stops_execution_on_abort_flag(self):
+        thread = self.mod.operation_worker(self.operation_worker_args)
+        self.abort_event.set()
+        thread.join()
+        messages = list(self.drain_queue())
+
+        self.assertEqual(messages[:-1], self.operation_messages[:1])
+        self.assertIs(messages[-1].kind, self.mod.MessageKind.END)
+
+    def test_calls_finish_callback_after_all_done(self):
+        thread = self.mod.operation_worker(self.operation_worker_args)
+        self.finish_callback.assert_not_called()
+
+        thread.join()
+        self.finish_callback.assert_called()
+
+
+class TFOFeedbackWorker(_BaseCases.FOTestCase):
+    def setUp(self):
+        super().setUp()
+        self.feedback_queue = SimpleQueue()
+        self.feedback_widget = create_autospec(self.mod.FeedbackWidget, instance=True)
+        self.feedback_worker_args = self.mod.FeedbackWorkerArguments(
+            feedback_queue=self.feedback_queue,
+            feedback_widget=self.feedback_widget,
+        )
+
+    def tearDown(self):
+        del self.feedback_queue
+        del self.feedback_widget
+        del self.feedback_worker_args
+        super().tearDown()
+
+    def test_drains_gueue_unit_end_message_received(self):
+        self.feedback_queue.put(self.mod.MessageKind.INFO.with_body("foo"))
+
+        thread = self.mod.feedback_worker(self.feedback_worker_args)
+        _thread_pause()
+
+        self.assertTrue(self.feedback_queue.empty())
+        self.assertTrue(thread.is_alive())
+
+        self.feedback_queue.put(self.mod.MessageKind.END.with_body("bar"))
+
+        thread.join()
+
+        self.assertTrue(self.feedback_queue.empty())
+
+    def test_calls_feedback_widget_on_messages(self):
+        info = self.mod.MessageKind.INFO.with_body("foo")
+        self.feedback_queue.put(info)
+        error = self.mod.MessageKind.ERROR.with_body("bar")
+        self.feedback_queue.put(error)
+        end = self.mod.MessageKind.END.with_body("baz")
+        self.feedback_queue.put(end)
+
+        thread = self.mod.feedback_worker(self.feedback_worker_args)
+        thread.join()
+
+        self.feedback_widget.on_info.assert_called_with(info)
+        self.feedback_widget.on_error.assert_called_with(error)
+        self.feedback_widget.on_end.assert_called_with(end)


### PR DESCRIPTION
Check-list
----------

 * [x] There is a linked issue discussing the motivations for this feature or bugfix: #3549
 * [x] Unit tests have been added where possible
 * [ ] I've added / updated documentation for any user-facing features: individual plugins don't seem to have a dedicated documentation section
 * [x] Performance seems to be comparable or better than current `master`


What this change is adding / fixing
-----------------------------------
<!-- A high-level description of the changes.
Hopefully the commits are atomic and well described, but this is the overall
summary of the change, to other developers / maintainers, plus any TODOs. -->

This change is adding a songsmenu plugin that provides two menu options: `Copy` and `Move`.

These options open a file chooser to select destination, and then copy or move the selected songs to the destination.

Moving / copying is done in a separate thread.

A window is opened with a progress bar, log of each file copied / moved and any exceptions that might occur, and a button to abort the copy / move.