### PR TITLE
reload(): only migrate actual internal tags

### DIFF
--- a/quodlibet/formats/_audio.py
+++ b/quodlibet/formats/_audio.py
@@ -253,8 +253,13 @@ class AudioFile(dict, ImageContainer):
         backup = dict(self)
         fn = self["~filename"]
         saved = {}
+        persisted = config.getboolean("editing", "save_to_songs")
+        persisted_keys = ({"~#rating", "~#playcount"}
+                          if self.supports_rating_and_play_count_in_file and persisted
+                          else set())
         for key in self:
-            if key in MIGRATE:
+            # Only migrate keys that aren't (probably) persisted to file (#3569)
+            if key in MIGRATE - persisted_keys:
                 saved[key] = self[key]
         self.clear()
         self["~filename"] = fn

--- a/tests/test_formats__audio.py
+++ b/tests/test_formats__audio.py
@@ -54,7 +54,8 @@ bar_va = AudioFile({
     "performer": "Jay-Z"})
 
 num_call = AudioFile({"custom": "0.3"})
-
+ANOTHER_RATING = 0.2
+SOME_RATING = 0.8
 
 class TAudioFile(TestCase):
 
@@ -961,6 +962,20 @@ class TAudioFile(TestCase):
         audio["title"] = u"foo"
         audio.reload()
         self.assertNotEqual(audio.get("title"), u"foo")
+
+    def test_reload_externally_modified(self):
+        config.set("editing", "save_to_songs", True)
+        fn = self.quux("~filename") + ".mp3"
+        shutil.copy(get_data_path('silence-44-s.mp3'), fn)
+        orig = MusicFile(fn)
+        copy = MusicFile(fn)
+        orig["~#rating"] = SOME_RATING
+        copy["~#rating"] = ANOTHER_RATING
+        orig.write()
+        orig.reload()
+        copy.reload() # should pick up the change to the file
+        assert orig("~#rating") == SOME_RATING, "reloading failed"
+        assert copy("~#rating") == SOME_RATING, "should have picked up external change"
 
     def test_reload_fail(self):
         audio = MusicFile(get_data_path('silence-44-s.mp3'))

--- a/tests/test_formats__audio.py
+++ b/tests/test_formats__audio.py
@@ -57,6 +57,7 @@ num_call = AudioFile({"custom": "0.3"})
 ANOTHER_RATING = 0.2
 SOME_RATING = 0.8
 
+
 class TAudioFile(TestCase):
 
     def setUp(self):


### PR DESCRIPTION
* If saved to files (and the file format supports this), don't migrate `~#rating` or `~#playcount` on `reload(). Otherwise we'll never pick up external changes from files.

Closes #3561 
