### PR TITLE
Support flaky tests

### DIFF
--- a/.ci/flatpak-test.sh
+++ b/.ci/flatpak-test.sh
@@ -5,7 +5,7 @@ set -e
 DIR="$( cd "$( dirname "$0" )" && pwd )"
 
 if [[ $1 == "inflatpak" ]]; then
-    python3 -m pip install --user pytest flake8
+    python3 -m pip install --user pytest flake8 flaky
     python3 setup.py test
 else
     xvfb-run -a flatpak run --devel --user --command="bash" io.github.quodlibet.QuodLibet "${DIR}"/flatpak-test.sh inflatpak

--- a/.ci/macos-install.sh
+++ b/.ci/macos-install.sh
@@ -7,4 +7,4 @@ hdiutil attach -noverify -readonly -mountpoint _mount ql.dmg
 cp -R _mount/QuodLibet.app "$TMPDIR/_app"
 hdiutil detach -force _mount
 RUN="$TMPDIR/_app/Contents/MacOS/run"
-$RUN -m pip install flake8 pytest pytest-faulthandler "coverage[toml]"
+$RUN -m pip install flake8 pytest pytest-faulthandler flaky "coverage[toml]"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Install additional dependencies
         shell: msys2 {0}
         run: |
-          pip3 install feedparser musicbrainzngs mutagen
+          pip3 install feedparser musicbrainzngs mutagen flaky
 
       - name: Run tests
         shell: msys2 {0}
@@ -131,7 +131,8 @@ jobs:
         python3 -m pip install --user --upgrade \
           xvfbwrapper \
           pytest-faulthandler \
-          flake8
+          flake8 \
+          flaky
 
     - name: Run tests
       run: |

--- a/poetry.lock
+++ b/poetry.lock
@@ -119,6 +119,14 @@ pycodestyle = ">=2.7.0,<2.8.0"
 pyflakes = ">=2.3.0,<2.4.0"
 
 [[package]]
+name = "flaky"
+version = "3.7.0"
+description = "Plugin for nose or pytest that automatically reruns flaky tests."
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[[package]]
 name = "idna"
 version = "2.10"
 description = "Internationalized Domain Names in Applications (IDNA)"
@@ -600,7 +608,7 @@ plugins = ["musicbrainzngs", "pyinotify", "dbus-python", "soco"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "88c386465bda80bf3d10a11b1d08c046a9b04a3f72772e34bda469243bf4e1f0"
+content-hash = "bac3e380d75f6c2ce0475261c3135e07a0d509faaf49a0a3267542820f40897f"
 
 [metadata.files]
 alabaster = [
@@ -699,6 +707,10 @@ feedparser = [
 flake8 = [
     {file = "flake8-3.9.0-py2.py3-none-any.whl", hash = "sha256:12d05ab02614b6aee8df7c36b97d1a3b2372761222b19b58621355e82acddcff"},
     {file = "flake8-3.9.0.tar.gz", hash = "sha256:78873e372b12b093da7b5e5ed302e8ad9e988b38b063b61ad937f26ca58fc5f0"},
+]
+flaky = [
+    {file = "flaky-3.7.0-py2.py3-none-any.whl", hash = "sha256:d6eda73cab5ae7364504b7c44670f70abed9e75f77dd116352f662817592ec9c"},
+    {file = "flaky-3.7.0.tar.gz", hash = "sha256:3ad100780721a1911f57a165809b7ea265a7863305acb66708220820caf8aa0d"},
 ]
 idna = [
     {file = "idna-2.10-py2.py3-none-any.whl", hash = "sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ xvfbwrapper = { version = "^0.2", platform = "linux" }
 flake8 = "^3.7.9"
 coverage = { extras = ["toml"], version = "^5.0.3" }
 mypy = "^0.812"
+flaky = "^3.7.0"
 
 [tool.coverage.run]
 omit = ["quodlibet/packages/*"]

--- a/tests/test_util_copool.py
+++ b/tests/test_util_copool.py
@@ -12,6 +12,7 @@ from gi.repository import Gtk
 from quodlibet.util import copool
 
 
+@pytest.mark.flaky(max_runs=3, min_passes=2)
 class Tcopool(TestCase):
     def setUp(self):
         self.buffer = None


### PR DESCRIPTION
What this change is adding / fixing
-----------------------------------

Support flaky tests, to stop all the random annoying failures (mainly around TCopool but some new ones coming soon, Gtk signals always seem to be at the heart)

* Add `flaky` as test dep
* Mark copool tests as flaky
* Update lots of CI scripts etc