### PR TITLE
Adding album browser sorts to cover grid

### DIFF
--- a/quodlibet/browsers/covergrid/main.py
+++ b/quodlibet/browsers/covergrid/main.py
@@ -56,8 +56,11 @@ class PreferencesButton(AlbumPreferencesButton):
             (_("_Title"), self.__compare_title),
             (_("_Artist"), self.__compare_artist),
             (_("_Date"), self.__compare_date),
+            (_("_Date Added"), self.__compare_date_added),
+            (_("_Original Date"), self.__compare_original_date),
             (_("_Genre"), self.__compare_genre),
             (_("_Rating"), self.__compare_rating),
+            (_("_Playcount"), self.__compare_avgplaycount),
         ]
 
         menu = Gtk.Menu()


### PR DESCRIPTION
Check-list
----------

 * [x] There is a linked issue discussing the motivations for this feature or bugfix #3820 
 * [ ] Unit tests have been added where possible
 * [ ] I've added / updated documentation for any user-facing features.
 * [x] Performance seems to be comparable or better than current `master`


What this change is adding / fixing
-----------------------------------
Album List view has a richer set of sorting options that are not available in Cover Grid, and I realized that it's within my abilities to extend this functionality (i.e. copy and paste) to Cover Grid. All the sorting options work in Cover Grid as expected.