### PR TITLE
Allow markup in plugin descriptions

### DIFF
--- a/quodlibet/ext/covers/artwork_url.py
+++ b/quodlibet/ext/covers/artwork_url.py
@@ -1,4 +1,4 @@
-# Copyright 2016 Nick Boultbee
+# Copyright 2016-2021 Nick Boultbee
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -17,8 +17,9 @@ from quodlibet.util.path import escape_filename
 class ArtworkUrlCover(CoverSourcePlugin, HTTPDownloadMixin):
     PLUGIN_ID = "artwork-url-cover"
     PLUGIN_NAME = _("Artwork URL Cover Source")
-    PLUGIN_DESC = _("Downloads covers linked to by the artwork_url tag. "
-                    "This works with the Soundcloud browser.")
+    PLUGIN_DESC_MARKUP = _(
+        "Downloads covers linked to by the <tt>artwork_url</tt> tag. "
+        "This works with the Soundcloud browser.")
 
     @classmethod
     def group_by(cls, song):

--- a/quodlibet/ext/editing/resub.py
+++ b/quodlibet/ext/editing/resub.py
@@ -16,13 +16,14 @@ from quodlibet.qltk import Icons
 class RegExpSub(Gtk.HBox, RenameFilesPlugin, TagsFromPathPlugin):
     PLUGIN_ID = "Regex Substitution"
     PLUGIN_NAME = _("Regex Substitution")
-    PLUGIN_DESC = _("Allows arbitrary regex substitutions (s///) when "
-                    "tagging or renaming files.")
+    PLUGIN_DESC_MARKUP = _(
+        "Allows arbitrary regex substitutions (<tt>s/from/to/</tt>) "
+        "when tagging or renaming files.")
     PLUGIN_ICON = Icons.EDIT_FIND_REPLACE
 
     __gsignals__ = {
         "changed": (GObject.SignalFlags.RUN_LAST, None, ())
-        }
+    }
     active = True
 
     def __init__(self):

--- a/quodlibet/ext/events/jep118.py
+++ b/quodlibet/ext/events/jep118.py
@@ -28,7 +28,8 @@ format = """\
 class JEP118(EventPlugin):
     PLUGIN_ID = "JEP-118"
     PLUGIN_NAME = _("JEP-118")
-    PLUGIN_DESC = _("Outputs a Jabber User Tunes file to ~/.quodlibet/jabber.")
+    PLUGIN_DESC_MARKUP = _("Outputs a Jabber User Tunes file to "
+                           "<tt>~/.quodlibet/jabber</tt>.")
     PLUGIN_ICON = Icons.DOCUMENT_SAVE
 
     def plugin_on_song_started(self, song):

--- a/quodlibet/ext/events/seekpoints.py
+++ b/quodlibet/ext/events/seekpoints.py
@@ -22,8 +22,8 @@ class SeekPointsPlugin(EventPlugin, PluginConfigMixin):
     PLUGIN_CONFIG_SECTION = __name__
     PLUGIN_DESC = _(
        "Store Seekpoints A and/or B for tracks. "
-       "Skip to time A and stop after time B when track is played.\n"
-       "Note that changing the names of the points below does not "
+       "Skip to time A and stop after time B when track is played.\n\n"
+       "ℹ Note that changing the names of the points below does not "
        "update the actual bookmark names, it only changes which "
        "bookmark names the plugin looks for when deciding whether to seek.")
 

--- a/quodlibet/ext/events/squeezebox_sync.py
+++ b/quodlibet/ext/events/squeezebox_sync.py
@@ -1,4 +1,4 @@
-# Copyright 2011-2014 Nick Boultbee
+# Copyright 2011-2021 Nick Boultbee
 #
 # Inspired in parts by PySqueezeCenter (c) 2010 JingleManSweep
 # SqueezeCenter and SqueezeBox are copyright Logitech
@@ -17,17 +17,23 @@ from quodlibet.util.dprint import print_d
 from quodlibet.qltk import Icons
 from quodlibet.plugins.events import EventPlugin
 
-
 if os.name == "nt":
     from quodlibet.plugins import PluginNotSupportedError
+
     raise PluginNotSupportedError
 
 
 class SqueezeboxSyncPlugin(EventPlugin, SqueezeboxPluginMixin):
     PLUGIN_ID = 'Squeezebox Output'
     PLUGIN_NAME = _('Squeezebox Sync')
-    PLUGIN_DESC = _("Makes Logitech Squeezebox mirror Quod Libet output, "
-                    "provided both read from an identical library.")
+    PLUGIN_DESC_MARKUP = (
+        _("Makes Logitech Squeezebox mirror Quod Libet output, "
+          "provided both read from an identical library.") + "\n" +
+        _("Shares configuration with %(plugin)s.")
+        % {"plugin":
+            ("<a href=\"quodlibet:///prefs/plugins/Export to Squeezebox Playlist\">"
+             "Export to Squeezebox plugin</a>")}
+    )
     PLUGIN_ICON = Icons.MEDIA_PLAYBACK_START
 
     server = None

--- a/quodlibet/ext/events/thumbrating.py
+++ b/quodlibet/ext/events/thumbrating.py
@@ -89,10 +89,10 @@ class ThumbRating(EventPlugin, UserInterfacePlugin):
 
     PLUGIN_ID = 'Thumb Rating'
     PLUGIN_NAME = _('Thumb Rating')
-    PLUGIN_DESC = _('Adds a thumb-up/thumb-down scoring system '
-                    'which is converted to a rating value. Useful '
-                    'for keeping running vote totals and sorting by '
-                    '\'~#score\'.')
+    PLUGIN_DESC_MARKUP = _('Adds a thumb-up / thumb-down scoring system '
+                           'which is converted to a rating value. Useful '
+                           'for keeping running vote totals and sorting by '
+                           '<b><tt>~#score</tt></b>.')
     PLUGIN_ICON = Icons.USER_BOOKMARKS
 
     # Threshold value where points should be recalculated

--- a/quodlibet/ext/events/waveformseekbar.py
+++ b/quodlibet/ext/events/waveformseekbar.py
@@ -607,7 +607,7 @@ class WaveformSeekBarPlugin(EventPlugin):
     PLUGIN_ICON = Icons.GO_JUMP
     PLUGIN_CONFIG_SECTION = __name__
     PLUGIN_DESC = _(
-        "A seekbar in the shape of the waveform of the current song.")
+        "∿ A seekbar in the shape of the waveform of the current song.")
 
     def __init__(self):
         self._bar = None

--- a/quodlibet/ext/playlist/export_to_squeezebox.py
+++ b/quodlibet/ext/playlist/export_to_squeezebox.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 Nick Boultbee
+# Copyright 2014-2021 Nick Boultbee
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -20,13 +20,13 @@ from quodlibet.ext._shared.squeezebox.base import SqueezeboxPluginMixin
 class SqueezeboxPlaylistPlugin(PlaylistPlugin, SqueezeboxPluginMixin):
     PLUGIN_ID = "Export to Squeezebox Playlist"
     PLUGIN_NAME = _(u"Export to Squeezebox")
-    PLUGIN_DESC = \
+    PLUGIN_DESC_MARKUP = (
         _("Dynamically exports a playlist to Logitech Squeezebox "
-          "playlist, provided both share a directory structure. "
-          "Shares configuration with "
-          "<a href=\"quodlibet:///prefs/plugins/Squeezebox Output\">"
-          "Squeezebox Sync plugin"
-          "</a>.")
+          "playlist, provided both share a directory structure.") + "\n" +
+        _("Shares configuration with %(plugin)s")
+        % {"plugin": ("<a href=\"quodlibet:///prefs/plugins/Squeezebox Output\">"
+                      "Squeezebox Sync plugin</a>.")}
+    )
     PLUGIN_ICON = Icons.NETWORK_WORKGROUP
     ELLIPSIZE_NAME = True
     _PERSIST_FUDGE = 100
@@ -75,9 +75,10 @@ class SqueezeboxPlaylistPlugin(PlaylistPlugin, SqueezeboxPluginMixin):
     @staticmethod
     def __get_playlist_name(name="Quod Libet playlist"):
         dialog = GetStringDialog(None,
-            _("Export playlist to Squeezebox"),
-            _("Playlist name (will overwrite existing)"),
-            button_label=_("_Save"), button_icon=Icons.DOCUMENT_SAVE)
+                                 _("Export playlist to Squeezebox"),
+                                 _("Playlist name (will overwrite existing)"),
+                                 button_label=_("_Save"),
+                                 button_icon=Icons.DOCUMENT_SAVE)
         name = dialog.run(text=name)
         return name
 

--- a/quodlibet/ext/songsmenu/editplaycount.py
+++ b/quodlibet/ext/songsmenu/editplaycount.py
@@ -17,15 +17,17 @@ from quodlibet.qltk import Icons
 class EditPlaycount(SongsMenuPlugin):
     PLUGIN_ID = "editplaycount"
     PLUGIN_NAME = _("Edit Playcount")
-    PLUGIN_DESC = _("Edit a song's ~#playcount and ~#skipcount."
-                    "\n\n"
-                    "When multiple songs are selected, counts will be "
-                    "incremented, rather than set."
-                    "\n\n"
-                    "When setting a song's ~#playcount to 0, the "
-                    "~#lastplayed and ~#laststarted entries will be cleared. "
-                    "However, when setting a 0-play song to a positive play "
-                    "count, no play times will be created.")
+    PLUGIN_DESC_MARKUP = _(
+        "Edit a song's <tt>~#playcount</tt> and <tt>~#skipcount.</tt>"
+        "\n\n"
+        "When multiple songs are selected, counts will be "
+        "incremented, rather than set."
+        "\n\n"
+        "When setting a song's <tt>~#playcount</tt> to 0, "
+        "the <tt>~#lastplayed</tt> and <tt>~#laststarted</tt> "
+        "entries will be cleared. "
+        "However, when setting a 0-play song to a positive play "
+        "count, no play times will be created.")
     PLUGIN_ICON = Icons.EDIT
     REQUIRES_ACTION = True
 

--- a/quodlibet/ext/songsmenu/replaygain.py
+++ b/quodlibet/ext/songsmenu/replaygain.py
@@ -1,6 +1,6 @@
 #    ReplayGain Album Analysis using gstreamer rganalysis element
 #    Copyright (C) 2005,2007,2009  Michael Urman
-#                  2012,2014,2016  Nick Boultbee
+#                       2012-2021  Nick Boultbee
 #                            2013  Christoph Reiter
 #
 # This program is free software; you can redistribute it and/or modify
@@ -215,7 +215,6 @@ class RGSong:
 
 
 class ReplayGainPipeline(GObject.Object):
-
     __gsignals__ = {
         # done(self, album)
         'done': (GObject.SignalFlags.RUN_LAST, None, (object,)),
@@ -568,8 +567,11 @@ class RGDialog(Dialog):
 class ReplayGain(SongsMenuPlugin, PluginConfigMixin):
     PLUGIN_ID = 'ReplayGain'
     PLUGIN_NAME = _('Replay Gain')
-    PLUGIN_DESC = _('Analyzes and updates ReplayGain information, '
-                    'using GStreamer. Results are grouped by album.')
+    PLUGIN_DESC_MARKUP = (
+        _('Analyzes and updates %(rg_link)s information, '
+          'using GStreamer. Results are grouped by album.')
+        % {"rg_link":
+           "<a href=\"https://en.wikipedia.org/wiki/\">ReplayGain</a>"})
     PLUGIN_ICON = Icons.MULTIMEDIA_VOLUME_CONTROL
     CONFIG_SECTION = 'replaygain'
 
@@ -599,7 +601,7 @@ class ReplayGain(SongsMenuPlugin, PluginConfigMixin):
         rows = []
 
         def process_option_changed(combo):
-            #xcode = combo.get_child().get_text()
+            # xcode = combo.get_child().get_text()
             model = combo.get_model()
             lbl, value = model[combo.get_active()]
             cls.config_set("process_if", value)

--- a/quodlibet/ext/songsmenu/tapbpm.py
+++ b/quodlibet/ext/songsmenu/tapbpm.py
@@ -175,7 +175,7 @@ class TapBpmPanel(Gtk.VBox):
 class TapBpm(SongsMenuPlugin):
     PLUGIN_ID = "Tap BPM"
     PLUGIN_NAME = _("Tap BPM")
-    PLUGIN_DESC = _("Tap BPM for the selected song.")
+    PLUGIN_DESC = _("🥁 Tap BPM for the selected song.")
     PLUGIN_ICON = Icons.EDIT
     PLUGIN_VERSION = "0.1"
 

--- a/quodlibet/ext/songsmenu/website_search.py
+++ b/quodlibet/ext/songsmenu/website_search.py
@@ -34,10 +34,11 @@ class WebsiteSearch(SongsMenuPlugin):
     PLUGIN_ICON = Icons.APPLICATION_INTERNET
     PLUGIN_ID = "Website Search"
     PLUGIN_NAME = _("Website Search")
-    PLUGIN_DESC = _("Searches your choice of website using any song tags.\n"
-                    "Supports patterns e.g. %(pattern-example)s.") % {
-                        "pattern-example":
-                            "https://google.com?q=&lt;~artist~title&gt;"}
+    PLUGIN_DESC_MARKUP = (_(
+        "Searches your choice of website using any song tags.\n"
+        "Supports patterns e.g. <tt>%(pattern-example)s</tt>.")
+         % {"pattern-example": "https://duckduckgo.com?q=&lt;~artist~title&gt;"}
+    )
 
     # Here are some starters...
     DEFAULT_URL_PATS = [

--- a/quodlibet/plugins/__init__.py
+++ b/quodlibet/plugins/__init__.py
@@ -11,6 +11,7 @@ from quodlibet import _
 from quodlibet import config
 from quodlibet import util
 from quodlibet.qltk.ccb import ConfigCheckButton
+from quodlibet.util import escape
 from quodlibet.util.config import ConfigProxy
 from quodlibet.util.dprint import print_d
 from quodlibet.util.modulescanner import ModuleScanner
@@ -147,6 +148,13 @@ class Plugin:
     @property
     def description(self):
         return getattr(self.cls, "PLUGIN_DESC", None)
+
+    @property
+    def description_markup(self):
+        try:
+            return getattr(self.cls, "PLUGIN_DESC_MARKUP")
+        except AttributeError:
+            return escape(self.description)
 
     @property
     def tags(self):

--- a/quodlibet/qltk/pluginwin.py
+++ b/quodlibet/qltk/pluginwin.py
@@ -331,9 +331,9 @@ class PluginPreferencesContainer(Gtk.VBox):
             text = (f"<big><b>{name}</b> "
                     f"<span alpha='40%'> – {category}</span>"
                     f"</big>")
-            if plugin.description:
-                text += "<span font='4'>\n\n</span>"
-                text += util.escape(plugin.description)
+            markup = plugin.description_markup
+            if markup:
+                text += f"<span font='4'>\n\n</span>{markup}"
             label.set_markup(text)
             label.connect("activate-link", show_uri)
 

--- a/tests/plugin/test_style.py
+++ b/tests/plugin/test_style.py
@@ -1,4 +1,5 @@
 # Copyright 2015 Anton Shestakov
+#           2021 Nick Boultbee
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -51,21 +52,31 @@ class TPluginStyle(PluginTestCase):
         self.conclude(fails)
 
     def test_plugin_desc(self):
-        REASON_ABSENT = "plugin should have PLUGIN_DESC"
-        REASON_DOT = "PLUGIN_DESC should be a full sentence and end with a '.'"
+        REASON_ABSENT = "plugin should have PLUGIN_DESC or PLUGIN_DESC_MARKUP"
+        REASON_DOT = ("PLUGIN_DESC / PLUGIN_DESC_MARKUP "
+                      "should be a full sentence and end with a '.'")
 
         skip_plugins = L('pickle_plugin')
         fails = []
 
         for pid, plugin in self.plugins.items():
+            cls = plugin.cls
             if pid in skip_plugins:
                 continue
-            if not hasattr(plugin.cls, 'PLUGIN_DESC'):
+            got = 0
+            if hasattr(cls, 'PLUGIN_DESC'):
+                got += 1
+                desc = cls.PLUGIN_DESC
+                if not desc.endswith('.'):
+                    fails.append((plugin, desc, REASON_DOT))
+                    continue
+            if hasattr(cls, "PLUGIN_DESC_MARKUP"):
+                got += 1
+                desc = cls.PLUGIN_DESC_MARKUP
+                if not desc.endswith('.'):
+                    fails.append((plugin, desc, REASON_DOT))
+                    continue
+            if not got:
                 fails.append((plugin, None, REASON_ABSENT))
-                continue
-            desc = plugin.cls.PLUGIN_DESC
-            if not desc.endswith('.'):
-                fails.append((plugin, desc, REASON_DOT))
-
         skip_plugins.check_unused()
         self.conclude(fails)


### PR DESCRIPTION
* Add a new attribute `PLUGIN_DESC_MARKUP`, as an alternative to `PLUGIN_DESC` (which nowadays is always escaped for safety, see #3780)
* Move _lots_ of plugins to using this either because they _were_ using markup or they now can / do / should, updating markup / adding links etc
* Also fix both Squeezebox plugin to link to each other (TODO: figure out segfaults! :grimace: )
* Update tests around plugin descriptions

Fixes #3780

Check-list
----------

 * [x] There is a linked issue discussing the motivations for this feature or bugfix
 * [x] Unit tests have been added where possible
 * [x] I've added / updated documentation for any user-facing features.
 * [x] Performance seems to be comparable or better than current `master`


What this change is adding / fixing
-----------------------------------
<!-- A high-level description of the changes.
Hopefully the commits are atomic and well described, but this is the overall
summary of the change, to other developers / maintainers, plus any TODOs. -->

