### PR TITLE
Inkscape --export-png deprecated option

### DIFF
--- a/quodlibet/images/Makefile
+++ b/quodlibet/images/Makefile
@@ -38,15 +38,15 @@ png-%: $(THEME)/%/apps/$(QL_DEST) $(THEME)/%/apps/$(EF_DEST) $(THEME)/%/status/$
 
 $(THEME)/%/apps/$(QL_DEST): $(QL_SOURCE)
 	mkdir -p $(dir $@)
-	inkscape $< -o $@ -w $(shell echo $* | cut -dx -f1) -h $(shell echo $* | cut -dx -f2) ;
+	inkscape $< --export-filename $@ -w $(shell echo $* | cut -dx -f1) -h $(shell echo $* | cut -dx -f2) ;
 
 $(THEME)/%/apps/$(EF_DEST): $(EF_SOURCE)
 	mkdir -p $(dir $@)
-	inkscape $< -o $@ -w $(shell echo $* | cut -dx -f1) -h $(shell echo $* | cut -dx -f2) ;
+	inkscape $< --export-filename $@ -w $(shell echo $* | cut -dx -f1) -h $(shell echo $* | cut -dx -f2) ;
 
 $(THEME)/%/status/$(QL_MC_DEST): $(QL_MC_SOURCE)
 	mkdir -p $(dir $@)
-	inkscape $< -o $@ -w $(shell echo $* | cut -dx -f1) -h $(shell echo $* | cut -dx -f2) ;
+	inkscape $< --export-filename $@ -w $(shell echo $* | cut -dx -f1) -h $(shell echo $* | cut -dx -f2) ;
 
 $(SYMBOLIC_TARGET): $(SYMBOLIC_SRC)
 	cp $(@:.svg=.svg.in) "_temp.svg"

--- a/quodlibet/images/Makefile
+++ b/quodlibet/images/Makefile
@@ -38,15 +38,15 @@ png-%: $(THEME)/%/apps/$(QL_DEST) $(THEME)/%/apps/$(EF_DEST) $(THEME)/%/status/$
 
 $(THEME)/%/apps/$(QL_DEST): $(QL_SOURCE)
 	mkdir -p $(dir $@)
-	inkscape $< --export-png $@ -w $(shell echo $* | cut -dx -f1) -h $(shell echo $* | cut -dx -f2) ;
+	inkscape $< -o $@ -w $(shell echo $* | cut -dx -f1) -h $(shell echo $* | cut -dx -f2) ;
 
 $(THEME)/%/apps/$(EF_DEST): $(EF_SOURCE)
 	mkdir -p $(dir $@)
-	inkscape $< --export-png $@ -w $(shell echo $* | cut -dx -f1) -h $(shell echo $* | cut -dx -f2) ;
+	inkscape $< -o $@ -w $(shell echo $* | cut -dx -f1) -h $(shell echo $* | cut -dx -f2) ;
 
 $(THEME)/%/status/$(QL_MC_DEST): $(QL_MC_SOURCE)
 	mkdir -p $(dir $@)
-	inkscape $< --export-png $@ -w $(shell echo $* | cut -dx -f1) -h $(shell echo $* | cut -dx -f2) ;
+	inkscape $< -o $@ -w $(shell echo $* | cut -dx -f1) -h $(shell echo $* | cut -dx -f2) ;
 
 $(SYMBOLIC_TARGET): $(SYMBOLIC_SRC)
 	cp $(@:.svg=.svg.in) "_temp.svg"


### PR DESCRIPTION
Check-list
----------

 * [ ] There is a linked issue discussing the motivations for this feature or bugfix
 * [ ] I've added / updated documentation for any user-facing features.
 * [ ] Unit tests have been added where possible
 * [x] Performance seems to be comparable or better than current `master`


What this change is adding / fixing
-----------------------------------
 `--export-png` option in Inkscape is deprecated in favor of `--export-filename`

```
$ inkscape --help

File export:                        
  -o, --export-filename=EXPORT-FILENAME      Output file name (file type is guessed from extension)
```
See https://wiki.inkscape.org/wiki/Using_the_Command_Line#Via_export_options
