### PR TITLE
Do not start dragging from empty treeview area (#3538)

### DIFF
--- a/quodlibet/browsers/playlists/main.py
+++ b/quodlibet/browsers/playlists/main.py
@@ -258,8 +258,8 @@ class PlaylistsBrowser(Browser, DisplayPatternMixin):
         ]
         targets = [Gtk.TargetEntry.new(*t) for t in targets]
         view.drag_dest_set(Gtk.DestDefaults.ALL, targets, Gdk.DragAction.COPY)
-        view.drag_source_set(Gdk.ModifierType.BUTTON1_MASK, targets[:2],
-                             Gdk.DragAction.COPY)
+        view.enable_model_drag_source(
+            Gdk.ModifierType.BUTTON1_MASK, targets[:2], Gdk.DragAction.COPY)
         view.connect('drag-data-received', self.__drag_data_received)
         view.connect('drag-data-get', self._drag_data_get)
         view.connect('drag-motion', self.__drag_motion)


### PR DESCRIPTION
What this change is adding / fixing
-----------------------------------
Fixes #3538 

What's notable is that if the playlists browser used `AllTreeView` instead of `RCMHintedTreeView` the `MultiDragTreeView`, which is mixed in with it, would deal with that by checking if there is a row at the current mouse pointer position and not start dragging if there isn't.

```python
class RCMHintedTreeView(HintedTreeView, RCMTreeView, DragIconTreeView):
    """A TreeView that has hints and a context menu."""
    pass


class AllTreeView(HintedTreeView, RCMTreeView, DragIconTreeView,
                  MultiDragTreeView):
    """A TreeView that has hints, a context menu, and multi-selection
    dragging support."""
    pass
```
(from [quodlibet/qltk/views.py](https://github.com/quodlibet/quodlibet/blob/80977572a307d81016a0f7bcc55049284f609d0a/quodlibet/qltk/views.py#L1313))

Check-list
----------

 * [x] There is a linked issue discussing the motivations for this feature or bugfix
 * [ ] Unit tests have been added where possible
 * [x] I've added / updated documentation for any user-facing features.
 * [x] Performance seems to be comparable or better than current `master`