### PR TITLE
Fix info area not updating on songlist removal

### DIFF
--- a/tests/test_qltk_browser.py
+++ b/tests/test_qltk_browser.py
@@ -3,33 +3,33 @@
 # the Free Software Foundation; either version 2 of the License, or
 # (at your option) any later version.
 
-from tests import TestCase
-
-from quodlibet.qltk.browser import LibraryBrowser
-from quodlibet.player.nullbe import NullPlayer
 import quodlibet.config
+from quodlibet.browsers.albums import AlbumList
+from quodlibet.browsers.tracks import TrackList
+from quodlibet.library import SongLibrarian, SongLibrary
+from quodlibet.player.nullbe import NullPlayer
+from quodlibet.qltk.browser import LibraryBrowser
+from tests import TestCase
 
 
 class TLibraryBrowser(TestCase):
     def setUp(self):
         quodlibet.config.init()
+        self.library = SongLibrary()
 
     def test_ctr(self):
-        from quodlibet.library import SongLibrary
-        from quodlibet.browsers.albums import AlbumList
-        win = LibraryBrowser(AlbumList, SongLibrary(), NullPlayer())
+        win = LibraryBrowser(AlbumList, self.library, NullPlayer())
         win.browser.emit("songs-selected", [], False)
         win.songlist.get_selection().emit("changed")
         win.destroy()
 
     def test_open(self):
-        from quodlibet.browsers.tracks import TrackList
-        from quodlibet.library import SongLibrary
-
-        widget = LibraryBrowser.open(TrackList, SongLibrary(), NullPlayer())
+        self.library.librarian = SongLibrarian()
+        widget = LibraryBrowser.open(TrackList, self.library, NullPlayer())
         self.assertTrue(widget)
         self.assertTrue(widget.get_visible())
         widget.destroy()
 
     def tearDown(self):
+        self.library.destroy()
         quodlibet.config.quit()

--- a/tests/test_qltk_quodlibetwindow.py
+++ b/tests/test_qltk_quodlibetwindow.py
@@ -4,26 +4,35 @@
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation; either version 2 of the License, or
 # (at your option) any later version.
-
-from tests import TestCase
+from quodlibet.library import SongFileLibrary, SongLibrarian
+from quodlibet.qltk.notif import TaskController
+from tests import TestCase, init_fake_app
 
 from quodlibet.qltk.quodlibetwindow import QuodLibetWindow, PlaybackErrorDialog
-from quodlibet import library
 from quodlibet import player
 from quodlibet import config
 
 
 class TQuodLibetWindow(TestCase):
     def setUp(self):
+        init_fake_app()
+        # Ugh
+        TaskController.default_instance = TaskController()
         config.init()
 
     def tearDown(self):
+        # Avoid leaking to other tests
+        if SongFileLibrary.librarian:
+            SongFileLibrary.librarian.destroy()
+            SongFileLibrary.librarian = None
         config.quit()
 
     def test_window(self):
-        lib = library.init()
+        lib = SongFileLibrary()
+        lib.librarian = SongLibrarian()
         pl = player.init_player("nullbe", lib.librarian)
         window = QuodLibetWindow(lib, pl, headless=True)
+        assert window.windows
         window.destroy()
 
     def test_playback_error_dialog(self):

--- a/tests/test_qltk_quodlibetwindow.py
+++ b/tests/test_qltk_quodlibetwindow.py
@@ -25,6 +25,7 @@ class TQuodLibetWindow(TestCase):
         if SongFileLibrary.librarian:
             SongFileLibrary.librarian.destroy()
             SongFileLibrary.librarian = None
+        QuodLibetWindow.windows.clear()
         config.quit()
 
     def test_window(self):
@@ -32,7 +33,7 @@ class TQuodLibetWindow(TestCase):
         lib.librarian = SongLibrarian()
         pl = player.init_player("nullbe", lib.librarian)
         window = QuodLibetWindow(lib, pl, headless=True)
-        assert window.windows
+        assert window in window.windows
         window.destroy()
 
     def test_playback_error_dialog(self):

--- a/tests/test_qltk_songlist.py
+++ b/tests/test_qltk_songlist.py
@@ -2,19 +2,19 @@
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation; either version 2 of the License, or
 # (at your option) any later version.
-
-from typing import List
+from typing import List, Set
 
 from gi.repository import Gtk
 
 from quodlibet import config
+from quodlibet.browsers.tracks import TrackList
 from quodlibet.formats import AudioFile
-from quodlibet.library import SongFileLibrary
+from quodlibet.library import SongFileLibrary, SongLibrarian
 from quodlibet.qltk.songlist import (SongList, set_columns, get_columns,
                                      header_tag_split, get_sort_tag)
 from quodlibet.qltk.songlistcolumns import SongListColumn
 from senf import fsnative
-from tests import TestCase
+from tests import TestCase, run_gtk_loop
 
 
 class TSongList(TestCase):
@@ -27,7 +27,7 @@ class TSongList(TestCase):
         self.songlist = SongList(self.lib)
 
         self.orders_changed = 0
-        self.songs_removed: List[List] = []
+        self.songs_removed: List[Set] = []
 
         def orders_changed_cb(*args):
             self.orders_changed += 1
@@ -35,8 +35,10 @@ class TSongList(TestCase):
         def orders_removed_cb(songlist, removed):
             self.songs_removed.append(removed)
 
-        self.songlist.connect("orders-changed", orders_changed_cb)
-        self.songlist.connect("songs-removed", orders_removed_cb)
+        self.__sigs = [
+            self.songlist.connect("orders-changed", orders_changed_cb),
+            self.songlist.connect("songs-removed", orders_removed_cb)
+        ]
 
     def test_set_all_column_headers(self):
         SongList.set_all_column_headers(self.HEADERS)
@@ -181,21 +183,22 @@ class TSongList(TestCase):
         song = AudioFile({"~filename": "/dev/null"})
         song.sanitize()
         self.lib.add([song])
+        assert song in self.lib, "Broken library?"
         self.songlist.add_songs([song])
+        assert set(self.songlist.get_songs()) == {song}
         self.lib.remove([song])
-        assert self.songs_removed == [{song}]
+        assert not list(self.lib), "Didn't get removed"
+        run_gtk_loop()
+        assert self.songs_removed == [{song}], "Signal wasn't emitted"
 
     def test_header_menu(self):
-        from quodlibet import browsers
-        from quodlibet.library import SongLibrarian
-
         song = AudioFile({"~filename": fsnative(u"/dev/null")})
         song.sanitize()
         self.songlist.set_songs([song])
 
-        library = SongFileLibrary()
-        library.librarian = SongLibrarian()
-        browser = browsers.get("SearchBar")(library)
+        library = self.lib
+        self.lib.librarian = SongLibrarian()
+        browser = TrackList(library)
 
         self.songlist.set_column_headers(["foo"])
 
@@ -253,5 +256,8 @@ class TSongList(TestCase):
         assert {"Title", "Genre", "Comment", "Artist"} < names
 
     def tearDown(self):
+        for sig in self.__sigs:
+            self.songlist.disconnect(sig)
         self.songlist.destroy()
+        self.lib.destroy()
         config.quit()

--- a/tests/test_qltk_songlist.py
+++ b/tests/test_qltk_songlist.py
@@ -25,6 +25,7 @@ class TSongList(TestCase):
         config.init()
         self.lib = SongFileLibrary()
         self.songlist = SongList(self.lib)
+        assert not self.lib.librarian, "not expecting a librarian - leaky test?"
 
         self.orders_changed = 0
         self.songs_removed: List[Set] = []
@@ -182,7 +183,6 @@ class TSongList(TestCase):
     def test_remove_songs(self):
         song = AudioFile({"~filename": "/dev/null"})
         song.sanitize()
-        assert not self.lib.librarian, "not expecting a librarian - leaky test?"
         self.lib.add([song])
         assert song in self.lib, "Broken library?"
         self.songlist.add_songs([song])

--- a/tests/test_qltk_window.py
+++ b/tests/test_qltk_window.py
@@ -11,7 +11,7 @@ from quodlibet.util import InstanceTracker, is_osx
 from .helper import realized
 
 
-class TWindows(TestCase):
+class TWindow(TestCase):
 
     def test_on_first_map(self):
         w = Window()


### PR DESCRIPTION
 * Add a new signal to songlist for removals, if anything relevant was removed
 * Listen to this and trigger a (smart) info area update if so
 * Catch and log more exceptions in signal handling, it's _really_ hard to debug things otherwise
 * A whole bunch of unrelated testing clean-up, as there were some nasty class instance / globals being updated in some tests which broke signals here (as [global] librarians are used if available). Tracking these down was... not fun

This fixes #3659
