### PR TITLE
Dequeue after song ended

### DIFF
--- a/quodlibet/qltk/songmodel.py
+++ b/quodlibet/qltk/songmodel.py
@@ -25,13 +25,13 @@ class PlaylistMux:
     def __init__(self, player, q, pl):
         self.q = q
         self.pl = pl
-        self._id = player.connect('song-started', self.__song_started)
+        self._id = player.connect('song-ended', self.__song_ended)
         self._player = player
 
     def destroy(self):
         self._player.disconnect(self._id)
 
-    def __song_started(self, player, song):
+    def __song_ended(self, player, song, stopped):
         if song is not None and self.q.sourced:
             iter = self.q.find(song)
             keep_song = config.getboolean("memory", "queue_keep_songs", False)

--- a/quodlibet/qltk/songmodel.py
+++ b/quodlibet/qltk/songmodel.py
@@ -33,12 +33,13 @@ class PlaylistMux:
 
     def __song_ended(self, player, song, stopped):
         if song is not None and self.q.sourced:
-            iter = self.q.find(song)
             keep_song = config.getboolean("memory", "queue_keep_songs", False)
-            if iter and not keep_song:
-                self.q.remove(iter)
-                # we don't call _check_sourced here since we want the queue
-                # to stay sourced even if no current song is left
+            if not keep_song:
+                iter = self.q.find(song)
+                if iter:
+                    self.q.remove(iter)
+                    # we don't call _check_sourced here since we want the queue
+                    # to stay sourced even if no current song is left
 
     @property
     def current(self):

--- a/quodlibet/qltk/songmodel.py
+++ b/quodlibet/qltk/songmodel.py
@@ -32,7 +32,7 @@ class PlaylistMux:
         self._player.disconnect(self._id)
 
     def __song_ended(self, player, song, stopped):
-        if song is not None and self.q.sourced:
+        if song is not None:
             keep_song = config.getboolean("memory", "queue_keep_songs", False)
             if not keep_song:
                 iter = self.q.find(song)


### PR DESCRIPTION
Check-list
----------

 * [ ] There is a linked issue discussing the motivations for this feature or bugfix
 * [ ] Unit tests have been added where possible
 * [ ] I've added / updated documentation for any user-facing features.
 * [x] Performance seems to be comparable or better than current `master`


What this change is adding / fixing
-----------------------------------
I am trying to change the behaviour of the playing queue.

Currently, a track is dequeued as soon it starts. I am still a bit confused about this way to do. If I want to rate the song, most of the time I think the current song is a the top of the list but I am wrong. Because the current song disappeared just when it started. The song at the top of the list is the next one, not the current.

I would like to propose the opposite behaviour. The song is dequeue when it finishes. When it's playing, the song remains at the top of the list. So it's easy to rate and see what track of the queue is played.

It's working this way with this patch, even if I didn't really understand all the tweaks about the song workflow in QL... So much calls, tests, events emitted on different classes, etc. I was lost. I just spotted where the track is dequeued in `songmodel.py`.

I had to remove the `self.q.sourced` condition (I didn't understand what is this sourced property) so that the last track of the queue is well removed. If I keep the condition, the last track loops forever and is never removed after it ends.

So, if someone can help, confirm it's ok or not...and wants to work on this feature too, you are welcome!

Read you.

