### PR TITLE
Added ObjectListMatcher utility class

### DIFF
--- a/quodlibet/util/matcher.py
+++ b/quodlibet/util/matcher.py
@@ -1,0 +1,382 @@
+# Copyright 2021 Joschua Gandert
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+
+from difflib import SequenceMatcher
+from operator import itemgetter
+from typing import Generic, TypeVar, Mapping, Callable, Any, Union, List, Sequence, \
+    Optional, Tuple
+
+
+T = TypeVar('T')
+Real = Union[int, float]
+AttributeGetter = Callable[[T], Any]
+AttributeGetterToWeight = Mapping[AttributeGetter, Real]
+
+SUPPORTED_NUMBER_TYPES = (int, float)
+
+
+class _MatchData:
+    def __init__(self, a_idx, a_value, b_size):
+        self.a_idx = a_idx
+        self.a_value = a_value
+        self.b_idx_to_similarity = [0 for _ in range(b_size)]
+
+        self.best_b_idx = -1
+        self.best_b_similarity = float('-inf')
+        self.second_best_b_idx = -1
+        self.second_best_b_similarity = float('-inf')
+
+        self.continue_attr_index = 0
+
+        # rarely needed since in a lot of cases there won't be conflicts
+        self._sorted_b_similarity_with_idx_pairs = None
+        self.is_fully_measured = False
+
+    def add_similarity(self, b_idx, similarity_part):
+        self.b_idx_to_similarity[b_idx] += similarity_part
+        b_idx_total_similarity = self.b_idx_to_similarity[b_idx]
+
+        if b_idx_total_similarity > self.best_b_similarity:
+            self.second_best_b_idx = self.best_b_idx
+            self.second_best_b_similarity = self.best_b_similarity
+
+            self.best_b_idx = b_idx
+            self.best_b_similarity = b_idx_total_similarity
+        elif b_idx_total_similarity > self.second_best_b_similarity:
+            self.second_best_b_idx = b_idx
+            self.second_best_b_similarity = b_idx_total_similarity
+
+    def set_to_fully_measured(self):
+        self.is_fully_measured = True
+
+        # We sort so last = best as calling pop() on a list is O(1)
+        # We negate the index here, so that the sorting is correct if the
+        # similarities of two b's are the same (lowest index last)
+        self._sorted_b_similarity_with_idx_pairs = sorted(
+            ((s, -i) for i, s in enumerate(self.b_idx_to_similarity)))
+
+    def replace_best(self):
+        if not self._sorted_b_similarity_with_idx_pairs:
+            return
+
+        self._sorted_b_similarity_with_idx_pairs.pop()
+        if not self._sorted_b_similarity_with_idx_pairs:
+            # None left, which means all others a's have better values
+            # than this one. As a result, this a will stay alone :(
+            self.best_b_idx = -1
+            self.best_b_similarity = float('-inf')
+            return
+
+        sim, idx = self._sorted_b_similarity_with_idx_pairs[-1]
+        self.best_b_idx = -idx
+        self.best_b_similarity = sim
+
+
+class ObjectListMatcher(Generic[T]):
+    """
+    Utility class that compares the objects of two lists (all the same type), and finds
+    the best matches. What is considered a good match depends on the supplied mapping,
+    which maps "attribute getter" functions to their weight.
+
+    Weights are normalized, so you can use values > 1.
+
+    A specific getter has to return objects of only one of these types:
+    - Real number (e.g. int or float) - compared by 1 - abs(delta) / max_delta
+    - Other non-Sequence - converted to str which is a Sequence and then..
+    - Sequence - compared using difflib.SequenceMatcher
+
+    The problem this solves is called the "Assignment problem".
+
+    Note that this class will not necessarily call every attribute function and thus
+    not use its weight in the calculation, as it will avoid doing unnecessary
+    calculations when the current best match for an element is undefeatable.
+
+    For example, let's say we have an attribute x with weight 0.8 and an attribute y
+    with weight 0.2. If, after checking the similarity on attribute x with all items,
+    the highest similarity is 0.8 (it was equal to the compared item) and the second
+    highest has a similarity of 0.5, then we won't check attribute y at all, as the
+    second best cannot possibly win with the remaining weight (0.5 + 0.2 < 0.8).
+
+    However, whenever there's a conflict (two elements match to one), the full
+    similarity scores of the affected elements will always be calculated."""
+
+    similarity_matrix: List[List[float]]
+    minimum_similarity_ratio: float
+
+    _matcher: SequenceMatcher
+    _attr_with_weight: List[Tuple[Callable[[T], Any], float]]
+    _b_idx_to_a_match_data: List[Optional[_MatchData]]
+
+    def __init__(self, attr_to_weight: AttributeGetterToWeight):
+        self.update_attr_to_weights(attr_to_weight)
+        self._matcher = SequenceMatcher()
+
+        self.should_store_similarity_matrix = False
+        """Whether or not to store the similarity_matrix.
+
+        You may want to enable should_go_through_every_attribute to make similarity
+        scores between different a_items more comparable. Without it, the algorithm
+        may have stopped before evaluating all attributes for one a_item."""
+
+        self.similarity_matrix = []
+        """This will be recreated whenever get_indices is called, given that if
+        should_store_similarity_matrix is True.
+
+        It's a matrix that has the same number of elements as a_items. Each of those
+        lists has the same number of elements as b_items. Those elements represent how
+        similar an a item is to each b item. So matrix[a_idx][b_idx] gives you the
+        similarity between the a item and b item at those indices. A similarity of 1
+        means that every attribute was evaluated and equal to the other."""
+
+        self.minimum_similarity_ratio = 0.0
+        """A value in the range [0, 1] that defines what similarity is required to be a
+        valid match. Setting this to a reasonable value will speed up the calculation
+        as low-quality matches will be discarded before a match conflict can even arise.
+
+        Note that this isn't using the absolute similarity for comparison, because that
+        would lead to confusing results, given that by default this class only evaluates
+        weights and attributes if there is no decisive winner (best match) yet. Instead,
+        it's using the absolute similarity divided by the current maximum possible
+        weight. Enable should_go_through_every_attribute so the full and thus absolute
+        similarity score is compared to the minimum."""
+
+        self.should_go_through_every_attribute = False
+        """Whether or not to go through every attribute and weight. If False, this class
+        only goes through weights until one element is undefeatable."""
+
+    @classmethod
+    def for_sequence(cls, weights: Sequence[Real]):
+        """Creates a matcher where itemgetter(n) is mapped to weight_list[n]"""
+        attr_to_weight = {itemgetter(n): w for n, w in enumerate(weights)}
+        return ObjectListMatcher(attr_to_weight)
+
+    @classmethod
+    def for_one_attr(cls, attr: AttributeGetter):
+        """Creates a matcher where a single attribute of the objects are compared."""
+        return ObjectListMatcher({attr: 1})
+
+    @classmethod
+    def of_identity(cls):
+        """Creates a matcher where only the objects themselves are compared."""
+        return cls.for_one_attr((lambda i: i))
+
+    def update_attr_to_weights(self, attr_to_weight: AttributeGetterToWeight):
+        if not attr_to_weight:
+            raise ValueError("there must be at least one weight")
+
+        # normalize
+        weight_sum = sum(attr_to_weight.values())
+
+        self._attr_with_weight = []
+        for attr, weight in attr_to_weight.items():
+            if weight <= 0:
+                raise ValueError("weights <= 0 are not allowed")
+
+            self._attr_with_weight.append((attr, weight / weight_sum))
+
+        # from largest to smallest weight
+        self._attr_with_weight.sort(key=lambda i: i[1], reverse=True)
+
+        weight_left = 1.0
+        self._weight_left = []
+        for _, weight in self._attr_with_weight:
+            self._weight_left.append(weight_left)
+            weight_left -= weight
+
+    def get_indices(self, a_items: List[T], b_items: List[T]) -> List[int]:
+        """
+        :return: the indices of b ordered so that they match elements in a.
+
+        Size of a_items and b_items can differ. If there are more a_items than
+        there are b_items, -1 is used if no match could be assigned to an a.
+        As a result, the returned list always has the size of a_items.
+
+        In terms of performance, it's preferable to supply the smaller list as a_items.
+        """
+        if not b_items:
+            return [-1 for _ in a_items]
+
+        self._b_items = b_items
+        b_size = len(b_items)
+
+        self._b_idx_to_a_match_data = [None for _ in range(b_size)]
+        self._a_idx_to_match_data = []
+
+        for a_idx, a in enumerate(a_items):
+            match_data = _MatchData(a_idx, a, b_size)
+            self._a_idx_to_match_data.append(match_data)
+
+            self._measure_similarity_to_find_best_b_match(match_data)
+
+            if self._is_below_minimum_similarity(match_data):
+                match_data.best_b_idx = -1
+            else:
+                self._handle_conflicts_if_any(match_data)
+
+        result = [md.best_b_idx for md in self._a_idx_to_match_data]
+
+        if self.should_store_similarity_matrix:
+            matrix = [md.b_idx_to_similarity for md in self._a_idx_to_match_data]
+            self.similarity_matrix = matrix
+
+        # cleanup
+        del self._b_items
+        del self._b_idx_to_a_match_data
+        del self._a_idx_to_match_data
+
+        return result
+
+    def _is_below_minimum_similarity(self, match_data):
+        cont_attr_idx = match_data.continue_attr_index
+        similarity = match_data.best_b_similarity
+
+        # If this hasn't gone through every attribute and weight yet, we normalize the
+        # similarity, so it's in the range of [0, 1]. Without this, minimum_similarity
+        # would be somewhat unpredictable.
+        #
+        # For example, a b_item might be undefeatable with a similarity of 0.52. If we
+        # wouldn't normalize it, it would not pass a minimum of 0.6, even if it could
+        # easily achieve that with the remaining weights.
+        if cont_attr_idx < len(self._attr_with_weight):
+            cur_total_weight = 1 - self._weight_left[cont_attr_idx]
+            similarity /= cur_total_weight
+
+        return similarity < self.minimum_similarity_ratio
+
+    def _handle_conflicts_if_any(self, a1_match_data):
+        while True:
+            best_b_idx = a1_match_data.best_b_idx
+            if best_b_idx == -1:
+                # a1 has no matches left or could not find a match
+                return
+
+            a2_match_data = self._b_idx_to_a_match_data[best_b_idx]
+            if a2_match_data is None:
+                self._b_idx_to_a_match_data[best_b_idx] = a1_match_data
+                return
+
+            # We have found a conflict and will now solve it.
+            a1_match_data = self._get_worse_match_data(a1_match_data, a2_match_data)
+
+    def _get_worse_match_data(self, a1_match_data, a2_match_data):
+        # b is matched to a previous a (a2), so we have to find a better match
+        self._finish_similarity_measures(a1_match_data)
+        self._finish_similarity_measures(a2_match_data)
+
+        # As the index of a1 will almost always be larger than a2, we use <=
+        # here, since in case they're equal in terms of similarity, we want to
+        # give some weight to the current order of b (index 0 preferred to 1).
+        if a1_match_data.best_b_similarity <= a2_match_data.best_b_similarity:
+            a1_match_data.replace_best()
+
+            # still need to find a better match for a1
+            return a1_match_data
+        else:
+            # a1 is better so replace a2 in map
+            best_b_idx = a1_match_data.best_b_idx
+            self._b_idx_to_a_match_data[best_b_idx] = a1_match_data
+
+            a2_match_data.replace_best()
+
+            # we need to find a new match for a2
+            return a2_match_data
+
+    def _finish_similarity_measures(self, a_match_data):
+        """Only if this was called, is match data full measured and only then
+        can match_data.replace_best() be called."""
+        if a_match_data.is_fully_measured:
+            return
+
+        # figure out total similarity (without stopping) if we didn't
+        self._measure_similarity_to_find_best_b_match(a_match_data)
+        a_match_data.set_to_fully_measured()
+
+    def _measure_similarity_to_find_best_b_match(self, a_match_data):
+        continue_attr_idx = a_match_data.continue_attr_index
+        can_stop = continue_attr_idx == 0 and not self.should_go_through_every_attribute
+        attr_size = len(self._attr_with_weight)
+
+        for attr_idx in range(continue_attr_idx, attr_size):
+            # stop if one has more similarity than is possible for the rest
+            if can_stop and self._is_max_similarity_undefeatable(attr_idx,
+                                                                 a_match_data):
+                a_match_data.continue_attr_index = attr_idx
+                return
+
+            self._measure_similarity_for_attr(attr_idx, a_match_data)
+
+        a_match_data.continue_attr_index = attr_size
+
+    def _is_max_similarity_undefeatable(self, attr_idx, a_match_data):
+        # Must only be called at the start of the loop.
+        # We need a second best, so we can check if they have any chance.
+        if a_match_data.second_best_b_idx < 0:
+            return False
+
+        # Any similarity has to be in [0, 1], so the following is the maximum
+        # similarity that could be achieved with the remaining attr / weights
+        optimal_second_best_similarity = self._weight_left[attr_idx]
+
+        # Now we add the second best similarity, since we want to know if it's
+        # even possible for the second best to win against the current best
+        optimal_second_best_similarity += a_match_data.second_best_b_similarity
+
+        return optimal_second_best_similarity < a_match_data.best_b_similarity
+
+    def _measure_similarity_for_attr(self, attr_idx, a_match_data):
+        get_attr, weight = self._attr_with_weight[attr_idx]
+        a_attr = get_attr(a_match_data.a_value)
+
+        # isinstance does not work with Union, so we need to use a tuple here
+        if isinstance(a_attr, SUPPORTED_NUMBER_TYPES):
+            self._add_number_similarity(a_match_data, a_attr, get_attr, weight)
+            return
+
+        if not isinstance(a_attr, Sequence):
+            a_attr = str(a_attr)
+
+            def get_attr(obj, original_get_attr=get_attr):
+                return str(original_get_attr(obj))
+
+            # replace it so we don't have to do this again for this attr_idx
+            self._attr_with_weight[attr_idx] = (get_attr, weight)
+
+        self._add_sequence_similarity(a_match_data, a_attr, get_attr, weight)
+
+    def _add_number_similarity(self, a_match_data, a_attr, get_attr, weight):
+        deltas = [abs(get_attr(b) - a_attr) for b in self._b_items]
+        max_delta = max(deltas)
+        if max_delta == 0:
+            if a_match_data.best_b_idx == -1:
+                # We try to set a match here manually to avoid the situation where
+                # nothing is matched to a and -1 returned just because all are the same.
+                # In all other cases MatchData's add_similarity takes care of this.
+                for b_idx, match_data in enumerate(self._b_idx_to_a_match_data):
+                    # find the first b index that's not matched to an a element
+                    if match_data is None:
+                        a_match_data.best_b_idx = b_idx
+                        a_match_data.best_b_similarity = 0
+                        break
+
+            # no delta, so all the same and no change in similarity
+            return  # also let's avoid division by zero
+
+        for b_idx, delta in enumerate(deltas):
+            # if delta is small relative to max, similarity is higher
+            # for example, if delta is 0, b_attr is the same as a_attr
+            similarity = weight * (1 - delta / max_delta)
+            a_match_data.add_similarity(b_idx, similarity)
+
+    def _add_sequence_similarity(self, a_match_data, a_attr, get_attr, weight):
+        matcher = self._matcher
+
+        # set_seq2 is used here as it caches information (contrary to 1)
+        matcher.set_seq2(a_attr)
+
+        for b_idx, b in enumerate(self._b_items):
+            matcher.set_seq1(get_attr(b))
+            a_match_data.add_similarity(b_idx, weight * matcher.ratio())

--- a/quodlibet/util/matcher.py
+++ b/quodlibet/util/matcher.py
@@ -21,6 +21,8 @@ SUPPORTED_NUMBER_TYPES = (int, float)
 
 class _MatchData(Generic[T]):
     a_value: T
+    best_b_idx: Optional[int]
+    second_best_b_idx: Optional[int]
 
     def __init__(self, a_idx: int, a_value: T, b_size: int):
         self.a_idx = a_idx

--- a/tests/test_util_matcher.py
+++ b/tests/test_util_matcher.py
@@ -1,0 +1,256 @@
+# Copyright 2021 Joschua Gandert
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+
+from typing import List
+
+from quodlibet.util.matcher import ObjectListMatcher
+
+from tests import TestCase
+
+
+class TMatchBasics(TestCase):
+    def test_empty_weight_not_allowed(self):
+        self.assertRaises(ValueError, lambda: ObjectListMatcher({}))
+
+    def test_negative_weights_not_allowed(self):
+        self.assertRaises(ValueError, lambda: ObjectListMatcher({lambda i: int(i): -1}))
+
+
+class TMatchIdentity(TestCase):
+    def test_all_elements_in_both_but_different_order(self):
+        matcher = ObjectListMatcher.of_identity()
+        a = ['cookie', 'beach', 'house']
+        b = ['house', 'cookie', 'beach']
+
+        b_match_indices = matcher.get_indices(a, b)
+        for a_item, b_idx in zip(a, b_match_indices):
+            assert a_item == b[b_idx]
+
+        b = ['house', 'beach', 'cookie']
+        assert matcher.get_indices(a, b) == [2, 1, 0]
+
+    def test_simple_unbalanced(self):
+        matcher = ObjectListMatcher.of_identity()
+        a = ['hell', 'gel', 'shell']
+        b = ['yell']
+        assert matcher.get_indices(a, b) == [0, -1, -1]
+
+        a = ['gel', 'hell', 'shell']
+        assert matcher.get_indices(a, b) == [-1, 0, -1]
+
+    def test_minimum_similarity(self):
+        matcher = ObjectListMatcher.of_identity()
+        a = ['mess', 'blessed', 'chess']
+        b = ['pudding', 'xylophone', 'yes']
+        matcher.should_store_similarity_matrix = True
+
+        assert matcher.get_indices(a, b) == [2, 0, 1], formatted_matrix(matcher)
+
+        matcher.minimum_similarity_ratio = 0.45
+        assert matcher.get_indices(a, b) == [2, -1, 1], formatted_matrix(matcher)
+
+        matcher.minimum_similarity_ratio = 0.6
+        assert matcher.get_indices(a, b) == [-1, -1, -1], formatted_matrix(matcher)
+
+
+class TMatchListOfSequences(TestCase):
+    def test_clear_match(self):
+        matcher = ObjectListMatcher.for_sequence([3, 1.5, 2])
+        a = [('cacc', 'cacc', 2), ('bacc', 'baca', 1)]
+        b = [('caba', 'bacc', 2), ('abaa', 'bcca', 2)]
+
+        assert matcher.get_indices(a, b) == [0, 1]
+
+        # test that repeating the same call doesn't change the result
+        assert matcher.get_indices(a, b) == [0, 1]
+
+        # in this case (same length), reversing arguments should result in the same list
+        assert matcher.get_indices(b, a) == [0, 1]
+
+    def test_other_now_barely_better(self):
+        matcher = ObjectListMatcher.for_sequence([3, 1.5, 2])
+        a = [('cacc', 'cacc', 2), ('bacc', 'baca', 1)]
+        b = [('caba', 'bacc', 1), ('abaa', 'bcca', 2)]  # third element of first changed
+
+        assert matcher.get_indices(a, b) == [1, 0]
+        assert matcher.get_indices(a, b) == [1, 0]
+        assert matcher.get_indices(b, a) == [1, 0]
+
+    def test_change_weights(self):
+        # same as in previous test
+        matcher = ObjectListMatcher.for_sequence([3, 1.5, 2])
+        a = [('cacc', 'cacc', 2), ('bacc', 'baca', 1)]
+        b = [('caba', 'bacc', 1), ('abaa', 'bcca', 2)]
+
+        matcher.update_attr_to_weights({lambda i: i[1]: 1})
+        assert matcher.get_indices(a, b) == [0, 1]
+
+    def test_double_weight(self):
+        matcher = ObjectListMatcher.for_sequence([4, 2])
+        a = [('Great Song', 'Law', 2), ('Night Mix', 'Beach', 1)]
+        b = [('Great Song', 'Beach', 1), ('Great Sea', 'Low', 2)]
+
+        assert matcher.get_indices(a, b) == [0, 1]
+
+        # changed "Law" to "Low"
+        a = [('Great Song', 'Low', 2), ('Night Mix', 'Beach', 1)]
+        assert matcher.get_indices(a, b) == [1, 0]
+
+    def test_nothing_to_match_b_to(self):
+        matcher = ObjectListMatcher.for_sequence([7, 1])
+        a = []
+        b = [('Great Song', 'Beach', 1), ('Great Sea', 'Low', 2)]
+
+        # As this returns the indices of b to match a, it always has the size of a.
+        assert matcher.get_indices(a, b) == []
+        assert matcher.get_indices([], []) == []
+
+    def test_match_a_to_nothing(self):
+        matcher = ObjectListMatcher.for_sequence([7, 1])
+        a = [('Great Song', 'Beach', 1), ('Great Sea', 'Low', 2)]
+        b = []
+
+        # When no b element could be matched to an a element, -1 is used.
+        assert matcher.get_indices(a, b) == [-1, -1]
+
+    def test_more_in_a(self):
+        matcher = ObjectListMatcher.for_sequence([7, 1])
+        a = [('Great Song', 'Beach', 1), ('Great Sea', 'Low', 2)]
+        b = [('Great Sea', 'Light', 2)]
+
+        assert matcher.get_indices(a, b) == [-1, 0]
+
+    def test_more_in_b(self):
+        matcher = ObjectListMatcher.for_sequence([7, 1])
+        a = [('Great Sea', 'Light', 2)]
+        b = [('Great Song', 'Beach', 1), ('Great Sea', 'Low', 2)]
+
+        assert matcher.get_indices(a, b) == [1]
+
+    def test_all_the_same(self):
+        matcher = ObjectListMatcher.for_sequence([0.2, 0.7, 0.1])
+
+        x = (9, 9, 9)
+        assert matcher.get_indices([x, x, x], [x, x, x]) == [0, 1, 2]
+
+    def test_numeric_if_both_good_match_current_order_preferred(self):
+        # we pre-normalized the weights for clarity here (they're always normalized)
+        matcher = ObjectListMatcher.for_sequence([0.6, 0.4])
+
+        a = [(3, 2), (3, 4)]
+        b = [(99, 99), (3, 3)]
+
+        # despite having the same delta to (3, 3), here (3, 2) should be preferred to
+        # (3, 4), as (3, 2) is a closer match (in terms of their indices)
+        assert matcher.get_indices(a, b) == [1, 0]
+        assert matcher.get_indices(b, a) == [1, 0]
+
+    def test_numeric_asymmetry(self):
+        matcher = ObjectListMatcher.for_sequence([0.6, 0.4])
+        matcher.should_store_similarity_matrix = True
+
+        a = [(3, 3), (8, 5), (9, 1)]
+        b = [(9, 8), (3, 2), (3, 4)]
+
+        # as (9, 8) is the best match for (9, 1), item (8, 5) will be matched to (3, 4)
+        assert matcher.get_indices(a, b) == [1, 2, 0], formatted_matrix(matcher)
+
+        matrix = matcher.similarity_matrix
+
+        # matrix[0] are the match scores of element (3, 3) in a to all elements in b
+        assert matrix[0][1] == matrix[0][2]
+
+        # (9, 1) is most similar to (9, 8) and second most similar to (3, 2)
+        assert matrix[2][0] > matrix[2][2]
+        assert matrix[2][1] > matrix[2][2]
+
+        # What happens here may seem confusing, but this is a result of the following
+        # asymmetry: the best match in b for (9, 1) is (9, 8), but the best match in a
+        # for (9, 8) isn't (9, 1), it's (8, 5). This can be seen by calculating the
+        # weighted delta between (9, 8) and each of them (smaller delta = more similar):
+        #   delta to (9, 1):    (9-9) * 0.6 + (8-1) * 0.4 = 2.8
+        #   delta to (8, 5):    (9-8) * 0.6 + (8-5) * 0.4 = 1.8
+        assert matcher.get_indices(b, a) == [1, 0, 2], formatted_matrix(matcher)
+
+    def test_should_go_through_every_attribute(self):
+        matcher = ObjectListMatcher.for_sequence([0.7, 0.3])
+        matcher.should_store_similarity_matrix = True
+
+        # There are undefeatable matches for the first attribute / weight here, and so
+        # by default the algorithm will not even check the second attribute.
+        a = [('a', -8), ('very clear', 0), ('way', 33), ('forward', 2)]
+        b = [('very clear', 33), ('forward', -1), ('a', 5), ('way', 2)]
+
+        assert matcher.get_indices(a, b) == [2, 0, 3, 1]
+        partial_matrix = matcher.similarity_matrix
+
+        matcher.should_go_through_every_attribute = True
+
+        # Result definitely shouldn't change
+        assert matcher.get_indices(a, b) == [2, 0, 3, 1], formatted_matrix(matcher)
+
+        # But in this case the matrix should have
+        assert matcher.similarity_matrix != partial_matrix, formatted_matrix(matcher)
+
+
+def formatted_matrix(matcher: ObjectListMatcher) -> str:
+    lines = ['<Similarity Matrix']
+    for b_similarities in matcher.similarity_matrix:
+        l = ''
+        for b_sim in b_similarities:
+            l += f'{b_sim:1.4f}  '
+        lines.append(l)
+    return '\n'.join(lines) + '\n>'
+
+
+class TMatchClassFields(TestCase):
+    def test_matching_works(self):
+        a, b = self._get_car_lists()
+
+        attr_to_weight = {(lambda c: c.seats): 4, (lambda c: c.name): 1,
+                          (lambda c: c.features): 5}
+        matcher = ObjectListMatcher(attr_to_weight)
+
+        assert matcher.get_indices(a, b) == [2, -1, 1, 0]
+
+    def _get_car_lists(self):
+        a = [Car(1, 'Speedy', ['gps', 'heater']), Car(2, 'Cheaporghiny', []),
+             Car(16, 'Half-a-Bus', ['buttons']), Car(5, 'Normal Model 1', ['music'])]
+        b = [Car(3, 'Mödel V5', ['gps']), Car(19, 'Cyberbus', ['buttons']),
+             Car(2, 'Sheeporghiny', ['gps', 'heater', 'sheep sound button'])]
+        return a, b
+
+    def test_dominating_name_weights(self):
+        a, b = self._get_car_lists()
+        attr_to_weight = {(lambda c: c.seats): 0.5, (lambda c: c.name): 9,
+                          (lambda c: c.features): 1.2}
+
+        matcher = ObjectListMatcher(attr_to_weight)
+
+        assert matcher.get_indices(a, b) == [-1, 2, 1, 0]
+
+    def test_minimum_similarity(self):
+        a, b = self._get_car_lists()
+
+        attr_to_weight = {(lambda c: c.seats): 3, (lambda c: c.features): 8}
+        matcher = ObjectListMatcher(attr_to_weight)
+        matcher.should_store_similarity_matrix = True
+
+        assert matcher.get_indices(a, b) == [2, 0, 1, -1], formatted_matrix(matcher)
+
+        matcher.minimum_similarity_ratio = 0.71
+        assert matcher.get_indices(a, b) == [2, -1, 1, -1], formatted_matrix(matcher)
+
+        matcher.minimum_similarity_ratio = 0.9
+        assert matcher.get_indices(a, b) == [-1, -1, 1, -1], formatted_matrix(matcher)
+
+
+class Car:
+    def __init__(self, seats: int, name: str, features: List[str]):
+        self.seats = seats
+        self.name = name
+        self.features = features

--- a/tests/test_util_matcher.py
+++ b/tests/test_util_matcher.py
@@ -4,7 +4,7 @@
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation; either version 2 of the License, or
 # (at your option) any later version.
-
+from dataclasses import dataclass
 from typing import List
 
 from quodlibet.util.matcher import ObjectListMatcher
@@ -87,7 +87,7 @@ class TMatchListOfSequences(TestCase):
         a = [('cacc', 'cacc', 2), ('bacc', 'baca', 1)]
         b = [('caba', 'bacc', 1), ('abaa', 'bcca', 2)]
 
-        matcher.update_attr_to_weights({lambda i: i[1]: 1})
+        matcher.update_attr_to_weight({lambda i: i[1]: 1})
         assert matcher.get_indices(a, b) == [0, 1]
 
     def test_double_weight(self):
@@ -252,8 +252,8 @@ class TMatchClassFields(TestCase):
             matcher)
 
 
+@dataclass
 class Car:
-    def __init__(self, seats: int, name: str, features: List[str]):
-        self.seats = seats
-        self.name = name
-        self.features = features
+    seats: int
+    name: str
+    features: List[str]

--- a/tests/test_util_matcher.py
+++ b/tests/test_util_matcher.py
@@ -37,10 +37,10 @@ class TMatchIdentity(TestCase):
         matcher = ObjectListMatcher.of_identity()
         a = ['hell', 'gel', 'shell']
         b = ['yell']
-        assert matcher.get_indices(a, b) == [0, -1, -1]
+        assert matcher.get_indices(a, b) == [0, None, None]
 
         a = ['gel', 'hell', 'shell']
-        assert matcher.get_indices(a, b) == [-1, 0, -1]
+        assert matcher.get_indices(a, b) == [None, 0, None]
 
     def test_minimum_similarity(self):
         matcher = ObjectListMatcher.of_identity()
@@ -51,10 +51,11 @@ class TMatchIdentity(TestCase):
         assert matcher.get_indices(a, b) == [2, 0, 1], formatted_matrix(matcher)
 
         matcher.minimum_similarity_ratio = 0.45
-        assert matcher.get_indices(a, b) == [2, -1, 1], formatted_matrix(matcher)
+        assert matcher.get_indices(a, b) == [2, None, 1], formatted_matrix(matcher)
 
         matcher.minimum_similarity_ratio = 0.6
-        assert matcher.get_indices(a, b) == [-1, -1, -1], formatted_matrix(matcher)
+        assert matcher.get_indices(a, b) == [None, None, None], formatted_matrix(
+            matcher)
 
 
 class TMatchListOfSequences(TestCase):
@@ -115,14 +116,14 @@ class TMatchListOfSequences(TestCase):
         b = []
 
         # When no b element could be matched to an a element, -1 is used.
-        assert matcher.get_indices(a, b) == [-1, -1]
+        assert matcher.get_indices(a, b) == [None, None]
 
     def test_more_in_a(self):
         matcher = ObjectListMatcher.for_sequence([7, 1])
         a = [('Great Song', 'Beach', 1), ('Great Sea', 'Low', 2)]
         b = [('Great Sea', 'Light', 2)]
 
-        assert matcher.get_indices(a, b) == [-1, 0]
+        assert matcher.get_indices(a, b) == [None, 0]
 
     def test_more_in_b(self):
         matcher = ObjectListMatcher.for_sequence([7, 1])
@@ -215,7 +216,7 @@ class TMatchClassFields(TestCase):
                           (lambda c: c.features): 5}
         matcher = ObjectListMatcher(attr_to_weight)
 
-        assert matcher.get_indices(a, b) == [2, -1, 1, 0]
+        assert matcher.get_indices(a, b) == [2, None, 1, 0]
 
     def _get_car_lists(self):
         a = [Car(1, 'Speedy', ['gps', 'heater']), Car(2, 'Cheaporghiny', []),
@@ -231,7 +232,7 @@ class TMatchClassFields(TestCase):
 
         matcher = ObjectListMatcher(attr_to_weight)
 
-        assert matcher.get_indices(a, b) == [-1, 2, 1, 0]
+        assert matcher.get_indices(a, b) == [None, 2, 1, 0]
 
     def test_minimum_similarity(self):
         a, b = self._get_car_lists()
@@ -240,13 +241,15 @@ class TMatchClassFields(TestCase):
         matcher = ObjectListMatcher(attr_to_weight)
         matcher.should_store_similarity_matrix = True
 
-        assert matcher.get_indices(a, b) == [2, 0, 1, -1], formatted_matrix(matcher)
+        assert matcher.get_indices(a, b) == [2, 0, 1, None], formatted_matrix(matcher)
 
         matcher.minimum_similarity_ratio = 0.71
-        assert matcher.get_indices(a, b) == [2, -1, 1, -1], formatted_matrix(matcher)
+        assert matcher.get_indices(a, b) == [2, None, 1, None], formatted_matrix(
+            matcher)
 
         matcher.minimum_similarity_ratio = 0.9
-        assert matcher.get_indices(a, b) == [-1, -1, 1, -1], formatted_matrix(matcher)
+        assert matcher.get_indices(a, b) == [None, None, 1, None], formatted_matrix(
+            matcher)
 
 
 class Car:


### PR DESCRIPTION
Check-list
----------

 * [x] There is a linked issue discussing the motivations for this feature or bugfix 

This is needed for a plugin I'm working on, which is described in #3658. So, instead of creating a very large pull request, I thought it's probably better to split it up a bit. 

Basically this will be used when importing for matching exported metadata to the selected albums.

I can also imagine this class being useful in other situations like, for example, finding the best fitting `lrc` file for a track, or matching downloaded metadata to songs.

 * [x] Unit tests have been added where possible
 * [x] I've added / updated documentation for any user-facing features.
 * [x] Performance seems to be comparable or better than current `master`


What this change is adding / fixing
-----------------------------------
It's adding a new utility class, `ObjectListMatcher`, which can be used to match the elements of two lists. It does so by comparing how similar user-selected attributes of the elements are, and returns the indices of the second list in a order that best matches elements in the first list.

**Construction**
* Elements in both lists have to have the same type. Apart from that, any type is okay.
* When creating a new instance with the constructor (and not a factory method), one has to supply a dictionary that maps a function that returns a certain attribute to the weight of that attribute.
* There are factory methods for comparing objects themselves (`of_identity`), a single attribute or sequences (`for_sequence`).

**Values returned by attribute getters**
  * Numbers (`int` or `float`) will be compared by `1 - abs_delta / abs_max_delta`
  * If an attribute is neither `Sequence` nor number, it will be converted to a `str` and then:
  * Whenever a `Sequence` attribute has to be compared, [`difflib.SequenceMatcher`](https://docs.python.org/3/library/difflib.html#difflib.SequenceMatcher) is used.

**Getting the matches**
* The `get_indices` method returns the indices of the second argument in the order that they best match elements in the first argument.
* If enabled, the similarity matrix can be retrieved after that call.