### PR TITLE
Feature: Support description and language in lyrics (USLT) [WIP, comments appreciated]

### DIFF
--- a/quodlibet/formats/_id3.py
+++ b/quodlibet/formats/_id3.py
@@ -374,17 +374,16 @@ class ID3File(AudioFile):
         tag.delall("USLT")
         if "lyrics" in self:
             enc = encoding_for(self["lyrics"])
-            if not "~lyricslanguage" in self:
+            if not ("~lyricslanguage" in self and
+                    # language has to be a 3 byte ISO 639-2 code
+                    self["~lyricslanguage"] in ISO_639_2):
                 self["~lyricslanguage"] = "und" # undefined
-            lang = self["~lyricslanguage"]
-            # language has to be a 3 byte ISO 639-2 code
-            if not lang in ISO_639_2:
-                lang = "und"
             if not "~lyricsdescription" in self:
                 self["~lyricsdescription"] = ""
             # lyrics are single string, not array
             tag.add(mutagen.id3.USLT(encoding=enc, text=self["lyrics"],
-                                     desc=self["~lyricsdescription"], lang=lang))
+                                     desc=self["~lyricsdescription"],
+                                     lang=self["~lyricslanguage"]))
 
         # Delete old foobar replaygain ..
         for frame in tag.getall("TXXX"):

--- a/quodlibet/formats/_id3.py
+++ b/quodlibet/formats/_id3.py
@@ -381,7 +381,7 @@ class ID3File(AudioFile):
             if not lang in ISO_639_2:
                 lang = "und"
             if not "~lyricsdescription" in self:
-                self["~lyricsdescription"] = u""
+                self["~lyricsdescription"] = ""
             # lyrics are single string, not array
             tag.add(mutagen.id3.USLT(encoding=enc, text=self["lyrics"],
                                      desc=self["~lyricsdescription"], lang=lang))

--- a/quodlibet/formats/_id3.py
+++ b/quodlibet/formats/_id3.py
@@ -172,6 +172,8 @@ class ID3File(AudioFile):
             elif id3id == "USLT":
                 # lyrics are single string, not list
                 text = frame.text
+                self["~lyricsdescription"] = frame.desc
+                self["~lyricslanguage"] = frame.lang
             elif id3id.startswith("W"):
                 text = frame.url
                 frame.encoding = 0
@@ -372,9 +374,16 @@ class ID3File(AudioFile):
         tag.delall("USLT")
         if "lyrics" in self:
             enc = encoding_for(self["lyrics"])
+            if not "~lyricslanguage" in self:
+                self["~lyricslanguage"] = "und" # undefined
+            lang = self["~lyricslanguage"]
+            if not lang in ISO_639_2:
+                lang = "und"
+            if not "~lyricsdescription" in self:
+                self["~lyricsdescription"] = u""
             # lyrics are single string, not array
             tag.add(mutagen.id3.USLT(encoding=enc, text=self["lyrics"],
-                                     desc=u"", lang="\x00\x00\x00"))
+                                     desc=self["~lyricsdescription"], lang=lang))
 
         # Delete old foobar replaygain ..
         for frame in tag.getall("TXXX"):

--- a/quodlibet/formats/_id3.py
+++ b/quodlibet/formats/_id3.py
@@ -380,7 +380,7 @@ class ID3File(AudioFile):
                 self["~lyricslanguage"] = "und" # undefined
             # lyrics are single string, not array
             tag.add(mutagen.id3.USLT(encoding=enc, text=self["lyrics"],
-                                     desc=self.get("~lyricsdescription", "")
+                                     desc=self.get("~lyricsdescription", ""),
                                      lang=self["~lyricslanguage"]))
 
         # Delete old foobar replaygain ..

--- a/quodlibet/formats/_id3.py
+++ b/quodlibet/formats/_id3.py
@@ -1,5 +1,5 @@
 # Copyright 2004-2020 Joe Wreschnig, Michael Urman, Niklas Janlert,
-#                     Steven Robertson, Nick Boultbee
+#                     Steven Robertson, Nick Boultbee, h88e22dgpeps56sg
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/quodlibet/formats/_id3.py
+++ b/quodlibet/formats/_id3.py
@@ -378,11 +378,9 @@ class ID3File(AudioFile):
                     # language has to be a 3 byte ISO 639-2 code
                     self["~lyricslanguage"] in ISO_639_2):
                 self["~lyricslanguage"] = "und" # undefined
-            if not "~lyricsdescription" in self:
-                self["~lyricsdescription"] = ""
             # lyrics are single string, not array
             tag.add(mutagen.id3.USLT(encoding=enc, text=self["lyrics"],
-                                     desc=self["~lyricsdescription"],
+                                     desc=self.get("~lyricsdescription", "")
                                      lang=self["~lyricslanguage"]))
 
         # Delete old foobar replaygain ..

--- a/quodlibet/formats/_id3.py
+++ b/quodlibet/formats/_id3.py
@@ -377,6 +377,7 @@ class ID3File(AudioFile):
             if not "~lyricslanguage" in self:
                 self["~lyricslanguage"] = "und" # undefined
             lang = self["~lyricslanguage"]
+            # language has to be a 3 byte ISO 639-2 code
             if not lang in ISO_639_2:
                 lang = "und"
             if not "~lyricsdescription" in self:

--- a/tests/test_formats__id3.py
+++ b/tests/test_formats__id3.py
@@ -188,11 +188,27 @@ class TID3FileMixin:
                              sorted([u'lyrics',
                                      u'lyrics with non-empty lang',
                                      u'lyrics with non-empty desc']))
+        # multiple USLT tags are not supported so the behavior seems random
+        self.assertIn(f['~lyricsdescription'], [u'desc', u''])
+        self.assertIn(f['~lyricslanguage'], [u'xyz', u''])
         f['lyrics'] = u'modified lyrics'
+        f['~lyricsdescription'] = u''
         f.write()
 
         f = self.KIND(self.filename)
-        self.failUnlessEqual(f['lyrics'], u'modified lyrics')
+        self.assertEqual(f['lyrics'], u'modified lyrics')
+        self.assertEqual(f['~lyricsdescription'], u'')
+        # languages were invalid regarding ISO_639_2 → *und*efined is written
+        self.assertEqual(f['~lyricslanguage'], u'und')
+        f['lyrics'] = u'modified lyrics\nwith two lines'
+        f['~lyricsdescription'] = u'desc'
+        f['~lyricslanguage'] = u'eng'
+        f.write()
+
+        f = self.KIND(self.filename)
+        self.assertEqual(f['lyrics'], u'modified lyrics\nwith two lines')
+        self.assertEqual(f['~lyricsdescription'], u'desc')
+        self.assertEqual(f['~lyricslanguage'], u'eng')
         del f['lyrics']
         f.write()
 


### PR DESCRIPTION
Check-list
----------

 * [x] <s>There is a linked issue discussing the motivations for this feature or bugfix</s>
 * [x] Performance seems to be comparable <s>or better than</s> to current `master`
 * [x] Unit tests have been added where possible
                           They have to be updated to check for correctness of description and language.
 * [ ] Add it to song information window – _Lyrics_ tab.
 * [ ] I've added / updated documentation for any user-facing features.


What this change is adding / fixing
-----------------------------------
USLT (unsynchronised lyrics) [ID3 tag](https://id3.org/id3v2.4.0-frames) includes, besides lyrics of course, description and language. Currently Quodlibet (QL) will overwrite both of them with an empty string or `x00x00x00` on every write. This Pull request aims to add support for both of these subtags by, firstly, keeping these strings if they were already present and, secondly, add a possibility to edit them.

I chose internal tags analogously to the POPM tag, which includes rating and playcount – both internal tags in QL.

Please let me know what's missing or if I'm on the right track. In the latter case I will continue to work on the to-dos above.