### PR TITLE
Create GitHub Actions automated testing for Fedora 33 (resolves #3542)

### DIFF
--- a/.github/workflows/fedora33/Dockerfile
+++ b/.github/workflows/fedora33/Dockerfile
@@ -1,0 +1,42 @@
+FROM fedora:33
+
+# DNF dependencies required before poetry can install virtualenv dependencies
+RUN dnf -y install \
+      poetry \
+      cairo-devel \
+      gcc \
+      python3-devel \
+      dbus-devel \
+      gobject-introspection-devel \
+      cairo-gobject-devel
+
+# Dependencies for tests
+RUN dnf -y install \
+      Xvfb \
+      # Contains 'GdkPixbuf' namespace (used by 'gi') \
+      gtk3 \
+      # Contains 'Gst' module \
+      gstreamer1 \
+      # Contains GStreamer replaygain plugin \
+      gstreamer1-plugins-good \
+      # SVG support (for 'Timage_support.test_create_pixbuf' test) \
+      librsvg2 \
+      dbus-x11
+
+RUN dnf clean all
+
+# Create user (required for write access tests in 'tests/test_formats__audio.py' to pass)
+ARG HOST_USER_ID=5555
+ENV HOST_USER_ID ${HOST_USER_ID}
+RUN useradd -u $HOST_USER_ID -ms /bin/bash user
+
+# Required to prevent pytest from running into permissions errors when creating
+# cache files in GITHUB_WORKSPACE as 'user'
+ENV PYTHONDONTWRITEBYTECODE 1
+
+# required for translation tests that use 'gettext'
+ENV LANG C.UTF-8
+
+# run tests
+COPY entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/.github/workflows/fedora33/action.yml
+++ b/.github/workflows/fedora33/action.yml
@@ -1,0 +1,6 @@
+# action.yml
+name: Fedora 33
+description: Run tests for Fedora 33
+runs:
+  using: docker
+  image: Dockerfile

--- a/.github/workflows/fedora33/entrypoint.sh
+++ b/.github/workflows/fedora33/entrypoint.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+# Fix for hanging flake8 test
+# https://github.com/quodlibet/quodlibet/issues/3539#issuecomment-767389459
+poetry config virtualenvs.in-project true
+
+poetry install -E plugins
+sudo -u user poetry run python3 setup.py test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,6 +3,14 @@ name: test
 on: [push, pull_request]
 
 jobs:
+  fedora:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Run tests in Docker container
+        uses: ./.github/workflows/fedora33
 
   msys2:
     runs-on: windows-latest


### PR DESCRIPTION
Check-list
----------

 * [x ] There is a linked issue discussing the motivations for this feature or bugfix


What this change is adding / fixing
-----------------------------------
Automation is added for building on Fedora 33 in Github Actions CI, to make it easier for Fedora users to contibute ( i.e. ..me :^]  )

