### PR TITLE
Follow-up to #3749

### DIFF
--- a/quodlibet/qltk/views.py
+++ b/quodlibet/qltk/views.py
@@ -7,6 +7,7 @@
 # (at your option) any later version.
 
 import contextlib
+import sys
 
 from gi.repository import Gtk, Gdk, GObject, Pango, GLib
 import cairo
@@ -355,8 +356,10 @@ class TreeViewHints(Gtk.Window):
 
         # Set region on this window for which to receive mouse events to the
         # empty region. Mouse events will be passed to the window below the
-        # tooltip.
-        self.input_shape_combine_region(self.__empty_region)
+        # tooltip. The Gdk implementation for win32 does not support this, which
+        # leads to events not being received in either window.
+        if sys.platform != "win32":
+            self.input_shape_combine_region(self.__empty_region)
 
         window = self.get_window()
         if self.get_visible() and window:


### PR DESCRIPTION
Change in https://github.com/quodlibet/quodlibet/pull/3749 does not work properly on Windows, so here's a modification to enable it on non-Windows platforms only.

I originally looked through the Gdk source for [shape_combine_region](https://lazka.github.io/pgi-docs/Gdk-3.0/classes/Window.html#Gdk.Window.shape_combine_region). A comment in there suggests that the win32 implementation handles this, but turns out it behaves very differently.