### PR TITLE
Support downloading remote files

### DIFF
--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -174,6 +174,7 @@ quodlibet/qltk/chooser.py
 quodlibet/qltk/controls.py
 quodlibet/qltk/data_editors.py
 quodlibet/qltk/delete.py
+quodlibet/qltk/download.py
 quodlibet/qltk/edittags.py
 quodlibet/qltk/_editutils.py
 quodlibet/qltk/entry.py

--- a/quodlibet/browsers/audiofeeds.py
+++ b/quodlibet/browsers/audiofeeds.py
@@ -28,6 +28,7 @@ from quodlibet.formats import AudioFile
 from quodlibet.formats.remote import RemoteFile
 from quodlibet.qltk.getstring import GetStringDialog
 from quodlibet.qltk.msg import ErrorMessage
+from quodlibet.qltk.songsmenu import SongsMenu
 from quodlibet.qltk.views import AllTreeView
 from quodlibet.qltk import Icons
 from quodlibet.util import connect_obj, print_w
@@ -393,6 +394,9 @@ class AudioFeeds(Browser):
 
         for child in self.get_children():
             child.show_all()
+
+    def Menu(self, songs, library, items):
+        return SongsMenu(library, songs, download=True, items=items)
 
     def __drag_motion(self, view, ctx, x, y, time):
         targets = [t.name() for t in ctx.list_targets()]

--- a/quodlibet/browsers/soundcloud/main.py
+++ b/quodlibet/browsers/soundcloud/main.py
@@ -17,6 +17,7 @@ from quodlibet.browsers import Browser
 from quodlibet.qltk import Icons, Message
 from quodlibet.qltk.completion import LibraryTagCompletion
 from quodlibet.qltk.searchbar import SearchBarBox
+from quodlibet.qltk.songsmenu import SongsMenu
 from quodlibet.qltk.views import RCMHintedTreeView
 from quodlibet.qltk.x import Align, ScrolledWindow, WebImage
 from quodlibet.util import connect_destroy, DeferredSignal, website, enum, \
@@ -127,6 +128,9 @@ class SoundcloudBrowser(Browser, util.InstanceTracker):
         pane.pack2(songs_box, resize=True, shrink=False)
         self.pack_start(pane, True, True, 0)
         self.show()
+
+    def Menu(self, songs, library, items):
+        return SongsMenu(library, songs, download=True, items=items)
 
     @property
     def online(self):

--- a/quodlibet/qltk/chooser.py
+++ b/quodlibet/qltk/chooser.py
@@ -174,7 +174,7 @@ def create_chooser_filter(name, patterns):
     return filter_
 
 
-def choose_folders(parent, title, action_title):
+def choose_folders(parent, title, action_title, allow_multiple=True):
     """Opens a folder chooser widget and returns a list of folders selected.
 
     Args:
@@ -189,7 +189,7 @@ def choose_folders(parent, title, action_title):
     chooser.set_title(title)
     chooser.set_action(Gtk.FileChooserAction.SELECT_FOLDER)
     chooser.set_local_only(True)
-    chooser.set_select_multiple(True)
+    chooser.set_select_multiple(allow_multiple)
 
     return _run_chooser(parent, chooser)
 
@@ -243,7 +243,7 @@ def choose_target_file(parent, title, action_title, name_suggestion=None):
 
 
 def choose_target_folder(parent, title, action_title, name_suggestion=None):
-    """Opens a file chooser for saving a file.
+    """Opens a file chooser for choosing a directory.
 
     Args:
         parent (Gtk.Widget)

--- a/quodlibet/qltk/download.py
+++ b/quodlibet/qltk/download.py
@@ -1,0 +1,94 @@
+# Copyright 2022 Nick Boultbee
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+
+
+from os.path import splitext
+from pathlib import Path
+from time import sleep
+from typing import Tuple, Collection, Any, Set
+
+from gi.repository import Soup, GObject
+from urllib3.util import parse_url
+
+from quodlibet import print_d, print_w, _, print_e
+from quodlibet.formats import AudioFile
+from quodlibet.qltk.notif import Task
+from quodlibet.util import http, format_size
+
+
+class DownloadProgress(GObject.Object):
+    """Downloads songs asynchronously, updating a Task"""
+
+    __gsignals__ = {
+        'finished': (GObject.SignalFlags.RUN_LAST, None, (object, object)),
+    }
+
+    def __init__(self, songs: Collection[AudioFile], task=None) -> None:
+        super().__init__()
+        self.songs = songs
+        self.successful: Set[AudioFile] = set()
+        self.failed: Set[AudioFile] = set()
+        self.task = task or Task(_("Browser"), _("Downloading files"))
+
+    def success(self, song: AudioFile) -> None:
+        self.successful.add(song)
+        self._update()
+
+    def failure(self, song: AudioFile) -> None:
+        self.failed.add(song)
+        self._update()
+
+    def _update(self) -> None:
+        frac = self.frac
+        print_d(f"At {frac * 100:.0f}% ({len(self.successful)}, {len(self.failed)})")
+        self.task.update(frac)
+
+    @property
+    def frac(self):
+        frac = (len(self.successful) + len(self.failed)) / len(self.songs)
+        return frac
+
+    def _downloaded(self, msg: Soup.Message, result: Any, data: Tuple) -> None:
+        path, song = data
+        try:
+            headers = msg.get_property('response-headers')
+            size = int(headers.get('content-length'))
+            content_type = headers.get('content-type')
+            print_d(
+                f"Downloaded {format_size(size)} of {content_type}: {song('title')}")
+            _, ext = splitext(parse_url(song("~uri")).path)
+            fn = (song("~artist~title")[:200]
+                  or song("~basename")
+                  or f"download-{hash(song('~filename'))}")
+            path = path / Path(fn + ext)
+            if path.is_file() and path.stat():
+                print_w(f"{path!s} already exists. Skipping download")
+                self.success(song)
+                return
+            with open(path, "wb") as f:
+                f.write(result)
+            self.success(song)
+            print_d(f"Downloaded to {path} successfully!")
+        except Exception as e:
+            print_e(f"Failed download ({e}")
+            self.failure(song)
+
+    def _failed(self, _req: Any, _exc: Exception, data: Tuple) -> None:
+        path, song = data
+        self.failure(song)
+
+    def download_songs(self, path: Path):
+        for s in self.songs:
+            msg = Soup.Message.new('GET', s("~uri"))
+            http.download(msg, cancellable=None, callback=self._downloaded,
+                          failure_callback=self._failed, data=(path, s))
+            yield
+        while self.frac < 1 and self.task:
+            sleep(0.1)
+            yield
+        self.task.finish()
+        self.emit("finished", len(self.successful), len(self.failed))

--- a/quodlibet/qltk/download.py
+++ b/quodlibet/qltk/download.py
@@ -74,7 +74,7 @@ class DownloadProgress(GObject.Object):
             self.success(song)
             print_d(f"Downloaded to {path} successfully!")
         except Exception as e:
-            print_e(f"Failed download ({e}")
+            print_e(f"Failed download ({e})")
             self.failure(song)
 
     def _failed(self, _req: Any, _exc: Exception, data: Tuple) -> None:

--- a/quodlibet/qltk/download.py
+++ b/quodlibet/qltk/download.py
@@ -18,6 +18,7 @@ from quodlibet import print_d, print_w, _, print_e
 from quodlibet.formats import AudioFile
 from quodlibet.qltk.notif import Task
 from quodlibet.util import http, format_size
+from quodlibet.util.path import escape_filename
 
 
 class DownloadProgress(GObject.Object):
@@ -61,7 +62,7 @@ class DownloadProgress(GObject.Object):
             print_d(
                 f"Downloaded {format_size(size)} of {content_type}: {song('title')}")
             _, ext = splitext(parse_url(song("~uri")).path)
-            fn = (song("~artist~title")[:200]
+            fn = (escape_filename(song("~artist~title")[:100], safe=b" ,';")
                   or song("~basename")
                   or f"download-{hash(song('~filename'))}")
             path = path / Path(fn + ext)

--- a/quodlibet/qltk/download.py
+++ b/quodlibet/qltk/download.py
@@ -10,9 +10,9 @@ from os.path import splitext
 from pathlib import Path
 from time import sleep
 from typing import Tuple, Collection, Any, Set
+from urllib.parse import urlparse
 
 from gi.repository import Soup, GObject
-from urllib3.util import parse_url
 
 from quodlibet import print_d, print_w, _, print_e
 from quodlibet.formats import AudioFile
@@ -61,7 +61,7 @@ class DownloadProgress(GObject.Object):
             content_type = headers.get('content-type')
             print_d(
                 f"Downloaded {format_size(size)} of {content_type}: {song('title')}")
-            _, ext = splitext(parse_url(song("~uri")).path)
+            _, ext = splitext(urlparse(song("~uri")).path)
             fn = (escape_filename(song("~artist~title")[:100], safe=b" ,';")
                   or song("~basename")
                   or f"download-{hash(song('~filename'))}")

--- a/quodlibet/qltk/msg.py
+++ b/quodlibet/qltk/msg.py
@@ -22,10 +22,11 @@ class Message(Gtk.MessageDialog, Dialog):
     """A message dialog that destroys itself after it is run, uses
     markup, and defaults to an 'OK' button."""
 
-    def __init__(self, kind, parent, title, description, buttons=Gtk.ButtonsType.OK):
+    def __init__(self, kind, parent, title, description, buttons=Gtk.ButtonsType.OK,
+                 escape_desc=True):
         parent = get_top_parent(parent)
         text = ("<span weight='bold' size='larger'>%s</span>\n\n%s"
-                % (escape(title), escape(description)))
+                % (escape(title), escape(description) if escape_desc else description))
         super().__init__(
             transient_for=parent, modal=True, destroy_with_parent=True,
             message_type=kind, buttons=buttons)

--- a/quodlibet/qltk/songsmenu.py
+++ b/quodlibet/qltk/songsmenu.py
@@ -453,7 +453,7 @@ class SongsMenu(Gtk.Menu):
                 msg = msg.format(name=next(iter(songs))("title")[:99] if total else "?",
                                  total=total)
                 chooser = folder_chooser or choose_folders
-                paths = chooser(None, msg, _("Start Download"), allow_multiple=False)
+                paths = chooser(None, msg, _("Download here"), allow_multiple=False)
                 if not paths:
                     print_d("Cancelling download")
                     return

--- a/tests/test_qltk_download.py
+++ b/tests/test_qltk_download.py
@@ -1,0 +1,30 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+
+from quodlibet import config
+from quodlibet.formats import AudioFile
+from quodlibet.formats.remote import RemoteFile
+from quodlibet.qltk.download import DownloadProgress
+from tests import TestCase, mkdtemp, run_gtk_loop
+
+
+def an_rf(i: int) -> AudioFile:
+    return RemoteFile(f"https://github.com/quodlibet/quodlibet/{i}.mp3")
+
+
+class TDownloadProgress(TestCase):
+
+    def setUp(self):
+        config.init()
+
+    def tearDown(self):
+        config.quit()
+
+    def test_download_fails_for_non_existent(self):
+        songs = [an_rf(i) for i in range(3)]
+        d = DownloadProgress(songs)
+        for _ in d.download_songs(mkdtemp()):
+            run_gtk_loop()
+        assert d.failed == set(songs)


### PR DESCRIPTION
 * Add to songsmenu, for configurable browsers, and supporting multiple files
 * Let user choose a download directory first
 * Currently enaboled for Audio Feeds and Soundcloud only
 * Use Libsoup wrappers for download
 * ...and Tasks for download tracking
 * Add a few tests

Fixes #3898 