### PR TITLE
Increase space between icon and text

### DIFF
--- a/quodlibet/qltk/x.py
+++ b/quodlibet/qltk/x.py
@@ -313,7 +313,7 @@ def _Button(type_, label, icon_name, size):
         return type_.new_with_mnemonic(label)
 
     align = Align(halign=Gtk.Align.CENTER, valign=Gtk.Align.CENTER)
-    hbox = Gtk.HBox(spacing=2)
+    hbox = Gtk.HBox(spacing=6)
     image = Gtk.Image.new_from_icon_name(icon_name, size)
     hbox.pack_start(image, True, True, 0)
     label = Gtk.Label(label=label)


### PR DESCRIPTION
Check-list
----------

 * [ ] There is a linked issue discussing the motivations for this feature or bugfix
 * [ ] Unit tests have been added where possible
 * [ ] I've added / updated documentation for any user-facing features.
 * [X] Performance seems to be comparable or better than current `master`


What this change is adding / fixing
-----------------------------------
Just a bit more padding between icon and text in buttons.

Currently:
![capture_ecran_20220202-181733](https://user-images.githubusercontent.com/33821/153871612-01d193a7-0951-45a9-a4f7-9b4a0e860947.png)
![capture_ecran_20220202-181739](https://user-images.githubusercontent.com/33821/153871651-33cebb25-4bef-4a2d-8f7c-b8686316f8b1.png)

I suggest this:
![capture_ecran_20220202-181734](https://user-images.githubusercontent.com/33821/153871722-142246e0-891f-4ef8-8e34-d546293b769c.png)
![capture_ecran_20220202-181735](https://user-images.githubusercontent.com/33821/153871724-2b1fb46b-0b36-4108-bcee-dabc1f161c82.png)



