### PR TITLE
Update plugins.rst to include locations on MacOS.

### DIFF
--- a/docs/development/plugins.rst
+++ b/docs/development/plugins.rst
@@ -55,9 +55,10 @@ Location of Plugins
 ^^^^^^^^^^^^^^^^^^^
 
 In older versions of Quod Libet, before they were moved into the main
-``quodlibet`` module, plugins could be placed in ``~/.config/quodlibet/plugins``.
+``quodlibet`` module, plugins could be placed in ``~/.config/quodlibet/plugins``
+on many Linux systems, and in ``~/.quodlibet/plugins`` on MacOS.
 
-Whilst this still works on many Linux systems,
+Whilst this still may work,
 we recommend installing from source (see :ref:`DevEnv`) for all plugin development,
 which will allow a fuller integration experience (debugging, etc).
 


### PR DESCRIPTION
I´ve included the location of plugins for older versions of QL on MacOS. This info would have saved me some headache regarding  #3426 and #3559. The locattion still works for me and this information might be helpful for others as well.