### PR TITLE
New config option for search bar historic count

### DIFF
--- a/quodlibet/config.py
+++ b/quodlibet/config.py
@@ -111,6 +111,9 @@ INITIAL: Dict[str, Dict[str, str]] = {
         # search bar text
         "query_text": "",
 
+        # number of history entries in the search bar
+        "searchbar_historic_entries": "8",
+
         # panes in paned browser
         "panes":
             "~people\t<~year|[b][i]<~year>[/i][/b] - ><album>",

--- a/quodlibet/ext/events/advanced_preferences.py
+++ b/quodlibet/ext/events/advanced_preferences.py
@@ -139,8 +139,8 @@ class AdvancedPreferences(EventPlugin):
                  "(restart required)")),
             text_config(
                 "settings", "datecolumn_timestamp_format",
-                "DateColumn timestamp format",
-                "A timestamp format, e.g. %Y%m%d %X "),
+                "DateColumn timestamp format:",
+                "A timestamp format, e.g. %Y%m%d %X"),
             text_config(
                 "settings", "scrollbar_always_visible",
                 "Scrollbars always visible:",
@@ -154,7 +154,7 @@ class AdvancedPreferences(EventPlugin):
                 "(restart required)"),
             text_config(
                 "settings", "query_font_size",
-                "Search input font size",
+                "Search input font size:",
                 "Size to apply to the search query entry, "
                 "in any Pango CSS units, e.g. '100%', '1rem'. (restart required)"),
             boolean_config(
@@ -163,17 +163,17 @@ class AdvancedPreferences(EventPlugin):
                 "It's not the default on win/macOS (restart required)"),
             text_config(
                 "browsers", "ignored_characters",
-                "Ignored characters: ",
+                "Ignored characters:",
                 "Characters to ignore in queries"),
             boolean_config(
                 "settings", "plugins_window_on_top",
-                "Plugin window on top: ",
+                "Plugin window on top:",
                 "Toggles whether the plugin window appears on top of others"),
             int_config(
                 "autosave", "queue_interval",
-                "Queue autosave interval: ",
+                "Queue autosave interval:",
                 ("Longest time between play queue auto-saves, or 0 for disabled. "
-                 "(restart required")),
+                 "(restart required)")),
             int_config(
                 "browsers", "searchbar_historic_entries",
                 "Number of history entries in the search bar:",

--- a/quodlibet/ext/events/advanced_preferences.py
+++ b/quodlibet/ext/events/advanced_preferences.py
@@ -1,6 +1,7 @@
 # Copyright 2015    Christoph Reiter
 #           2016-21 Nick Boultbee
 #           2019    Peter Strulo
+#           2022    Jej@github
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -172,7 +173,11 @@ class AdvancedPreferences(EventPlugin):
                 "autosave", "queue_interval",
                 "Queue autosave interval: ",
                 ("Longest time between play queue auto-saves, or 0 for disabled. "
-                 "(restart required"))
+                 "(restart required")),
+            int_config(
+                "browsers", "searchbar_historic_entries",
+                "Number of history entries in the search bar:",
+                "8 by default (restart advised)")
         ]
 
         for (row, (label, widget, button)) in enumerate(rows):

--- a/quodlibet/qltk/searchbar.py
+++ b/quodlibet/qltk/searchbar.py
@@ -52,10 +52,10 @@ class SearchBarBox(Gtk.Box):
             filename = os.path.join(
                 quodlibet.get_user_dir(), "lists", "queries")
 
-        combo = ComboBoxEntrySave(filename, count=8,
-                                  validator=validator,
-                                  title=_("Saved Searches"),
-                                  edit_title=_(u"Edit saved searches…"))
+        combo = ComboBoxEntrySave(
+            filename, count=config.getint("browsers", "searchbar_historic_entries", 8),
+            validator=validator, title=_("Saved Searches"),
+            edit_title=_(u"Edit saved searches…"))
 
         self.__deferred_changed = DeferredSignal(
             self._filter_changed, timeout=timeout, owner=self)

--- a/quodlibet/qltk/searchbar.py
+++ b/quodlibet/qltk/searchbar.py
@@ -52,10 +52,11 @@ class SearchBarBox(Gtk.Box):
             filename = os.path.join(
                 quodlibet.get_user_dir(), "lists", "queries")
 
+        historic_entries_count = config.getint("browsers", "searchbar_historic_entries")
+
         combo = ComboBoxEntrySave(
-            filename, count=config.getint("browsers", "searchbar_historic_entries", 8),
-            validator=validator, title=_("Saved Searches"),
-            edit_title=_(u"Edit saved searches…"))
+            filename, count=historic_entries_count, validator=validator,
+            title=_("Saved Searches"), edit_title=_(u"Edit saved searches…"))
 
         self.__deferred_changed = DeferredSignal(
             self._filter_changed, timeout=timeout, owner=self)


### PR DESCRIPTION
Check-list
----------

 * [x] There is a linked issue discussing the motivations for this feature or bugfix
 * [ ] Unit tests have been added where possible
 * [ ] I've added / updated documentation for any user-facing features.
 * [x] Performance seems to be comparable or better than current `master`


What this change is adding / fixing
-----------------------------------
Add a new option to set in config file how many entries are saved in the search bar.
See also issue #3884