### PR TITLE
Fix dnd after librarian usage refactor (#3732)

### DIFF
--- a/quodlibet/library/base.py
+++ b/quodlibet/library/base.py
@@ -15,6 +15,7 @@ from typing import (Collection, TypeVar, Sequence, Iterable,
 
 from gi.repository import GObject
 
+import quodlibet
 from quodlibet import util
 from quodlibet.formats import (load_audio_files,
                                dump_audio_files, SerializationError)
@@ -52,7 +53,9 @@ class Library(GObject.GObject, DictMixin, Generic[K, V]):
         'added': (GObject.SignalFlags.RUN_LAST, None, (object,)),
     }
 
-    librarian = None
+    librarian: Optional["quodlibet.library.librarians.Librarian"] = None
+    """A librarian, if defined will be used for collaborating with other libraries"""
+
     dirty = False
 
     def __init__(self, name: Optional[str] = None):


### PR DESCRIPTION
 * Revert to previous librarian behaviour (my bad)
 * Add types in lots of places through the stack here; `library` and `librarian` are distinct types and not really that interchangeable (e.g. `library.librarian`). Could have that refer to `self` in Librarians, but down that path lies madness...
 * Existing usage would break when `lib.librarian` was `None`, as now found by MyPy. It starts with `None`, hence `Optional[Librarian]`, but in _practice_ should never end up with this...

See original discussion https://github.com/quodlibet/quodlibet/commit/ccc2f743e076ff5a0f22ece97b86edf1b2615a89#r53028419
