### PR TITLE
FAQ: where QL store data outdated

### DIFF
--- a/docs/guide/faq.rst
+++ b/docs/guide/faq.rst
@@ -13,17 +13,19 @@ Do you have a global filter in use? Check the *Browsers* tab in *Preferences*.
 Where does Quod Libet store all its metadata?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The short answer was originally: in ``~/.quodlibet``.
+The short answer was originally: in ``~/.quodlibet/``
 For newer versions of QL it's more complex:
 
+ * On all platforms, if the ``QUODLIBET_USERDIR`` environment variable is set, this will be used
  * On Windows, it will be in your user's ``AppData`` folder under ``Quod Libet``
    (except portable builds)
- * On OS X, it will be in ``~/.quodlibet``.
- * On Linux / Unix systems,
+ * On OS X, it will be in ``~/.quodlibet/``
+ * On Linux / Unix systems:
 
-    * if the ``QUODLIBET_USERDIR`` environment variable is set, this will be used
-    * else, ``$XDG_CONFIG_HOME/config`` will be used, if it exists
-    * else ``~/.quodlibet`` will be used still.
+    * if the ``XDG_CONFIG_HOME`` environment variable is set,
+      ``XDG_CONFIG_HOME/quodlibet/`` will be used
+    * else if folder ``~/.config/`` exists, ``~/.config/quodlibet/`` will be used
+    * else ``~/.quodlibet/`` will be used still
 
 
 Under there you'll find all sorts of things,


### PR DESCRIPTION
What this change is adding / fixing
-----------------------------------

If I understand well the code in _main.py and path.py, the doc is outdated. Am I right?
I updated the faq to what I understand (except for windows-portable).
By the way, I added an trailing slash to show explicitly that `quodlibet` is a directory and not a single config file.

```
def get_user_dir():
    """Place where QL saves its state, database, config etc."""

    if os.name == "nt":
        USERDIR = os.path.join(windows.get_appdata_dir(), "Quod Libet")
    elif is_osx():
        USERDIR = os.path.join(os.path.expanduser("~"), ".quodlibet")
    else:
        USERDIR = os.path.join(xdg_get_config_home(), "quodlibet")

        if not os.path.exists(USERDIR):
            tmp = os.path.join(os.path.expanduser("~"), ".quodlibet")
            if os.path.exists(tmp):
                USERDIR = tmp

    if 'QUODLIBET_USERDIR' in environ:
        USERDIR = environ['QUODLIBET_USERDIR']

    if build.BUILD_TYPE == u"windows-portable":
        USERDIR = os.path.normpath(os.path.join(
            os.path.dirname(path2fsn(sys.executable)), "..", "..", "config"))

    # XXX: users shouldn't assume the dir is there, but we currently do in
    # some places
    mkdir(USERDIR, 0o750)

    return USERDIR


def xdg_get_config_home():
    if os.name == "nt":
        from gi.repository import GLib
        return glib2fsn(GLib.get_user_config_dir())

    data_home = os.getenv("XDG_CONFIG_HOME")
    if data_home:
        return os.path.abspath(data_home)
    else:
        return os.path.join(os.path.expanduser("~"), ".config")

```
