### PR TITLE
Remove tracks when scandirs removed

### DIFF
--- a/quodlibet/library/librarians.py
+++ b/quodlibet/library/librarians.py
@@ -12,7 +12,7 @@ Librarians for libraries.
 """
 
 import itertools
-from typing import Generator
+from typing import Generator, Iterable
 
 from gi.repository import GObject
 
@@ -141,9 +141,17 @@ class Librarian(GObject.GObject):
     def move_root(self, old_root: fsnative, new_root: fsnative) -> Generator:
         if old_root == new_root:
             print_d("Not moving to same root")
+            return
         for library in self.libraries.values():
             if hasattr(library, "move_root"):
                 yield from library.move_root(old_root, new_root)
+
+    def remove_roots(self, old_roots: Iterable[fsnative]) -> Generator:
+        if not old_roots:
+            return
+        for library in self.libraries.values():
+            if hasattr(library, "remove_roots"):
+                yield from library.remove_roots(old_roots)
 
 
 class SongLibrarian(Librarian):

--- a/quodlibet/qltk/msg.py
+++ b/quodlibet/qltk/msg.py
@@ -1,4 +1,5 @@
 # Copyright 2005 Joe Wreschnig, Michael Urman
+#           2021 Nick Boultbee
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -6,6 +7,8 @@
 # (at your option) any later version.
 
 from gi.repository import Gtk
+
+from quodlibet.util import escape
 from senf import fsn2text, path2fsn
 
 from quodlibet import _
@@ -22,7 +25,7 @@ class Message(Gtk.MessageDialog, Dialog):
     def __init__(self, kind, parent, title, description, buttons=Gtk.ButtonsType.OK):
         parent = get_top_parent(parent)
         text = ("<span weight='bold' size='larger'>%s</span>\n\n%s"
-                % (title, description))
+                % (escape(title), escape(description)))
         super().__init__(
             transient_for=parent, modal=True, destroy_with_parent=True,
             message_type=kind, buttons=buttons)

--- a/quodlibet/qltk/prefs.py
+++ b/quodlibet/qltk/prefs.py
@@ -1,6 +1,6 @@
 # Copyright 2004-2009 Joe Wreschnig, Michael Urman, Iñigo Serna,
 #                     Steven Robertson
-#           2011-2017 Nick Boultbee
+#           2011-2021 Nick Boultbee
 #           2013      Christoph Reiter
 #           2014      Jan Path
 #
@@ -799,6 +799,10 @@ class PreferencesWindow(UniqueWindow):
 
     def __destroy(self):
         config.save()
-        if self.current_scan_dirs != get_scan_dirs():
-            print_d("Library paths have changed, re-scanning...")
+        new_dirs = set(get_scan_dirs())
+        gone_dirs = set(self.current_scan_dirs) - new_dirs
+        if new_dirs - set(self.current_scan_dirs):
+            print_d("Library paths have been added, re-scanning...")
             scan_library(app.library, force=False)
+        elif gone_dirs:
+            copool.add(app.librarian.remove_roots, gone_dirs)

--- a/tests/test_library_libraries.py
+++ b/tests/test_library_libraries.py
@@ -446,6 +446,25 @@ class TFileLibrary(TLibrary):
         assert in_song._written, "Song wasn't written to disk"
         assert not out_song._written, "Excluded songs was written!"
 
+    def test_remove_roots(self):
+        self.library.filename = "removing"
+        root = Path(normalize_path(mkdtemp(), True))
+        other_root = Path(normalize_path(mkdtemp(), True))
+        out_song = FakeAudioFile(str(other_root / "out file.mp3"))
+        in_song = FakeAudioFile(str(root / "in file.mp3"))
+        in_song.sanitize()
+        out_song.sanitize()
+        self.library.add([in_song, out_song])
+        assert in_song in self.library, "test seems broken"
+
+        # Run it by draining the generator
+        list(self.library.remove_roots([root]))
+
+        assert in_song not in self.library
+        assert out_song in self.library, "removed too many files"
+        assert self.removed == [in_song], "didn't signal the song removal"
+        assert not self.changed, "shouldn't have changed any tracks"
+
 
 class TSongFileLibrary(TSongLibrary):
     Fake = FakeSongFile


### PR DESCRIPTION
 * Update tooltips for add and remove
 * Add explicit warning prompt when clicking remove button, with different text for single or multiple removals when clicked
 * Add background task to actually remove library files from _all_ paths that were removed after close.
 * ...which calls new `remove_roots` method on library / librarian to do the dirty work (and signal)
 * Add unit tests for this library method to check library *and* signals are as they should be

Closes #2293
