### PR TITLE
Improve the console plug-in in a number of ways

### DIFF
--- a/quodlibet/ext/songsmenu/console.py
+++ b/quodlibet/ext/songsmenu/console.py
@@ -127,7 +127,8 @@ class PythonConsole(Gtk.ScrolledWindow):
         self.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
         self.set_shadow_type(Gtk.ShadowType.NONE)
         self.view = Gtk.TextView()
-        add_css(self, "* { background-color: white; padding: 6px; } ")
+        add_css(self, "scrolledwindow { padding: 6px; "
+                "background-color: white; background-color: @content_view_bg;}")
         self.view.modify_font(Pango.font_description_from_string('Monospace'))
         self.view.set_editable(True)
         self.view.set_wrap_mode(Gtk.WrapMode.CHAR)

--- a/quodlibet/ext/songsmenu/console.py
+++ b/quodlibet/ext/songsmenu/console.py
@@ -277,7 +277,7 @@ class PythonConsole(Gtk.ScrolledWindow):
             return True
 
         # completion - Ctrl+Space , Ctrl+Shift+Space
-        elif event.keyval == Gdk.KEY_space \
+        elif event.keyval == Gdk.KEY_Tab or event.keyval == Gdk.KEY_space \
                 and (event_state ==
                         (Gdk.ModifierType.CONTROL_MASK | Gdk.ModifierType.SHIFT_MASK)
                     or event_state == (Gdk.ModifierType.CONTROL_MASK)):

--- a/quodlibet/ext/songsmenu/console.py
+++ b/quodlibet/ext/songsmenu/console.py
@@ -529,7 +529,7 @@ class PythonConsole(Gtk.ScrolledWindow):
         else:
             comp = get_comp(obj=None, pre=ids_str)
 
-        return comp
+        return comp or []
 
 
 class OutFile:


### PR DESCRIPTION
Check-list
----------

 * [ ] There is a linked issue discussing the motivations for this feature or bugfix
 * [ ] Unit tests have been added where possible
 * [ ] I've added / updated documentation for any user-facing features.
 * [ ] Performance seems to be comparable or better than current `master`


What this change is adding / fixing
-----------------------------------

 * Allow using the tab key to trigger autocompletion, similar to zsh / bash. This is handled in such a way that if the user is editing a multi-line command, the tab key will add four spaces, so the ability to quickly add indentation is not lost with this change.
 * Better autocomplete: if only one option would be shown, it is appended automatically instead. The '.' character is autocompleted when an object has discoverable properties.
 * Fixed a bug with "overscroll" (Gtk feature). On my system at least (KDE), some CSS used by the plugin added a nasty white bar that flashed over the screen whenever I scrolled the console window.
 * Ctrl-c will now delete the existing line(s) without adding them to the history when editing a command at the prompt. (Similar to zsh / bash).
 * Slightly better behavior around auto-indentation and multi-line editing.

To do (not necessarily in this PR)
------------------------------------

 * Documentation and tests would be nice, I guess. I didn't add them because they were basically non-existent for this plugin prior to this PR anyway. I'm a little unsure about how testing with Gtk / UI input should work anyway. (Suggestions appreciated.)
 * It would be nice if the autosuggestion window automatically started filtering the results when you continue typing, such that when you have entered enough characters the suggestion you want will rise to the top and you can simply press return. Would mirror the behavior of most shell autosuggestion systems.
 * It would be nice if instead of a modal dialog, the suggestions were better integrated into the shell interface itself. I think a full-width widget that slid down from the top of the window when triggered would be nice?
 * It would be nice if clicking outside of the autosuggestion widget / dialog automatically closed it, similarly to pressing ESC.
 * The console plugin is still *extremely* buggy overall. For example, if you enter `help()` at the prompt, all of Quod Libet will hang! (This issue is not introduced by this PR.) I'll file an issue for this and other problems when I get around it it...