### PR TITLE
Make missing pixbufs less fatal

### DIFF
--- a/quodlibet/browsers/covergrid/main.py
+++ b/quodlibet/browsers/covergrid/main.py
@@ -11,6 +11,7 @@
 from __future__ import absolute_import
 
 import os
+from typing import Optional
 
 import cairo
 from gi.repository import Gtk, Pango, Gdk, Gio
@@ -200,7 +201,7 @@ class CoverGrid(Browser, util.InstanceTracker, VisibleUpdate,
             klass.__library.albums.refresh(albums)
 
     @util.cached_property
-    def _no_cover(self) -> cairo.Surface:
+    def _no_cover(self) -> Optional[cairo.Surface]:
         """Returns a cairo surface representing a missing cover"""
 
         mag = config.getfloat("browsers", "covergrid_magnification", 3.)

--- a/quodlibet/browsers/covergrid/main.py
+++ b/quodlibet/browsers/covergrid/main.py
@@ -1,6 +1,6 @@
 # Copyright 2004-2007 Joe Wreschnig, Michael Urman, Iñigo Serna
 #           2009-2010 Steven Robertson
-#           2012-2018 Nick Boultbee
+#           2012-2021 Nick Boultbee
 #           2009-2014 Christoph Reiter
 #
 # This program is free software; you can redistribute it and/or modify
@@ -12,6 +12,7 @@ from __future__ import absolute_import
 
 import os
 
+import cairo
 from gi.repository import Gtk, Pango, Gdk, Gio
 
 from .prefs import Preferences, DEFAULT_PATTERN_TEXT
@@ -199,7 +200,7 @@ class CoverGrid(Browser, util.InstanceTracker, VisibleUpdate,
             klass.__library.albums.refresh(albums)
 
     @util.cached_property
-    def _no_cover(self):
+    def _no_cover(self) -> cairo.Surface:
         """Returns a cairo surface representing a missing cover"""
 
         mag = config.getfloat("browsers", "covergrid_magnification", 3.)

--- a/quodlibet/ext/songsmenu/albumart.py
+++ b/quodlibet/ext/songsmenu/albumart.py
@@ -509,6 +509,8 @@ class CoverArea(Gtk.VBox, PluginConfigMixin):
             boundary = (width * scale_factor, height * scale_factor)
             pixbuf = scale(pixbuf, boundary, scale_up=False)
 
+        if not pixbuf:
+            return
         surface = get_surface_for_pixbuf(self, pixbuf)
         self.image.set_from_surface(surface)
 
@@ -867,6 +869,8 @@ class AlbumArtWindow(qltk.Window, PluginConfigMixin):
             pixbuf = pbloader.get_pixbuf().scale_simple(size, size,
                 GdkPixbuf.InterpType.BILINEAR)
             pixbuf = add_border_widget(pixbuf, self)
+            if not pixbuf:
+                return
             surface = get_surface_for_pixbuf(self, pixbuf)
         except (GLib.GError, IOError):
             pass

--- a/quodlibet/qltk/cover.py
+++ b/quodlibet/qltk/cover.py
@@ -207,7 +207,9 @@ class ResizeImage(Gtk.Bin):
             pixbuf = scale(pixbuf, (width, height))
 
         style_context = self.get_style_context()
-
+        if not pixbuf:
+            print_w(f"Failed to scale pixbuf for {self._path}")
+            return
         surface = get_surface_for_pixbuf(self, pixbuf)
         Gtk.render_icon_surface(style_context, cairo_context, surface, 0, 0)
 

--- a/quodlibet/qltk/image.py
+++ b/quodlibet/qltk/image.py
@@ -14,8 +14,8 @@ from gi.repository import GdkPixbuf, Gtk, Gdk, GLib
 import cairo
 
 
-def get_surface_for_pixbuf(widget: Gtk.Widget,
-                           pixbuf: Optional[GdkPixbuf]) -> Optional[cairo.Surface]:
+def get_surface_for_pixbuf(widget: Gtk.Widget, pixbuf: Optional[GdkPixbuf.Pixbuf])\
+        -> Optional[cairo.Surface]:
     """:returns: a cairo surface, if possible"""
     if not pixbuf:
         return None

--- a/quodlibet/qltk/image.py
+++ b/quodlibet/qltk/image.py
@@ -8,14 +8,17 @@
 """Some helper function for loading and converting image data."""
 
 import math
+from typing import Optional
 
 from gi.repository import GdkPixbuf, Gtk, Gdk, GLib
 import cairo
 
 
-def get_surface_for_pixbuf(widget, pixbuf):
-    """Returns a cairo surface"""
-
+def get_surface_for_pixbuf(widget: Gtk.Widget,
+                           pixbuf: Optional[GdkPixbuf]) -> Optional[cairo.Surface]:
+    """:returns: a cairo surface, if possible"""
+    if not pixbuf:
+        return None
     scale_factor = widget.get_scale_factor()
     return Gdk.cairo_surface_create_from_pixbuf(
             pixbuf, scale_factor, widget.get_window())


### PR DESCRIPTION
* Throw a deliberate exception in one case
* Otherwise generally try to move on without the pixbuf in question
* ...but also return `None` in `get_surface_for_pixbuf` instead of failing _there_ at least.
* Add some typing too

Fixes #3757
Fixes #3614