### PR TITLE
Set empty input shape for hints window (Fixes #1691)

### DIFF
--- a/quodlibet/qltk/views.py
+++ b/quodlibet/qltk/views.py
@@ -39,6 +39,8 @@ class TreeViewHints(Gtk.Window):
          'enter-notify-event', 'leave-notify-event'],
         'override')
 
+    __empty_region = cairo.Region(cairo.RectangleInt())
+
     def __init__(self):
         try:
             # gtk+ 3.20
@@ -350,6 +352,11 @@ class TreeViewHints(Gtk.Window):
         self.set_transient_for(get_top_parent(view))
         set_text(label)
         self.set_size_request(w, h)
+
+        # Set region on this window for which to receive mouse events to the
+        # empty region. Mouse events will be passed to the window below the
+        # tooltip.
+        self.input_shape_combine_region(self.__empty_region)
 
         window = self.get_window()
         if self.get_visible() and window:


### PR DESCRIPTION
This change makes gdk pass all events on the gtk window for "hints" to the window below (which is some quodlibet window in which the tooltip was triggered). 

Fixes #1691 on x11, wayland and win32. On macOS this doesn't do anything, so the current code which passes the events to the other window remains.

Check-list
----------

 * [x] There is a linked issue discussing the motivations for this feature or bugfix
 * [ ] Unit tests have been added where possible
 * [x] I've added / updated documentation for any user-facing features.
 * [x] Performance seems to be comparable or better than current `master`