### PR TITLE
Don't clear queue when set_explicit returns None

### DIFF
--- a/quodlibet/qltk/songmodel.py
+++ b/quodlibet/qltk/songmodel.py
@@ -119,8 +119,9 @@ class PlaylistMux:
             assert source in (self.pl, self.q)
             if source is self.q:
                 main, other = other, main
-        other.go_to(None)
         res = main.go_to(song, explicit)
+        if res is not None or not explicit:
+            other.go_to(None)
         self._check_sourced()
         return res
 

--- a/tests/test_qltk_songmodel.py
+++ b/tests/test_qltk_songmodel.py
@@ -488,5 +488,19 @@ class TPlaylistMux(TestCase):
         self.next()
         self.assertTrue(self.pl.sourced)
 
+    def test_queue_preserved_when_setexplicit_rejected(self):
+        class TestOrder(Order):
+            def set_explicit(self, playlist, iter):
+                return None
+
+        self.pl.set(range(10, 20))
+        self.pl.order = TestOrder()
+        self.q.set(range(10))
+        self.mux.go_to(self.q[0].iter, source=self.q)
+        self.assertTrue(self.q.sourced)
+        self.mux.go_to(self.pl[0].iter, explicit=True, source=self.pl)
+        self.assertTrue(self.q.sourced)
+        self.assertEqual(self.mux.current, self.q[0][0])
+
     def tearDown(self):
         self.p.destroy()


### PR DESCRIPTION
When a new index in a model is set with go_to,
`order.set_explicit()` is called. But this function is allowed to
return None, and documentation says that "no action will be taken
by the player."

This commit fixes an issue where an action *is* taken: calling
`PlaylistMux`'s `go_to` method will unconditionally reset the model it
thinks is inactive.

This surfaces as a user visible issue when using persistent queue
mode and some extension (like Queue Only) that expects to be able
to override `set_explicit()`. When activating an item in a song list,
`go_to` is called with the song list as a source, so Queue Only will
fail to prevent the queue from losing its state.

Fixes #3385

-------------------------

Additional discussion:

The source of a ton of issues like this one with queue only mode is 
interactions with the "normal" queue (the song list / PlaylistModel) and
the explicit queue. Trying to create a true queue mode with a PlayOrder
plugin is a very difficult and ultimately limited approach to the problem.

I think it would make a lot of sense and solve many problems to build
this mode directly into Quod Libet. Maybe someone with more
knowledge of the codebase than I have is interested in working on that?

I can draw up a proposal for what this would look like if there's interest.
