### PR TITLE
Add an option to set how missing titles are displayed

### DIFF
--- a/quodlibet/config.py
+++ b/quodlibet/config.py
@@ -177,8 +177,8 @@ INITIAL: Dict[str, Dict[str, str]] = {
         # show "all albums" in covergrid view
         "covergrid_all": "1",
 
-        # Pattern to build the track title when title tag is missing
-        "missing_title_pattern": "{stem} [untitled {ext}]",
+        # Template to build the track title when title tag is missing
+        "missing_title_template": "{stem} [untitled {ext}]",
     },
 
     # Kind of a dumping ground right now, should probably be

--- a/quodlibet/config.py
+++ b/quodlibet/config.py
@@ -178,7 +178,7 @@ INITIAL: Dict[str, Dict[str, str]] = {
         "covergrid_all": "1",
 
         # Pattern to build the track title when title tag is missing
-        "missing_title_pattern": "{basename} [untitled]",
+        "missing_title_pattern": "{stem} [untitled {ext}]",
     },
 
     # Kind of a dumping ground right now, should probably be

--- a/quodlibet/config.py
+++ b/quodlibet/config.py
@@ -2,6 +2,7 @@
 #           2009-2020 Nick Boultbee
 #           2011-2014 Christoph Reiter
 #           2018-2019 Peter Strulo
+#                2022 Jej@github
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -175,6 +176,9 @@ INITIAL: Dict[str, Dict[str, str]] = {
 
         # show "all albums" in covergrid view
         "covergrid_all": "1",
+
+        # Pattern to build the track title when title tag is missing
+        "missing_title_pattern": "{basename} [untitled]",
     },
 
     # Kind of a dumping ground right now, should probably be

--- a/quodlibet/config.py
+++ b/quodlibet/config.py
@@ -178,7 +178,7 @@ INITIAL: Dict[str, Dict[str, str]] = {
         "covergrid_all": "1",
 
         # Template to build the track title when title tag is missing
-        "missing_title_template": "{stem} [untitled {ext}]",
+        "missing_title_template": "<~basename:humanized> [untitled <~format>]",
     },
 
     # Kind of a dumping ground right now, should probably be

--- a/quodlibet/config.py
+++ b/quodlibet/config.py
@@ -178,7 +178,7 @@ INITIAL: Dict[str, Dict[str, str]] = {
         "covergrid_all": "1",
 
         # Template to build the track title when title tag is missing
-        "missing_title_template": "<~basename:humanized> [untitled <~format>]",
+        "missing_title_template": "<~basename> [untitled <~format>]",
     },
 
     # Kind of a dumping ground right now, should probably be

--- a/quodlibet/ext/events/advanced_preferences.py
+++ b/quodlibet/ext/events/advanced_preferences.py
@@ -220,11 +220,11 @@ class AdvancedPreferences(EventPlugin):
                  "its total duration"),
                 label_value_callback=lambda value: f"{int(value * 100)}%"),
             text_config(
-                "browsers", "missing_title_pattern",
-                "Missing title pattern string:",
-                ("Pattern for building title of tracks when title tag is missing. "
+                "browsers", "missing_title_template",
+                "Missing title template string:",
+                ("Template for building title of tracks when title tag is missing. "
                  "{basename} is expanded to the filename of the track, "
-                 "{stem} is the filename without extension, ."
+                 "{stem} is the filename without extension, "
                  "{ext} is the extension (so that {basename}=={stem}.{ext})"))
         ]
 

--- a/quodlibet/ext/events/advanced_preferences.py
+++ b/quodlibet/ext/events/advanced_preferences.py
@@ -218,7 +218,12 @@ class AdvancedPreferences(EventPlugin):
                 "Minimum length proportion to consider a track as played:",
                 ("Consider a track played after listening to this proportion of "
                  "its total duration"),
-                label_value_callback=lambda value: f"{int(value * 100)}%")
+                label_value_callback=lambda value: f"{int(value * 100)}%"),
+            text_config(
+                "browsers", "missing_title_pattern",
+                "Missing title pattern string:",
+                ("Pattern for building title of tracks when title tag is missing. "
+                 "{basename} is replaced by the file name of the track."))
         ]
 
         for (row, (label, widget, button)) in enumerate(rows):

--- a/quodlibet/ext/events/advanced_preferences.py
+++ b/quodlibet/ext/events/advanced_preferences.py
@@ -223,9 +223,9 @@ class AdvancedPreferences(EventPlugin):
                 "browsers", "missing_title_template",
                 "Missing title template string:",
                 ("Template for building title of tracks when title tag is missing. "
-                 "{basename} is expanded to the filename of the track, "
-                 "{stem} is the filename without extension, "
-                 "{ext} is the extension (so that {basename}=={stem}.{ext})"))
+                 "Tags are allowed, like <~basename> <~dirname> <~format> <~length> "
+                 "<~#bitrate>, etc. See tags documentation for details.")
+            )
         ]
 
         for (row, (label, widget, button)) in enumerate(rows):

--- a/quodlibet/ext/events/advanced_preferences.py
+++ b/quodlibet/ext/events/advanced_preferences.py
@@ -223,7 +223,9 @@ class AdvancedPreferences(EventPlugin):
                 "browsers", "missing_title_pattern",
                 "Missing title pattern string:",
                 ("Pattern for building title of tracks when title tag is missing. "
-                 "{basename} is replaced by the file name of the track."))
+                 "{basename} is expanded to the filename of the track, "
+                 "{stem} is the filename without extension, ."
+                 "{ext} is the extension (so that {basename}=={stem}.{ext})"))
         ]
 
         for (row, (label, widget, button)) in enumerate(rows):

--- a/quodlibet/formats/_audio.py
+++ b/quodlibet/formats/_audio.py
@@ -521,17 +521,17 @@ class AudioFile(dict, ImageContainer, HasKey):
         elif key == "title":
             title = dict.get(self, "title")
             if title is None:
-                # build a title with missing_title_pattern option
+                # build a title with missing_title_template option
                 basename = decode_value("~basename", self("~basename"))
                 stem = stem_of_file_name(basename)
                 extension = extension_of_file_name(basename)[1:]
-                unknown_track_pattern = _(config.gettext(
-                    "browsers", "missing_title_pattern"))
+                unknown_track_template = _(config.gettext(
+                    "browsers", "missing_title_template"))
                 try:
-                    title = unknown_track_pattern.format(
+                    title = unknown_track_template.format(
                     basename=basename, stem=stem, ext=extension)
                 except KeyError:
-                    # fallback to filename if user provided a bad pattern
+                    # fallback to filename if user provided a bad template
                     title = basename
             return title
         elif key in SORT_TO_TAG:

--- a/quodlibet/formats/_audio.py
+++ b/quodlibet/formats/_audio.py
@@ -397,6 +397,10 @@ class AudioFile(dict, ImageContainer, HasKey):
                                 connector))
             elif key == "basename":
                 return os.path.basename(self["~filename"]) or self["~filename"]
+            elif key == "basename:stem":
+                return stem_of_file_name(self("~basename"))
+            elif key == "basename:humanized":
+                return self("~basename:stem").replace('_', ' ').replace('-', ' ')
             elif key == "dirname":
                 return os.path.dirname(self["~filename"]) or self["~filename"]
             elif key == "uri":

--- a/quodlibet/formats/_audio.py
+++ b/quodlibet/formats/_audio.py
@@ -1,5 +1,6 @@
 # Copyright 2004-2005 Joe Wreschnig, Michael Urman
 #           2012-2021 Nick Boultbee
+#                2022 Jej@github
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -519,9 +520,10 @@ class AudioFile(dict, ImageContainer, HasKey):
         elif key == "title":
             title = dict.get(self, "title")
             if title is None:
-                basename = self("~basename")
-                return "%s [%s]" % (
-                    decode_value("~basename", basename), _("Unknown"))
+                basename = decode_value("~basename", self("~basename"))
+                unknown_track_pattern = _(config.gettext(
+                    "browsers", "missing_title_pattern"))
+                return unknown_track_pattern.format(basename=basename)
             else:
                 return title
         elif key in SORT_TO_TAG:

--- a/quodlibet/formats/_audio.py
+++ b/quodlibet/formats/_audio.py
@@ -397,10 +397,6 @@ class AudioFile(dict, ImageContainer, HasKey):
                                 connector))
             elif key == "basename":
                 return os.path.basename(self["~filename"]) or self["~filename"]
-            elif key == "basename:stem":
-                return stem_of_file_name(self("~basename"))
-            elif key == "basename:humanized":
-                return self("~basename:stem").replace('_', ' ').replace('-', ' ')
             elif key == "dirname":
                 return os.path.dirname(self["~filename"]) or self["~filename"]
             elif key == "uri":

--- a/quodlibet/formats/_audio.py
+++ b/quodlibet/formats/_audio.py
@@ -522,17 +522,17 @@ class AudioFile(dict, ImageContainer, HasKey):
             title = dict.get(self, "title")
             if title is None:
                 # build a title with missing_title_template option
-                basename = decode_value("~basename", self("~basename"))
-                stem = stem_of_file_name(basename)
-                extension = extension_of_file_name(basename)[1:]
                 unknown_track_template = _(config.gettext(
                     "browsers", "missing_title_template"))
+
+                from quodlibet.pattern import Pattern
                 try:
-                    title = unknown_track_template.format(
-                    basename=basename, stem=stem, ext=extension)
-                except KeyError:
-                    # fallback to filename if user provided a bad template
-                    title = basename
+                    pattern = Pattern(unknown_track_template)
+                except ValueError:
+                    title = decode_value("~basename", self("~basename"))
+                else:
+                    title = pattern % self
+
             return title
         elif key in SORT_TO_TAG:
             try:

--- a/quodlibet/formats/_audio.py
+++ b/quodlibet/formats/_audio.py
@@ -25,7 +25,8 @@ from quodlibet import _, print_d
 from quodlibet import util
 from quodlibet import config
 from quodlibet.util.path import mkdir, mtime, expanduser, normalize_path, \
-                                ismount, get_home_dir, RootPathFile
+                                ismount, get_home_dir, RootPathFile, \
+                                stem_of_file_name, extension_of_file_name
 from quodlibet.util.string import encode, decode, isascii
 from quodlibet.util.environment import is_windows
 
@@ -520,12 +521,19 @@ class AudioFile(dict, ImageContainer, HasKey):
         elif key == "title":
             title = dict.get(self, "title")
             if title is None:
+                # build a title with missing_title_pattern option
                 basename = decode_value("~basename", self("~basename"))
+                stem = stem_of_file_name(basename)
+                extension = extension_of_file_name(basename)[1:]
                 unknown_track_pattern = _(config.gettext(
                     "browsers", "missing_title_pattern"))
-                return unknown_track_pattern.format(basename=basename)
-            else:
-                return title
+                try:
+                    title = unknown_track_pattern.format(
+                    basename=basename, stem=stem, ext=extension)
+                except KeyError:
+                    # fallback to filename if user provided a bad pattern
+                    title = basename
+            return title
         elif key in SORT_TO_TAG:
             try:
                 return self[key]

--- a/quodlibet/formats/_audio.py
+++ b/quodlibet/formats/_audio.py
@@ -25,8 +25,7 @@ from quodlibet import _, print_d
 from quodlibet import util
 from quodlibet import config
 from quodlibet.util.path import mkdir, mtime, expanduser, normalize_path, \
-                                ismount, get_home_dir, RootPathFile, \
-                                stem_of_file_name, extension_of_file_name
+                                ismount, get_home_dir, RootPathFile
 from quodlibet.util.string import encode, decode, isascii
 from quodlibet.util.environment import is_windows
 

--- a/tests/test_formats__audio.py
+++ b/tests/test_formats__audio.py
@@ -15,7 +15,8 @@ from quodlibet.formats import decode_value, MusicFile, FILESYSTEM_TAGS
 from quodlibet.formats._audio import NUMERIC_ZERO_DEFAULT
 from quodlibet.util.environment import is_windows
 from quodlibet.util.path import (normalize_path, mkdir, get_home_dir, unquote,
-                                 escape_filename, RootPathFile)
+                                 escape_filename, RootPathFile,
+                                 stem_of_file_name, extension_of_file_name)
 from quodlibet.util.tags import _TAGS as TAGS
 from senf import fsnative, fsn2text, bytes2fsn, mkstemp, mkdtemp
 from tests import TestCase, get_data_path, init_fake_app, destroy_fake_app
@@ -162,9 +163,13 @@ class TAudioFile(TestCase):
 
         assert self.quux("~basename")
         assert self.quux("~dirname") == os.path.dirname(self.quux("~filename"))
-        assert self.quux("title") == \
-            config.gettext('browsers', 'missing_title_template').format(
-                basename=fsn2text(self.quux("~basename")))
+
+        basename = fsn2text(self.quux("~basename"))
+        stem = stem_of_file_name(basename)
+        extension = extension_of_file_name(basename)[1:]
+        assert self.quux("title") == config.gettext(
+            'browsers', 'missing_title_template').format(
+            basename=basename, stem=stem, ext=extension)
 
         self.failUnlessEqual(bar_1_1("~#disc"), 1)
         self.failUnlessEqual(bar_1_2("~#disc"), 1)

--- a/tests/test_formats__audio.py
+++ b/tests/test_formats__audio.py
@@ -163,7 +163,8 @@ class TAudioFile(TestCase):
         assert self.quux("~basename")
         assert self.quux("~dirname") == os.path.dirname(self.quux("~filename"))
         assert self.quux("title") == \
-            "%s [Unknown]" % fsn2text(self.quux("~basename"))
+            config.gettext('browsers', 'missing_title_pattern').format(
+                basename=fsn2text(self.quux("~basename")))
 
         self.failUnlessEqual(bar_1_1("~#disc"), 1)
         self.failUnlessEqual(bar_1_2("~#disc"), 1)

--- a/tests/test_formats__audio.py
+++ b/tests/test_formats__audio.py
@@ -163,7 +163,7 @@ class TAudioFile(TestCase):
         assert self.quux("~basename")
         assert self.quux("~dirname") == os.path.dirname(self.quux("~filename"))
         assert self.quux("title") == \
-            config.gettext('browsers', 'missing_title_pattern').format(
+            config.gettext('browsers', 'missing_title_template').format(
                 basename=fsn2text(self.quux("~basename")))
 
         self.failUnlessEqual(bar_1_1("~#disc"), 1)

--- a/tests/test_formats__audio.py
+++ b/tests/test_formats__audio.py
@@ -15,8 +15,7 @@ from quodlibet.formats import decode_value, MusicFile, FILESYSTEM_TAGS
 from quodlibet.formats._audio import NUMERIC_ZERO_DEFAULT
 from quodlibet.util.environment import is_windows
 from quodlibet.util.path import (normalize_path, mkdir, get_home_dir, unquote,
-                                 escape_filename, RootPathFile,
-                                 stem_of_file_name, extension_of_file_name)
+                                 escape_filename, RootPathFile)
 from quodlibet.util.tags import _TAGS as TAGS
 from senf import fsnative, fsn2text, bytes2fsn, mkstemp, mkdtemp
 from tests import TestCase, get_data_path, init_fake_app, destroy_fake_app
@@ -163,13 +162,8 @@ class TAudioFile(TestCase):
 
         assert self.quux("~basename")
         assert self.quux("~dirname") == os.path.dirname(self.quux("~filename"))
-
-        basename = fsn2text(self.quux("~basename"))
-        stem = stem_of_file_name(basename)
-        extension = extension_of_file_name(basename)[1:]
-        assert self.quux("title") == config.gettext(
-            'browsers', 'missing_title_template').format(
-            basename=basename, stem=stem, ext=extension)
+        assert self.quux("title") == \
+            "%s [untitled Unknown Audio File]" % fsn2text(self.quux("~basename"))
 
         self.failUnlessEqual(bar_1_1("~#disc"), 1)
         self.failUnlessEqual(bar_1_2("~#disc"), 1)


### PR DESCRIPTION
Check-list
----------

 * [x] There is a linked issue discussing the motivations for this feature or bugfix
 * [x] Unit tests have been added where possible
 * [ ] I've added / updated documentation for any user-facing features.
 * [x] Performance seems to be comparable or better than current `master`

What this change is adding / fixing
-----------------------------------
See issue #3906 for details.
Fixes #3872
Fixes #3906
