### PR TITLE
Update macos devenv setup documentation

### DIFF
--- a/docs/development/devenv.rst
+++ b/docs/development/devenv.rst
@@ -44,6 +44,41 @@ the right environment set up.
     $ git clone https://github.com/quodlibet/quodlibet.git
     $ ./QuodLibet.app/Contents/MacOS/run <path_to_git_repo>/quodlibet/quodlibet.py
 
+On recent MacOS releases, the OS Gatekeeper will complain about the application not being recognised.
+It is easiest to just clear the `com.apple.quarantine` extended attribute from all files in the bundle
+rather than try and open each and every component that MacOS will refuse to open:
+
+::
+
+    $ xattr -rd com.apple.quarantine ./QuodLibet.app/Contents
+
+The bundle includes `pip`, so you can always install additional packages (such as `flake8`, `pytest` and
+`flaky`, which would let you run the test suite):
+
+::
+
+    $ ./QuodLibet.app/Contents/MacOS/run -m pip install flake8 pytest flaky
+    $ ./QuodLibet.app/Contents/MacOS/run <path_to_git_repo>/setup.py test
+
+If you want to run the tests with your own Python command, you'll need to install some additonal software
+and packages:
+
+::
+
+    $ brew install cairo dbus gst-libav gst-plugins-bad gst-plugins-good gst-plugins-ugly \
+        gstreamer gtk-mac-integration gtk+3 libsoup pkg-config pygobject3
+    $ poetry install
+    $ poetry run pip install pyobjc
+
+
+.. |quodlibet.modules ref| replace:: ``quodlibet.modules`` moduleset file 
+.. _quodlibet.modules ref: https://github.com/quodlibet/quodlibet/tree/master/dev-utils/osx_bundle/modulesets/quodlibet.modules
+
+This will *almost* cover all the dependencies that the bundle will contain; at the time of writing the brew
+gstreamer plugins do not include the wavpack (``gst-plugins-good``) or game-music-emu (gme, in ``gst-plugins-bad``)
+plugins. The above list may be out of date, check the ``quodlibet`` metamodule section of the |quodlibet.modules ref|_
+for a more up-to-date list of dependencies.
+
 If you want to build a bundle yourself or change/add dependencies,
 see the `osx_bundle directory
 <https://github.com/quodlibet/quodlibet/tree/master/dev-utils/osx_bundle>`__

--- a/docs/development/devenv.rst
+++ b/docs/development/devenv.rst
@@ -46,7 +46,7 @@ the right environment set up.
 
 If you want to build a bundle yourself or change/add dependencies,
 see the `osx_bundle directory
-<https://github.com/quodlibet/quodlibet/tree/master/osx_bundle>`__
+<https://github.com/quodlibet/quodlibet/tree/master/dev-utils/osx_bundle>`__
 in the Git repo for further instructions.
 
 


### PR DESCRIPTION
This covers:

- a small fix to the devenv documentation; these were moved a year ago in
227c1e7f9fcf62db724ad42dde83ecbdf63abed1.
- my own experience getting my macos dev env configured to the point where the (majority) of the test suite passes.
