### PR TITLE
Provide empty mpris:artUrl if cover art is not present

### DIFF
--- a/quodlibet/ext/events/mpris/mpris2.py
+++ b/quodlibet/ext/events/mpris/mpris2.py
@@ -267,6 +267,8 @@ value="false"/>
             if is_temp:
                 self.__cover = cover
             metadata["mpris:artUrl"] = fsn2uri(cover.name)
+        else:
+            metadata["mpris:artUrl"] = ""
 
         # All list values
         list_val = {"artist": "artist", "albumArtist": "albumartist",


### PR DESCRIPTION
Check-list
----------

 * [ ] There is a linked issue discussing the motivations for this feature or bugfix
 * [x] Unit tests have been added where possible
 * [x] I've added / updated documentation for any user-facing features.
 * [x] Performance seems to be comparable or better than current `master`


What this change is adding / fixing
-----------------------------------
This fixes an issue on KDE connect app that causes previous
cover art to get shown whenever currently playing song has
no artwork but the previous one does.