### PR TITLE
Make link text translatable in plugin descriptions

### DIFF
--- a/quodlibet/ext/events/squeezebox_sync.py
+++ b/quodlibet/ext/events/squeezebox_sync.py
@@ -29,10 +29,9 @@ class SqueezeboxSyncPlugin(EventPlugin, SqueezeboxPluginMixin):
     PLUGIN_DESC_MARKUP = (
         _("Makes Logitech Squeezebox mirror Quod Libet output, "
           "provided both read from an identical library.") + "\n" +
-        _("Shares configuration with %(plugin)s.")
-        % {"plugin":
-            ("<a href=\"quodlibet:///prefs/plugins/Export to Squeezebox Playlist\">"
-             "Export to Squeezebox plugin</a>")}
+        _("Shares configuration with <a href=\"%(plugin_link)s\">Export to "
+          "Squeezebox plugin</a>.")
+        % {"plugin_link": "quodlibet:///prefs/plugins/Export to Squeezebox Playlist"}
     )
     PLUGIN_ICON = Icons.MEDIA_PLAYBACK_START
 

--- a/quodlibet/ext/playlist/export_to_squeezebox.py
+++ b/quodlibet/ext/playlist/export_to_squeezebox.py
@@ -23,9 +23,9 @@ class SqueezeboxPlaylistPlugin(PlaylistPlugin, SqueezeboxPluginMixin):
     PLUGIN_DESC_MARKUP = (
         _("Dynamically exports a playlist to Logitech Squeezebox "
           "playlist, provided both share a directory structure.") + "\n" +
-        _("Shares configuration with %(plugin)s")
-        % {"plugin": ("<a href=\"quodlibet:///prefs/plugins/Squeezebox Output\">"
-                      "Squeezebox Sync plugin</a>.")}
+        _("Shares configuration with <a href=\"%(plugin_link)s\">Squeezebox "
+          "Sync plugin</a>.")
+        % {"plugin_link": "quodlibet:///prefs/plugins/Squeezebox Output"}
     )
     PLUGIN_ICON = Icons.NETWORK_WORKGROUP
     ELLIPSIZE_NAME = True

--- a/quodlibet/ext/songsmenu/replaygain.py
+++ b/quodlibet/ext/songsmenu/replaygain.py
@@ -568,10 +568,9 @@ class ReplayGain(SongsMenuPlugin, PluginConfigMixin):
     PLUGIN_ID = 'ReplayGain'
     PLUGIN_NAME = _('Replay Gain')
     PLUGIN_DESC_MARKUP = (
-        _('Analyzes and updates %(rg_link)s information, '
+        _('Analyzes and updates <a href=\"%(rg_link)s\">ReplayGain</a> information, '
           'using GStreamer. Results are grouped by album.')
-        % {"rg_link":
-           "<a href=\"https://en.wikipedia.org/wiki/ReplayGain\">ReplayGain</a>"})
+        % {"rg_link": _("https://en.wikipedia.org/wiki/ReplayGain")})
     PLUGIN_ICON = Icons.MULTIMEDIA_VOLUME_CONTROL
     CONFIG_SECTION = 'replaygain'
 


### PR DESCRIPTION
As a followup to #3792, I think it is better to set up the descriptions containing links like this, so that the relevant parts can be properly translated (_ReplayGain_ might need to be translated for languages using a non-latin script). I think it also makes sense to allow the ReplayGain link to be changed to a refer to a localized article.

