### PR TITLE
Fix translated menu labels for playorder plugins and add accelerators

### DIFF
--- a/quodlibet/ext/playorder/follow.py
+++ b/quodlibet/ext/playorder/follow.py
@@ -19,6 +19,8 @@ class FollowOrder(ShufflePlugin, OrderInOrder, OrderRemembered):
     PLUGIN_ICON = Icons.GO_JUMP
     PLUGIN_DESC = _("Adds a play order mode that follows your selection, "
                     "or the next song in the list once exhausted.")
+    display_name = _("Follow cursor")
+    accelerated_name = _("_Follow cursor")
 
     __last_path = None
 

--- a/quodlibet/ext/playorder/playcounteq.py
+++ b/quodlibet/ext/playorder/playcounteq.py
@@ -23,6 +23,7 @@ class PlaycountEqualizer(ShufflePlugin, OrderRemembered):
                     "that prefers songs with fewer total plays.")
     PLUGIN_ICON = Icons.MEDIA_PLAYLIST_SHUFFLE
     display_name = _("Prefer less played")
+    accelerated_name = _("Prefer _less played")
 
     priority = Reorder.priority
 

--- a/quodlibet/ext/playorder/queue.py
+++ b/quodlibet/ext/playorder/queue.py
@@ -21,6 +21,8 @@ class QueueOrder(ShufflePlugin, OrderInOrder):
                     "Select this play order in the main window, "
                     "then double-clicking any song will enqueue it "
                     "instead of playing.")
+    display_name = _("Queue only")
+    accelerated_name = _("_Queue only")
 
     def next(self, playlist, iter):
         return None

--- a/quodlibet/ext/playorder/reverse.py
+++ b/quodlibet/ext/playorder/reverse.py
@@ -15,6 +15,8 @@ class ReverseOrder(ShufflePlugin, OrderInOrder):
     PLUGIN_ICON = Icons.MEDIA_SKIP_BACKWARD
     PLUGIN_DESC = _("Adds a shuffle mode "
                     "that reverses the play order of songs.")
+    display_name = _("Reverse")
+    accelerated_name = _("Re_verse")
 
     def previous(self, playlist, iter):
         return super().next(playlist, iter)

--- a/quodlibet/ext/playorder/shufflebygrouping.py
+++ b/quodlibet/ext/playorder/shufflebygrouping.py
@@ -37,6 +37,7 @@ class ShuffleByGrouping(ShufflePlugin, OrderRemembered):
                     "before shuffling to the next piece.")
     PLUGIN_ICON = Icons.MEDIA_PLAYLIST_SHUFFLE
     display_name = _("Shuffle by grouping")
+    accelerated_name = _("Shuffle by _grouping")
     priority = Reorder.priority
 
     def next(self, playlist, current_song):

--- a/quodlibet/ext/playorder/skip_disliked.py
+++ b/quodlibet/ext/playorder/skip_disliked.py
@@ -26,6 +26,8 @@ class SkipDisliked(ShufflePlugin, OrderInOrder):
     PLUGIN_DESC = _("Adds a play order (shuffle) mode that plays in order, "
                     "but skips tracks with a rating "
                     "below (or equal to) a given threshold.")
+    display_name = _("Skip disliked tracks")
+    accelerated_name = _("Skip _disliked tracks")
 
     @classmethod
     def PluginPreferences(self, window):

--- a/quodlibet/ext/playorder/track_repeat.py
+++ b/quodlibet/ext/playorder/track_repeat.py
@@ -29,6 +29,9 @@ class TrackRepeatOrder(RepeatPlugin, PluginConfigMixin):
     PLUGIN_ICON = Icons.MEDIA_PLAYLIST_REPEAT
     PLUGIN_DESC = _("Adds a shuffle mode that plays tracks in order, "
                     "but repeating every track a set number of times.")
+    display_name = _("Repeat each track")
+    accelerated_name = _("Repeat _each track")
+
     PLAY_EACH_DEFAULT = 2
 
     START_COUNT = 1

--- a/quodlibet/order/reorder.py
+++ b/quodlibet/order/reorder.py
@@ -38,7 +38,7 @@ class OrderShuffle(Reorder, OrderRemembered):
 class OrderWeighted(Reorder, OrderRemembered):
     name = "weighted"
     display_name = _("Prefer higher rated")
-    accelerated_name = _("Prefer higher rated")
+    accelerated_name = _("Prefer _higher rated")
 
     def next(self, playlist, iter):
         super().next(playlist, iter)

--- a/quodlibet/order/repeat.py
+++ b/quodlibet/order/repeat.py
@@ -41,7 +41,7 @@ class RepeatSongForever(Repeat):
 
     name = "repeat_song"
     display_name = _("Repeat this track")
-    accelerated_name = _("Repeat this track")
+    accelerated_name = _("Repeat _this track")
 
     def next(self, playlist, iter):
         return iter
@@ -55,7 +55,7 @@ class RepeatListForever(Repeat):
 
     name = "repeat_all"
     display_name = _("Repeat all")
-    accelerated_name = _("Repeat all")
+    accelerated_name = _("Repeat _all")
 
     def next(self, playlist, iter):
         next = self.wrapped.next(playlist, iter)
@@ -70,8 +70,8 @@ class OneSong(Repeat):
     """Stops after the current song"""
 
     name = "one_song"
-    display_name = _("One Song")
-    accelerated_name = _("One Song")
+    display_name = _("One song")
+    accelerated_name = _("One _song")
     priority = 400
 
     def next(self, playlist, iter):


### PR DESCRIPTION
By specifying the display name explicitly, auto-capitalization of the plugin name is prevented; it produced wrongly capitalized menu entries for languages with different capitalization rules compared to English.

While at it, added accelerators to all entries.
