### PR TITLE
Ignore auto_sort when shuffle is enabled

### DIFF
--- a/quodlibet/qltk/songlist.py
+++ b/quodlibet/qltk/songlist.py
@@ -953,7 +953,8 @@ class SongList(AllTreeView, SongListDnDMixin, DragScroll,
         """
 
         model = self.get_model()
-        if config.getboolean("song_list", "auto_sort") and self.is_sorted():
+        if not config.getboolean("memory", "shuffle", False) and \
+                config.getboolean("song_list", "auto_sort") and self.is_sorted():
             iters, complete = self.__find_iters_in_selection(songs)
             if not complete:
                 iters = model.find_all(songs)


### PR DESCRIPTION
Check-list
----------

 * [ ] There is a linked issue discussing the motivations for this feature or bugfix
 * [x] Unit tests have been added where possible
 * [x] I've added / updated documentation for any user-facing features.
 * [x] Performance seems to be comparable or better than current `master`


What this change is adding / fixing
-----------------------------------

After #2509 has been merged the ability to go back to the previous track when shuffle mode
was enabled stopped working. This change makes it so that auto_sort is ignored when needed.