### PR TITLE
Strip blank tags out from metadata lists

### DIFF
--- a/quodlibet/formats/_audio.py
+++ b/quodlibet/formats/_audio.py
@@ -709,6 +709,9 @@ class AudioFile(dict, ImageContainer, HasKey):
         will be unicode.
 
         If the value is numeric, that is returned rather than a list.
+
+        Because this function is used to format values for display,
+        blank tags are removed from the results.
         """
 
         if "~" in key or key == "title":
@@ -722,7 +725,7 @@ class AudioFile(dict, ImageContainer, HasKey):
         if isinstance(v, (int, float)):
             return v
         else:
-            return v.replace("\n", ", ")
+            return re.sub("\n+", ", ", v.strip())
 
     def list(self, key):
         """Get all values of a tag, as a list. Synthetic tags are supported,
@@ -731,8 +734,9 @@ class AudioFile(dict, ImageContainer, HasKey):
         For file path keys the returned list might contain path items
         (non-unicode).
 
-        An empty synthetic tag cannot be distinguished from a non-existent
-        synthetic tag; both result in [].
+        An empty tag cannot be distinguished from a non-existent tag; both
+        result in []. If a file contains multiple values of a tag, empty
+        instances of the tag will not be included in the list.
         """
 
         if "~" in key or key == "title":
@@ -740,17 +744,24 @@ class AudioFile(dict, ImageContainer, HasKey):
             if v == "":
                 return []
             else:
-                return v.split("\n") if isinstance(v, str) else [v]
+                v = v.split("\n") if isinstance(v, str) else [v]
+                return [x for x in v if x]
         else:
-            v = self.get(key)
-            return [] if v is None else v.split("\n")
+            v = self.get(key, "")
+            return [x for x in v.split("\n") if x]
 
     def list_sort(self, key):
         """Like list but return display,sort pairs when appropriate
         and work on all tags.
 
-        In case no sort value exists the display one is returned. The sort
-        value is only an empty string if the display one is empty as well.
+        In case no sort value exists the display one is returned. If a
+        display tag is empty, the tag is removed from the returned list
+        and the corresponding tag in the sort tag list is ignored as
+        well.
+
+        The assumption being made here is that if the ordering between
+        display and sort tags doesn't match exactly, that's a problem
+        with the user's file.
         """
 
         display = decode_value(key, self(key))
@@ -765,7 +776,7 @@ class AudioFile(dict, ImageContainer, HasKey):
 
         result = []
         for d, s in zip_longest(display, sort):
-            if d is not None:
+            if d:
                 result.append((d, (s if s is not None and s != "" else d)))
         return result
 

--- a/tests/test_formats__audio.py
+++ b/tests/test_formats__audio.py
@@ -737,6 +737,27 @@ class TAudioFile(TestCase):
         self.failUnlessEqual(q.list("~peoplesort:roles"),
             ["B, The (Guitar)", "C, The (Performance)", "A, The (Vocals)"])
 
+    def test_blank_tag_handling_comma(self):
+        q = AudioFile([("title", "A\n"),
+                       ("artists", "A\n\nB\n")])
+        self.failUnlessEqual(q.comma("artists"), "A, B")
+        self.failUnlessEqual(q.comma("~title~version"), "A")
+
+    def test_blank_tag_handling_list(self):
+        q = AudioFile([("artist", "A\n\nB\n"),
+                       ("performer", ""),
+                       ("albumartist", "C")])
+        self.failUnlessEqual(q.list("performer"), [])
+        self.failUnlessEqual(q.list("~people"), ["A", "B", "C"])
+
+    def test_blank_tag_handling_list_sort(self):
+        q = AudioFile([("artist", "A\n\nB"),
+                       ("artistsort", "\n\nY")])
+        self.failUnlessEqual(q.list_sort("artist"), [("A", "A"), ("B", "Y")])
+        q = AudioFile([("artist", "A\n\nB"),
+                       ("artistsort", "X\nY")])
+        self.failUnlessEqual(q.list_sort("artist"), [("A", "X"), ("B", "B")])
+
     def test_to_dump(self):
         dump = bar_1_1.to_dump()
         num = len(set(bar_1_1.keys()) | NUMERIC_ZERO_DEFAULT)

--- a/tests/test_pattern.py
+++ b/tests/test_pattern.py
@@ -507,67 +507,52 @@ class TPatternFormatList(_TPattern):
         s.failUnlessEqual(pat.format_list(s.h), {(u'Album5', u'SortAlbum5')})
         pat = Pattern('<artist>')
         s.failUnlessEqual(pat.format_list(s.h), {(u'Artist1', u'SortA1'),
-                                                 (u'', u'SortA2'),
                                                  (u'Artist3', u'Artist3')})
         pat = Pattern('<artist> x')
         s.failUnlessEqual(pat.format_list(s.h), {(u'Artist1 x', u'SortA1 x'),
-                                                 (u' x', u'SortA2 x'),
                                                  (u'Artist3 x', u'Artist3 x')})
 
     def test_sort_tied(s):
         pat = Pattern('<~artist~album>')
         s.failUnlessEqual(pat.format_list(s.h), {(u'Artist1', u'SortA1'),
-                                                 (u'', u'SortA2'),
                                                  (u'Artist3', u'Artist3'),
                                                  (u'Album5', u'SortAlbum5')})
         pat = Pattern('<~album~artist>')
         s.failUnlessEqual(pat.format_list(s.h), {(u'Artist1', u'SortA1'),
-                                                 (u'', u'SortA2'),
                                                  (u'Artist3', u'Artist3'),
                                                  (u'Album5', u'SortAlbum5')})
         pat = Pattern('<~artist~artist>')
         s.failUnlessEqual(pat.format_list(s.h), {(u'Artist1', u'SortA1'),
-                                                 (u'', u'SortA2'),
                                                  (u'Artist3', u'Artist3')})
 
     def test_sort_combine(s):
         pat = Pattern('<album> <artist>')
         s.failUnlessEqual(pat.format_list(s.h),
                           {(u'Album5 Artist1', u'SortAlbum5 SortA1'),
-                           (u'Album5 ', u'SortAlbum5 SortA2'),
                            (u'Album5 Artist3', u'SortAlbum5 Artist3')})
         pat = Pattern('x <artist> <album>')
         s.failUnlessEqual(pat.format_list(s.h),
                           {(u'x Artist1 Album5', u'x SortA1 SortAlbum5'),
-                           (u'x  Album5', u'x SortA2 SortAlbum5'),
                            (u'x Artist3 Album5', u'x Artist3 SortAlbum5')})
         pat = Pattern(' <artist> <album> xx')
         s.failUnlessEqual(pat.format_list(s.h),
                           {(u' Artist1 Album5 xx', u' SortA1 SortAlbum5 xx'),
-                           (u'  Album5 xx', u' SortA2 SortAlbum5 xx'),
                            (u' Artist3 Album5 xx', u' Artist3 SortAlbum5 xx')})
         pat = Pattern('<album> <tracknumber> <artist>')
         s.failUnlessEqual(pat.format_list(s.h),
                           {(u'Album5 7/8 Artist1', u'SortAlbum5 7/8 SortA1'),
-                           (u'Album5 7/8 ', u'SortAlbum5 7/8 SortA2'),
                            (u'Album5 7/8 Artist3', u'SortAlbum5 7/8 Artist3')})
         pat = Pattern('<tracknumber> <album> <artist>')
         s.failUnlessEqual(pat.format_list(s.h),
                           {(u'7/8 Album5 Artist1', u'7/8 SortAlbum5 SortA1'),
-                           (u'7/8 Album5 ', u'7/8 SortAlbum5 SortA2'),
                            (u'7/8 Album5 Artist3', u'7/8 SortAlbum5 Artist3')})
 
     def test_sort_multiply(s):
         pat = Pattern('<artist> <artist>')
         s.failUnlessEqual(pat.format_list(s.h),
                           {(u'Artist1 Artist1', u'SortA1 SortA1'),
-                           (u' Artist1', u'SortA2 SortA1'),
                            (u'Artist3 Artist1', u'Artist3 SortA1'),
-                           (u'Artist1 ', u'SortA1 SortA2'),
-                           (u' ', u'SortA2 SortA2'),
-                           (u'Artist3 ', u'Artist3 SortA2'),
                            (u'Artist1 Artist3', u'SortA1 Artist3'),
-                           (u' Artist3', u'SortA2 Artist3'),
                            (u'Artist3 Artist3', u'Artist3 Artist3')})
 
     def test_missing_value(self):


### PR DESCRIPTION
When a tag is an empty string, return an empty list instead.

It's common to have a tag in a file be present but blank. When
this happens, lists of metadata used in collections (e.g. by the
~persons tag) will contain empty strings and be combined and exposed
to the user in ugly ways. (Example: "Artist 1, , Artist 2,")

Fixing this doesn't appear to have an negative side effects.

Fixes #3383