### PR TITLE
Fix excess minimum height of plugin window with long description

### DIFF
--- a/quodlibet/qltk/pluginwin.py
+++ b/quodlibet/qltk/pluginwin.py
@@ -306,6 +306,8 @@ class PluginPreferencesContainer(Gtk.VBox):
 
         self.desc = desc = Gtk.Label()
         desc.set_line_wrap(True)
+        # Ensure a reasonable minimum height request for long descriptions
+        desc.set_width_chars(30)
         desc.set_alignment(0, 0.5)
         desc.set_selectable(True)
         self.pack_start(desc, False, True, 0)


### PR DESCRIPTION
See #3203. Compare the minimum size with the *Edit Playcount* plugin selected before and after the change. This reduces unexpected resizes of the plugin window when changing the selected plugin. It does not help with some of the plugins that have a lot of options, they probably need to be handled on an individual basis.

<img src="https://user-images.githubusercontent.com/5852189/130322779-d0104e4e-2cbe-4d58-8f38-02c4ea0f3e4c.png" alt="before" width="250">
<img src="https://user-images.githubusercontent.com/5852189/130322781-c58109a8-b769-4421-8d04-790da0e706cf.png" alt="after" width="400">


