### PR TITLE
Fix Soundcloud with authenticated streaming (and more)

### DIFF
--- a/quodlibet/browsers/soundcloud/main.py
+++ b/quodlibet/browsers/soundcloud/main.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2021 Nick Boultbee
+# Copyright 2016-2022 Nick Boultbee
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -308,8 +308,8 @@ class SoundcloudBrowser(Browser, util.InstanceTracker):
     def __query_changed(self, bar, text, restore=False):
         try:
             self.__filter = SoundcloudQuery(text, self.STAR)
-            self.library.query_with_refresh(text)
-        except SoundcloudQuery.error as e:
+            self.library.query_with_refresh(self.__filter)
+        except SoundcloudQuery.Error as e:
             print_d("Couldn't parse query: %s" % e)
         else:
             print_d("Got terms from query: %s" % (self.__filter.terms,))
@@ -438,7 +438,7 @@ class SoundcloudBrowser(Browser, util.InstanceTracker):
         name = data.username
         self.login_state = State.LOGGED_IN
         self.update_connect_button()
-        self._refresh_online_filters()
+        self.activate()
         msg = Message(Gtk.MessageType.INFO, app.window, _("Connected"),
                       _("Quod Libet is now connected, %s!") % name)
         msg.run()

--- a/quodlibet/browsers/soundcloud/util.py
+++ b/quodlibet/browsers/soundcloud/util.py
@@ -28,7 +28,7 @@ class Wrapper:
         self._raw = data
         assert isinstance(data, dict)
 
-        self.data = {}
+        self.data: Dict = {}
         for k, v in data.items():
             if isinstance(v, Dict):
                 self.data[k] = Wrapper(v)
@@ -58,9 +58,8 @@ def json_callback(wrapped):
 
     def _callback(self, message, json, data):
         if json is None:
-            print_d('Invalid JSON ({message.status_code}): '
-                    '{message.response_body.data} (request: {data})'
-                    .format(**locals()))
+            print_d(f"[HTTP {message.status_code}] Invalid / empty JSON. "
+                    f"Body: {message.response_body.data!r} (request: {data})")
             return
         if 'errors' in json:
             raise ValueError("Got HTTP %d (%s)" % (message.status_code,
@@ -68,7 +67,7 @@ def json_callback(wrapped):
         if 'error' in json:
             raise ValueError("Got HTTP %d (%s)" % (message.status_code,
                                                    json['error']))
-        return wrapped(self, json)
+        return wrapped(self, json, data)
 
     return _callback
 

--- a/quodlibet/library/song.py
+++ b/quodlibet/library/song.py
@@ -3,7 +3,7 @@
 # the Free Software Foundation; either version 2 of the License, or
 # (at your option) any later version.
 
-from typing import Optional, Set
+from typing import Optional, Set, TypeVar
 
 from quodlibet import util, print_d
 from quodlibet.formats import MusicFile, AudioFile
@@ -15,7 +15,10 @@ from quodlibet.query import Query
 from quodlibet.util.path import normalize_path
 
 
-class SongLibrary(Library[K, AudioFile], PicklingMixin):
+V = TypeVar("V", bound=AudioFile)
+
+
+class SongLibrary(Library[K, V], PicklingMixin):
     """A library for songs.
 
     Items in this kind of library must support (roughly) the AudioFile

--- a/quodlibet/util/http.py
+++ b/quodlibet/util/http.py
@@ -1,5 +1,5 @@
 # Copyright 2013 Simonas Kazlauskas
-#        2016-21 Nick Boultbee
+#        2016-22 Nick Boultbee
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -156,7 +156,7 @@ class HTTPRequest(GObject.Object):
                                   self.cancellable, spliced, None)
 
 
-FailureCallback = Callable[[HTTPRequest, Exception], None]
+FailureCallback = Callable[[HTTPRequest, Exception, Any], None]
 
 
 def download(message: Soup.Message, cancellable: Gio.Cancellable, callback: Callable,
@@ -185,7 +185,7 @@ def download(message: Soup.Message, cancellable: Gio.Cancellable, callback: Call
     request.connect('received', received)
     request.connect('sent', lambda r, m: r.receive())
     if failure_callback:
-        request.connect('send-failure', failure_callback)
+        request.connect('send-failure', failure_callback, data)
     request.send()
 
 

--- a/tests/test_soundcloudFile.py
+++ b/tests/test_soundcloudFile.py
@@ -1,4 +1,4 @@
-# Copyright 2016-21 Nick Boultbee
+# Copyright 2016-22 Nick Boultbee
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -9,8 +9,7 @@ from collections import defaultdict
 
 from quodlibet import config
 from quodlibet.browsers.soundcloud.api import SoundcloudApiClient
-from quodlibet.browsers.soundcloud.library import SoundcloudLibrary, \
-    SoundcloudFile
+from quodlibet.browsers.soundcloud.library import SoundcloudLibrary, SoundcloudFile
 from tests import TestCase
 
 TRACK_ID = 1234
@@ -25,10 +24,10 @@ class TSoundcloudFile(TestCase):
             self.favoritings = defaultdict(int)
             self.unfavoritings = defaultdict(int)
 
-        def _on_favorited(self, json):
+        def _on_favorited(self, json, _data):
             super()._on_favorited(json)
 
-        def put_favorite(self, track_id):
+        def save_favorite(self, track_id):
             self.favoritings[track_id] += 1
 
         def remove_favorite(self, track_id):
@@ -43,28 +42,28 @@ class TSoundcloudFile(TestCase):
         self.client = self.FakeClient()
 
     def test_favoriting(self):
-        cl = self.client
-        song = SoundcloudFile("http://uri", TRACK_ID, False, cl)
+        client = self.client
+        song = SoundcloudFile("http://uri", TRACK_ID, client, favorite=False)
         self.failIf(song.has_rating)
         song['~#rating'] = 1.0
         self.failUnless(song.has_rating)
         self.failUnlessEqual(song("~#rating"), 1.0)
         song.write()
         self.failUnless(song.favorite)
-        self.failUnlessEqual(cl.favoritings[TRACK_ID], 1)
-        self.failUnlessEqual(cl.unfavoritings[TRACK_ID], 0)
+        self.failUnlessEqual(client.favoritings[TRACK_ID], 1)
+        self.failUnlessEqual(client.unfavoritings[TRACK_ID], 0)
         song.write()
-        self.failUnlessEqual(cl.favoritings[TRACK_ID], 1)
+        self.failUnlessEqual(client.favoritings[TRACK_ID], 1)
 
     def test_unfavoriting(self):
-        cl = self.client
-        song = SoundcloudFile("http://uri", TRACK_ID, True, cl)
+        client = self.client
+        song = SoundcloudFile("http://uri", TRACK_ID, client, favorite=True)
         self.failUnless(song.has_rating)
         self.failUnlessEqual(song("~#rating"), 1.0)
         song['~#rating'] = 0.2
         song.write()
         self.failIf(song.favorite)
-        self.failUnlessEqual(cl.unfavoritings[TRACK_ID], 1)
-        self.failUnlessEqual(cl.favoritings[TRACK_ID], 0)
+        self.failUnlessEqual(client.unfavoritings[TRACK_ID], 1)
+        self.failUnlessEqual(client.favoritings[TRACK_ID], 0)
         song.write()
-        self.failUnlessEqual(cl.unfavoritings[TRACK_ID], 1)
+        self.failUnlessEqual(client.unfavoritings[TRACK_ID], 1)

--- a/tests/test_soundcloudLibrary.py
+++ b/tests/test_soundcloudLibrary.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from quodlibet import config
 from quodlibet.browsers.soundcloud.api import SoundcloudApiClient
 from quodlibet.browsers.soundcloud.library import SoundcloudLibrary
+from quodlibet.browsers.soundcloud.query import SoundcloudQuery
 from tests import TestCase
 
 PERMALINK = "https://soundcloud.com/"
@@ -48,7 +49,7 @@ class TSoundcloudLibrary(TestCase):
 
     def test_parse(self):
         lib = self.lib
-        lib.query_with_refresh("dummy search")
+        lib.query_with_refresh(SoundcloudQuery("dummy search"))
         songs = list(lib._contents.values())
         assert len(songs) == 1
         s = songs[0]
@@ -64,7 +65,7 @@ class TSoundcloudLibrary(TestCase):
 
     def test_artwork_url(self):
         lib = SoundcloudLibrary(self.FakeClient())
-        lib.query_with_refresh("")
+        lib.query_with_refresh(SoundcloudQuery(""))
         s = list(lib._contents.values())[0]
         url = s("artwork_url")
         assert url == "https://i1.sndcdn.com/artworks-000121689963-0b0pdr-t500x500.jpg"


### PR DESCRIPTION
 * Support [authenticated] playing again via `stream_url`(though via lots of new requests) :tada:
 * Use undeprecated endpoints (`/likes/tracks` etc rather than `/me/favorites`)
 * Don't logout with 403 - it seems valid sometimes that some tracks don't allow you certain things
 * Remove support for downloadable tracks - this no longer works anyway
 * Fix some invalid exception handling
 * Avoid constructing one extra query every time user types
 * Don't dump _all_ comment responses
 * Improve library typing

Fixes #3892 
Fixes #3858