### PR TITLE
Add a keyboard shortcut for rescanning the library

### DIFF
--- a/quodlibet/qltk/quodlibetwindow.py
+++ b/quodlibet/qltk/quodlibetwindow.py
@@ -990,7 +990,7 @@ class QuodLibetWindow(Window, PersistentWindowMixin, AppWindow):
             name="RefreshLibrary", label=_("_Scan Library"),
             icon_name=Icons.VIEW_REFRESH)
         act.connect('activate', self.__rebuild, False)
-        ag.add_action(act)
+        ag.add_action_with_accel(act, "<Primary>R")
 
         current = config.get("memory", "browser")
         try:


### PR DESCRIPTION
Check-list
----------

 * [ ] There is a linked issue discussing the motivations for this feature or bugfix. N/A
 * [ ] Unit tests have been added where possible: N/A
 * [ ] I've added / updated documentation for any user-facing features. N/A
 * [x] Performance seems to be comparable or better than current `master`


What this change is adding / fixing
-----------------------------------
Add a keyboard shortcut for rescanning the library

