### PR TITLE
ReplayGain: Disambiguate column heading

### DIFF
--- a/quodlibet/ext/songsmenu/replaygain.py
+++ b/quodlibet/ext/songsmenu/replaygain.py
@@ -14,7 +14,7 @@ from gi.repository import Pango
 from gi.repository import Gst
 from gi.repository import GLib
 
-from quodlibet import print_d, ngettext, _
+from quodlibet import print_d, ngettext, C_, _
 from quodlibet.plugins import PluginConfigMixin
 
 from quodlibet.browsers.collection.models import EMPTY
@@ -391,7 +391,8 @@ class RGDialog(Dialog):
             cell.set_property('text', item.title)
             cell.set_sensitive(model[iter_][1])
 
-        column = Gtk.TreeViewColumn(_("Track"))
+        # Translators: Combined track number/title column heading
+        column = Gtk.TreeViewColumn(C_("track/title", "Track"))
         column.set_expand(True)
         column.set_sizing(Gtk.TreeViewColumnSizing.AUTOSIZE)
         track_render = Gtk.CellRendererText()


### PR DESCRIPTION
The column is a combined column for track number and title, and as such the heading may need a different translation compared to cases where it only stands for the track number.

E.g. for German *Track* is translated to *Titel-Nr.*, which only refers to the number.