### PR TITLE
Small Soundcloud refactors, split out from #3768

### DIFF
--- a/quodlibet/browsers/soundcloud/api.py
+++ b/quodlibet/browsers/soundcloud/api.py
@@ -7,15 +7,16 @@
 
 import json
 from datetime import datetime
+from typing import Optional, cast
 from urllib.parse import urlencode
 
 from gi.repository import GObject, Gio, Soup
 
 from quodlibet import util, config
+from quodlibet.formats import AudioFile
 from quodlibet.util import website
 from quodlibet.util.dprint import print_w, print_d
-from quodlibet.util.http import download_json, download
-
+from quodlibet.util.http import (download_json, download)
 from .library import SoundcloudFile
 from .util import json_callback, Wrapper, sanitise_tag, DEFAULT_BITRATE, EPOCH
 
@@ -101,11 +102,14 @@ class SoundcloudApiClient(RestApi):
         print_d("Starting Soundcloud API...")
         super().__init__(self.API_ROOT)
         self.access_token = config.get("browsers", "soundcloud_token", None)
-        self.online = bool(self.access_token)
         self.user_id = config.get("browsers", "soundcloud_user_id", None)
         if not self.user_id:
             self._get_me()
         self.username = None
+
+    @property
+    def online(self):
+        return bool(self.access_token)
 
     def _default_params(self):
         params = {'client_id': self.__CLIENT_ID}
@@ -124,7 +128,6 @@ class SoundcloudApiClient(RestApi):
         print_d("Destroying access token...")
         self.access_token = None
         self.save_auth()
-        self.online = False
 
     def get_token(self, code):
         print_d("Getting access token...")
@@ -142,7 +145,6 @@ class SoundcloudApiClient(RestApi):
         self.access_token = json['access_token']
         print_d("Got an access token: %s" % self.access_token)
         self.save_auth()
-        self.online = True
         self._get_me()
 
     def _get_me(self):
@@ -207,12 +209,12 @@ class SoundcloudApiClient(RestApi):
     def _on_favorited(self, json):
         print_d("Successfully updated favorite: %s" % json)
 
-    def _audiofile_for(self, response):
+    def _audiofile_for(self, response) -> Optional[AudioFile]:
         r = Wrapper(response)
         d = r.data
-        dl = d.get("downloadable", False) and d.get("download_url", None)
+        dl = d.get("download_url", None) if d.get("downloadable", False) else None
         try:
-            url = dl or r.stream_url
+            url = cast(str, dl or r.stream_url)
         except AttributeError as e:
             print_w("Unusable result (%s) from SC: %s" % (e, d))
             return None
@@ -279,8 +281,8 @@ class SoundcloudApiClient(RestApi):
         return song
 
     @classmethod
-    def _add_secret(cls, stream_url):
-        return "%s?client_id=%s" % (stream_url, cls.__CLIENT_ID)
+    def _add_secret(cls, stream_url: str) -> Optional[str]:
+        return f"{stream_url}?client_id={cls.__CLIENT_ID}" if stream_url else None
 
     @util.cached_property
     def _authorize_url(self):

--- a/quodlibet/browsers/soundcloud/main.py
+++ b/quodlibet/browsers/soundcloud/main.py
@@ -441,7 +441,7 @@ class SoundcloudBrowser(Browser, util.InstanceTracker):
         self.update_connect_button()
         self._refresh_online_filters()
         msg = Message(Gtk.MessageType.INFO, app.window, _("Connected"),
-                      _("Quod Libet is now connected, <b>%s</b>!") % name)
+                      _("Quod Libet is now connected, %s!") % name)
         msg.run()
 
     @cached_property

--- a/tests/test_soundcloudFile.py
+++ b/tests/test_soundcloudFile.py
@@ -1,4 +1,4 @@
-# Copyright 2016 Nick Boultbee
+# Copyright 2016-21 Nick Boultbee
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -21,7 +21,7 @@ class TSoundcloudFile(TestCase):
 
         def __init__(self):
             super().__init__()
-            self.online = True
+            self.access_token = "abc"
             self.favoritings = defaultdict(int)
             self.unfavoritings = defaultdict(int)
 


### PR DESCRIPTION
 * Typing improvements around HTTP
 * Use property for `self.online`
 * Pass `failure_callback` through for `download_json` too


