### PR TITLE
Exfalso: fix prefs

### DIFF
--- a/quodlibet/qltk/exfalsowindow.py
+++ b/quodlibet/qltk/exfalsowindow.py
@@ -30,7 +30,7 @@ from quodlibet.qltk.menubutton import MenuButton
 from quodlibet.qltk.about import AboutDialog
 from quodlibet.qltk.songsmenu import SongsMenuPluginHandler
 from quodlibet.qltk.x import Align, SeparatorMenuItem, ConfigRHPaned, \
-    Button, SymbolicIconImage, MenuItem
+    SymbolicIconImage, MenuItem
 from quodlibet.qltk.window import PersistentWindowMixin, Window
 from quodlibet.qltk.msg import CancelRevertSave
 from quodlibet.qltk.prefs import PreferencesWindow as QLPreferencesWindow
@@ -274,28 +274,10 @@ class PreferencesWindow(QLPreferencesWindow):
     def __init__(self, parent):
         if self.is_not_unique():
             return
-        super().__init__(parent)
+        super().__init__(parent, all_pages=False)
+        # Seems nicer when there's only one page
+        self.set_resizable(True)
         self.set_title(_("Ex Falso Preferences"))
-        self.set_border_width(12)
-        self.set_resizable(False)
-        self.set_transient_for(qltk.get_top_parent(parent))
-
-        tagging = self.Tagging()
-        f = qltk.Frame(_("Tag Editing"), child=(tagging.tag_editing_vbox()))
-
-        close = Button(_("_Close"), Icons.WINDOW_CLOSE)
-        connect_obj(close, 'clicked', lambda x: x.destroy(), self)
-        button_box = Gtk.HButtonBox()
-        button_box.set_layout(Gtk.ButtonBoxStyle.END)
-        button_box.pack_start(close, True, True, 0)
-
-        main_vbox = Gtk.VBox(spacing=12)
-        main_vbox.pack_start(f, True, True, 0)
-        if not self.has_close_button():
-            main_vbox.pack_start(button_box, False, True, 0)
-        self.add(main_vbox)
-
-        connect_obj(self, 'destroy', PreferencesWindow.__destroy, self)
         self.get_child().show_all()
 
     def __destroy(self):

--- a/quodlibet/qltk/prefs.py
+++ b/quodlibet/qltk/prefs.py
@@ -741,7 +741,7 @@ class PreferencesWindow(UniqueWindow):
             for child in self.get_children():
                 child.show_all()
 
-    def __init__(self, parent, open_page=None):
+    def __init__(self, parent, open_page=None, all_pages=True):
         if self.is_not_unique():
             return
         super().__init__()
@@ -751,8 +751,9 @@ class PreferencesWindow(UniqueWindow):
         self.set_transient_for(qltk.get_top_parent(parent))
 
         self.__notebook = notebook = qltk.Notebook()
-        pages = [self.SongList, self.Browsers, self.Player, self.Library,
-                 self.Tagging]
+        pages = [self.Tagging]
+        if all_pages:
+            pages = [self.SongList, self.Browsers, self.Player, self.Library] + pages
         for Page in pages:
             page = Page()
             page.show()

--- a/tests/test_qltk_exfalso.py
+++ b/tests/test_qltk_exfalso.py
@@ -28,4 +28,6 @@ class TExFalsoWindow(TestCase):
         self.prefs.present()
         assert self.prefs.get_title() == "Ex Falso Preferences"
         assert self.prefs.get_child(), "No window contents"
+        pages = [type(p) for p in self.prefs.get_child().get_children()]
+        assert pages == [self.prefs.Tagging], "Wrong prefs pages"
         self.prefs.destroy()


### PR DESCRIPTION
 * Remove duplicated code from super (fixes padding and warning)
 * Allow constructor param to specify all pages (default) or just the tagging (for EF)
 * Make it resizable, was kinda nasty otherwise.
 * Update test to make sure the prefs window for EF only has one pane

Check-list
----------

 * [x] There is a linked issue discussing the motivations for this feature or bugfix
 * [x] Unit tests have been added where possible
 * [x] Performance seems to be comparable or better than current `master`

This fixes #3805 