### PR TITLE
Linking tags.rst in renaming_files.rst

### DIFF
--- a/docs/guide/renaming_files.rst
+++ b/docs/guide/renaming_files.rst
@@ -6,9 +6,9 @@ Renaming files
 Basic Syntax
 ------------
 
-Quod Libet allows you to rename files based on their tags. In some cases
-you may wish to alter the filename depending on whether some tags are
-present or missing, in addition to their values.
+Quod Libet allows you to rename files based on their :ref:`tags<AudioTags>`. In
+some cases you may wish to alter the filename depending on whether some tags
+are present or missing, in addition to their values.
 
 Quod Libet allows _pattern_ syntax for this interaction, as well as plain text.
 A pattern is some text surrounded by angle brackets, typically containing tags.


### PR DESCRIPTION
See https://github.com/quodlibet/quodlibet/issues/3919

Check-list
----------

 * [x] There is a linked issue discussing the motivations for this feature or bugfix


What this change is adding / fixing
-----------------------------------

I couldn't find that internal tags are a thing where I was searching for them. This adds a link to the tags introduction to the renaming_files doc