### PR TITLE
Scanning: fix hidden files etc

### DIFF
--- a/quodlibet/library/file.py
+++ b/quodlibet/library/file.py
@@ -5,7 +5,7 @@
 
 import time
 from pathlib import Path
-from typing import Generator, Set, Iterable
+from typing import Generator, Set, Iterable, Optional
 
 from quodlibet import print_d, print_w, _, formats
 from quodlibet.formats import AudioFileError, AudioFile
@@ -131,7 +131,7 @@ class FileLibrary(Library[fsnative, AudioFile], PicklingMixin):
             else:
                 removed.add(item)
 
-    def rebuild(self, paths, force=False, exclude=[], cofuncid=None):
+    def rebuild(self, paths, force=False, exclude=None, cofuncid=None):
         """Reload or remove songs if they have changed or been deleted.
 
         This generator rebuilds the library over the course of iteration.
@@ -202,7 +202,9 @@ class FileLibrary(Library[fsnative, AudioFile], PicklingMixin):
 
         raise NotImplementedError
 
-    def scan(self, paths, exclude=[], cofuncid=None):
+    def scan(self, paths: Iterable[fsnative],
+             exclude: Optional[Iterable[fsnative]] = None,
+             cofuncid=None):
 
         def need_yield(last_yield=[0]):
             current = time.time()

--- a/quodlibet/util/library.py
+++ b/quodlibet/util/library.py
@@ -1,5 +1,5 @@
 # Copyright 2004-2017 Joe Wreschnig, Michael Urman, Iñigo Serna, Christoph Reiter
-#           2013-2021 Nick Boultbee
+#           2013-2022 Nick Boultbee
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -7,6 +7,7 @@
 # (at your option) any later version.
 
 import re
+from typing import Iterable
 
 from senf import fsn2bytes, bytes2fsn, fsnative, expanduser
 
@@ -87,16 +88,12 @@ def set_scan_dirs(dirs):
     config.setbytes("settings", "scan", fsn2bytes(joined, "utf-8"))
 
 
-def get_exclude_dirs():
-    """Returns a list of paths which should be ignored during scanning
-
-    Returns:
-        list
-    """
+def get_exclude_dirs() -> Iterable[fsnative]:
+    """:return: a list of paths which should be ignored during scanning"""
 
     paths = split_scan_dirs(
         bytes2fsn(config.getbytes("library", "exclude"), "utf-8"))
-    return [expanduser(p) for p in paths]
+    return [expanduser(p) for p in paths]  # type: ignore
 
 
 def scan_library(library, force):

--- a/quodlibet/util/path.py
+++ b/quodlibet/util/path.py
@@ -1,5 +1,5 @@
 # Copyright 2004-2009 Joe Wreschnig, Michael Urman, Steven Robertson
-#           2011-2019 Nick Boultbee
+#           2011-2022 Nick Boultbee
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -9,6 +9,7 @@
 import os
 import io
 import re
+import stat
 import sys
 import errno
 import codecs
@@ -454,24 +455,25 @@ def get_home_dir():
         return expanduser("~")
 
 
-def ishidden(path):
-    """Returns if a directory/ file is considered hidden by the platform.
+def is_hidden(path: _fsnative) -> bool:
+    """Returns if a directory / file is considered hidden by the platform.
 
     Hidden meaning the user should normally not be exposed to those files when
     opening the parent directory in the default file manager using the default
     settings.
 
     Does not check if any of the parents are hidden.
-    In case the file/dir does not exist the result is implementation defined.
+    If the file / dir does not exist, the result is implementation defined.
 
-    Args:
-        path (fsnative)
-    Returns:
-        bool
+    :param path: the path to check
+    :return: True if and only if the path is considered hidden on the system
     """
 
-    # TODO: win/osx
-    return os.path.basename(path).startswith(".")
+    if sys.platform == "windows":
+        return bool(os.stat(path).st_file_attributes & stat.FILE_ATTRIBUTE_HIDDEN)
+    basename = os.path.basename(path)
+    # Let's allow "...and Justice For All" etc (#3916)
+    return basename.startswith(".") and basename[1:2] != "."
 
 
 def uri_is_valid(uri):

--- a/tests/test_util_path.py
+++ b/tests/test_util_path.py
@@ -10,11 +10,10 @@ import unittest
 from senf import uri2fsn, fsn2uri, fsnative, environ
 
 from quodlibet.util.path import iscommand, limit_path, \
-    get_home_dir, uri_is_valid, ishidden, uri2gsturi
+    get_home_dir, uri_is_valid, is_hidden, uri2gsturi
 from quodlibet.util import print_d
 
-from . import TestCase
-
+from . import TestCase, skipIf
 
 is_win = os.name == "nt"
 path_set = bool(environ.get('PATH', False))
@@ -29,11 +28,17 @@ def test_uri2gsturi():
 
 class Tishidden(TestCase):
 
-    def test_main(self):
-        assert ishidden(fsnative(u"."))
-        assert ishidden(fsnative(u"foo/.bar"))
-        assert not ishidden(fsnative(u".foo/bar"))
-        assert not ishidden(fsnative(u"foo"))
+    @skipIf(is_win, "unix-like hidden")
+    def test_leading_dot(self):
+        assert is_hidden(fsnative("."))
+        assert is_hidden(fsnative("foo/.bar"))
+
+    def test_normal_names_not_hidden(self):
+        assert not is_hidden(fsnative("foo"))
+        assert not is_hidden(fsnative(".foo/bar"))
+
+    def test_multiple_dots(self):
+        assert not is_hidden(fsnative("...and Justice For All.flac"))
 
 
 class Turi(TestCase):


### PR DESCRIPTION
 * Hidden files now check hidden file attribute on Windows
 * And on non-Windows, only consider "single" dotfile names (`.git`, `.profile` etc) as hidden, not `...and Justice For All` etc
 * Also fix the naming of this function (better snake casing)
 * Revisit `scan()` / `rebuild()` for dodgy mutable params
 * Fix up typing on these too

Fixes #3916
