### PR TITLE
fix 'Convert Encoding' plugin

### DIFF
--- a/quodlibet/ext/editing/iconv.py
+++ b/quodlibet/ext/editing/iconv.py
@@ -70,4 +70,5 @@ class Iconv(EditTagsPlugin):
         try:
             return [(tag, self.__value)]
         except AttributeError:
-            return []  # make it different from [(tag, value)] so the menu entry is enabled
+            # make it different from [(tag, value)] so the menu entry is enabled
+            return []


### PR DESCRIPTION
Check-list
----------
 * [ ] Performance seems to be comparable or better than current `master`


What this change is adding / fixing
-----------------------------------
This one-line change fixes "Convert Encoding" plugin. It stopped working after this change:
`results = item.activated(entry.tag,text)` at  [quodlibet/qltk/edittags.py:699](https://github.com/schernikov/quodlibet/commit/999982e5f0e9b9910f8a074fa164eed44aee4676#diff-abe7bab83daa2aabc83f96484c9629ab1b9326fb9967d46dd0cc537297edb550R699)

