### PR TITLE
Adds Pipewire Sink

### DIFF
--- a/quodlibet/config.py
+++ b/quodlibet/config.py
@@ -44,6 +44,9 @@ INITIAL: Dict[str, Dict[str, str]] = {
         # Use Jack sink (via Gstreamer) if available
         "gst_use_jack": "false",
 
+        # Use PipeWire sink (via Gstreamer) if available
+        "gst_use_pipewire": "false",
+
         # Usually true is good here, but if you have patchbay configured maybe not...
         "gst_jack_auto_connect": "true",
 

--- a/quodlibet/player/gstbe/prefs.py
+++ b/quodlibet/player/gstbe/prefs.py
@@ -71,6 +71,11 @@ class GstPlayerPreferences(Gtk.VBox):
             tooltip=_("Disabling gapless playback can avoid track changing problems "
                       "with some GStreamer versions"))
 
+        pipewire_button = ConfigCheckButton(
+            _('Use PipeWire for playback if available'),
+            "player", "gst_use_pipewire", populate=True,
+            tooltip="Uses `pipewiresink` for playbin sink if it can be detected")
+
         jack_button = ConfigCheckButton(
             _('Use JACK for playback if available'),
             "player", "gst_use_jack", populate=True,
@@ -105,6 +110,7 @@ class GstPlayerPreferences(Gtk.VBox):
         table.attach(gapless_button, 0, 3, 2, 3)
         table.attach(jack_button, 0, 3, 3, 4)
         table.attach(jack_connect, 0, 3, 4, 5)
+        table.attach(pipewire_button, 0, 3, 5, 6)
 
         self.pack_start(table, True, True, 0)
 

--- a/quodlibet/player/gstbe/util.py
+++ b/quodlibet/player/gstbe/util.py
@@ -37,6 +37,8 @@ class AudioSinks(Enum):
     JACK = "jackaudiosink"
     """from plugins-good"""
 
+    PIPEWIRE = "pipewiresink"
+
     WASAPI = "wasapisink"
 
 
@@ -66,6 +68,18 @@ def jack_is_running() -> bool:
     """:returns: whether Jack is running"""
 
     element = Gst.ElementFactory.make(AudioSinks.JACK.value, "test sink")
+    if element:
+        element.set_state(Gst.State.READY)
+        res = element.get_state(0)[0]
+        element.set_state(Gst.State.NULL)
+        return res != Gst.StateChangeReturn.FAILURE
+    return False
+
+
+def pipewire_is_running() -> bool:
+    """:returns: whether Pipewire is running"""
+
+    element = Gst.ElementFactory.make(AudioSinks.PIPEWIRE.value, "test sink")
     if element:
         element.set_state(Gst.State.READY)
         res = element.get_state(0)[0]
@@ -120,6 +134,9 @@ def find_audio_sink() -> Tuple[Gst.Element, str]:
         if config.getboolean("player", "gst_use_jack") and jack_is_running():
             print_d("Using JACK output via Gstreamer")
             return [AudioSinks.JACK]
+        if config.getboolean("player", "gst_use_pipewire") and pipewire_is_running():
+            print_d("Using PipeWire output via Gstreamer")
+            return [AudioSinks.PIPEWIRE]
         elif is_windows():
             return [AudioSinks.DIRECTSOUND]
         elif is_linux() and pulse_is_running():


### PR DESCRIPTION
Uses the same strategy uses if you want to use Jack instead
of PulseAudio. Config option set to disabled by default.

Check-list
----------

 * [X] There is a linked issue discussing the motivations for this feature or bugfix #3551
 * [] Unit tests have been added where possible
 * [TODO] I've added / updated documentation for any user-facing features.
 * [X] Performance seems to be comparable or better than current `master`

