### PR TITLE
Remove some superfluous tooltip text

### DIFF
--- a/quodlibet/ext/events/mqtt.py
+++ b/quodlibet/ext/events/mqtt.py
@@ -134,16 +134,16 @@ class MqttPublisherPlugin(EventPlugin, PluginConfigMixin):
         self._set_up_mqtt_client()
 
     _CONFIG = [
-        (_("Broker hostname"), Config.HOST,
-         _("broker hostname / IP (defaults to localhost)")),
+        (_("Broker hostname / IP"), Config.HOST,
+         _("Defaults to localhost")),
 
-        (_("Broker port"), Config.PORT, _("broker port (defaults to 1883)")),
+        (_("Broker port"), Config.PORT, _("Defaults to 1883")),
 
-        (_("Broker username"), Config.USERNAME, _("broker username")),
+        (_("Broker username"), Config.USERNAME, None),
 
-        (_("Broker password"), Config.PASSWORD, _("broker password")),
+        (_("Broker password"), Config.PASSWORD, None),
 
-        (_("Topic"), Config.TOPIC, _("Topic")),
+        (_("Topic"), Config.TOPIC, None),
 
         (_("Playing Pattern"),
          Config.PAT_PLAYING,
@@ -187,7 +187,8 @@ class MqttPublisherPlugin(EventPlugin, PluginConfigMixin):
             lbl = Gtk.Label(label=label + ":")
             lbl.set_size_request(140, -1)
             lbl.set_alignment(xalign=0.0, yalign=0.5)
-            entry.set_tooltip_markup(tooltip)
+            if tooltip is not None:
+                entry.set_tooltip_markup(tooltip)
             lbl.set_mnemonic_widget(entry)
             t.attach(lbl, 0, 1, i, i + 1, xoptions=FILL)
             t.attach(entry, 1, 2, i, i + 1, xoptions=FILL | EXPAND)


### PR DESCRIPTION
Remove some superfluous tooltip text in the MQTT publisher plugin, which also removes some unnecessary work (and possible confusion) for translators.