### PR TITLE
New config option for search bar historic count

### DIFF
--- a/docs/guide/faq.rst
+++ b/docs/guide/faq.rst
@@ -13,19 +13,17 @@ Do you have a global filter in use? Check the *Browsers* tab in *Preferences*.
 Where does Quod Libet store all its metadata?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The short answer was originally: in ``~/.quodlibet/``
+The short answer was originally: in ``~/.quodlibet``.
 For newer versions of QL it's more complex:
 
- * On all platforms, if the ``QUODLIBET_USERDIR`` environment variable is set, this will be used
  * On Windows, it will be in your user's ``AppData`` folder under ``Quod Libet``
    (except portable builds)
- * On OS X, it will be in ``~/.quodlibet/``
- * On Linux / Unix systems:
+ * On OS X, it will be in ``~/.quodlibet``.
+ * On Linux / Unix systems,
 
-    * if the ``XDG_CONFIG_HOME`` environment variable is set,
-      ``XDG_CONFIG_HOME/quodlibet/`` will be used
-    * else if folder ``~/.config/`` exists, ``~/.config/quodlibet/`` will be used
-    * else ``~/.quodlibet/`` will be used still
+    * if the ``QUODLIBET_USERDIR`` environment variable is set, this will be used
+    * else, ``$XDG_CONFIG_HOME/config`` will be used, if it exists
+    * else ``~/.quodlibet`` will be used still.
 
 
 Under there you'll find all sorts of things,

--- a/quodlibet/config.py
+++ b/quodlibet/config.py
@@ -111,6 +111,9 @@ INITIAL: Dict[str, Dict[str, str]] = {
         # search bar text
         "query_text": "",
 
+        # search bar historic entries count
+        "searchbar_historic_entries": "8",
+
         # panes in paned browser
         "panes":
             "~people\t<~year|[b][i]<~year>[/i][/b] - ><album>",

--- a/quodlibet/ext/events/advanced_preferences.py
+++ b/quodlibet/ext/events/advanced_preferences.py
@@ -138,8 +138,8 @@ class AdvancedPreferences(EventPlugin):
                  "(restart required)")),
             text_config(
                 "settings", "datecolumn_timestamp_format",
-                "DateColumn timestamp format",
-                "A timestamp format, e.g. %Y%m%d %X "),
+                "DateColumn timestamp format:",
+                "A timestamp format, e.g. %Y%m%d %X"),
             text_config(
                 "settings", "scrollbar_always_visible",
                 "Scrollbars always visible:",
@@ -153,7 +153,7 @@ class AdvancedPreferences(EventPlugin):
                 "(restart required)"),
             text_config(
                 "settings", "query_font_size",
-                "Search input font size",
+                "Search input font size:",
                 "Size to apply to the search query entry, "
                 "in any Pango CSS units, e.g. '100%', '1rem'. (restart required)"),
             boolean_config(
@@ -162,17 +162,17 @@ class AdvancedPreferences(EventPlugin):
                 "It's not the default on win/macOS (restart required)"),
             text_config(
                 "browsers", "ignored_characters",
-                "Ignored characters: ",
+                "Ignored characters:",
                 "Characters to ignore in queries"),
             boolean_config(
                 "settings", "plugins_window_on_top",
-                "Plugin window on top: ",
+                "Plugin window on top:",
                 "Toggles whether the plugin window appears on top of others"),
             int_config(
                 "autosave", "queue_interval",
-                "Queue autosave interval: ",
+                "Queue autosave interval:",
                 ("Longest time between play queue auto-saves, or 0 for disabled. "
-                 "(restart required")),
+                 "(restart required)")),
             int_config(
                 "browsers", "searchbar_historic_entries",
                 "Number of history entries in the search bar:",

--- a/quodlibet/ext/events/advanced_preferences.py
+++ b/quodlibet/ext/events/advanced_preferences.py
@@ -172,7 +172,11 @@ class AdvancedPreferences(EventPlugin):
                 "autosave", "queue_interval",
                 "Queue autosave interval: ",
                 ("Longest time between play queue auto-saves, or 0 for disabled. "
-                 "(restart required"))
+                 "(restart required")),
+            int_config(
+                "browsers", "searchbar_historic_entries",
+                "Number of history entries in the search bar:",
+                "8 by default (restart advised)")
         ]
 
         for (row, (label, widget, button)) in enumerate(rows):

--- a/quodlibet/ext/events/advanced_preferences.py
+++ b/quodlibet/ext/events/advanced_preferences.py
@@ -176,7 +176,7 @@ class AdvancedPreferences(EventPlugin):
             int_config(
                 "browsers", "searchbar_historic_entries",
                 "Number of history entries in the search bar:",
-                "8 by default (restart advised)")
+                "A positive integer, or 0 to disable historic. 8 by default (restart advised)")
         ]
 
         for (row, (label, widget, button)) in enumerate(rows):

--- a/quodlibet/qltk/searchbar.py
+++ b/quodlibet/qltk/searchbar.py
@@ -52,10 +52,10 @@ class SearchBarBox(Gtk.Box):
             filename = os.path.join(
                 quodlibet.get_user_dir(), "lists", "queries")
 
-        combo = ComboBoxEntrySave(filename, count=8,
-                                  validator=validator,
-                                  title=_("Saved Searches"),
-                                  edit_title=_(u"Edit saved searches…"))
+        combo = ComboBoxEntrySave(
+            filename, count=config.getint("browsers", "searchbar_historic_entries", 8),
+            validator=validator, title=_("Saved Searches"),
+            edit_title=_(u"Edit saved searches…"))
 
         self.__deferred_changed = DeferredSignal(
             self._filter_changed, timeout=timeout, owner=self)


### PR DESCRIPTION
Check-list
----------

 * [x] There is a linked issue discussing the motivations for this feature or bugfix
 * [ ] Unit tests have been added where possible
 * [ ] I've added / updated documentation for any user-facing features.
 * [x] Performance seems to be comparable or better than current `master`


What this change is adding / fixing
-----------------------------------
Add a new option to set in config file how many entries are saved in the search bar.
See also issue #3884