### PR TITLE
Update patterns.rst

### DIFF
--- a/docs/guide/tags/patterns.rst
+++ b/docs/guide/tags/patterns.rst
@@ -43,7 +43,7 @@ So using the full (second) form, a Pattern of:
 
     ``<album|Has An Album|No Album>``
 
-produces *Has An album* for any song with at least one ``album`` tag value,
+produces *Has An Album* for any song with at least one ``album`` tag value,
 else *No Album*.
 
 Note that these can be recursive, i.e. both `non-empty-value` and


### PR DESCRIPTION
Match capitalization of "Has An Album" pattern above so "album" isn't mistaken for the text of the above tag-expression.

What this change is adding / fixing
-----------------------------------
Fixing typo in documentation of tag patterns.

