### PR TITLE
Validate units for tag expressions

### DIFF
--- a/quodlibet/formats/_audio.py
+++ b/quodlibet/formats/_audio.py
@@ -1,5 +1,5 @@
 # Copyright 2004-2005 Joe Wreschnig, Michael Urman
-#           2012-2021 Nick Boultbee
+#           2012-2022 Nick Boultbee
 #                2022 Jej@github
 #
 # This program is free software; you can redistribute it and/or modify
@@ -53,6 +53,9 @@ PEOPLE = ["artist", "albumartist", "author", "composer", "~performers",
 
 TIME_TAGS = {"~#lastplayed", "~#laststarted", "~#added", "~#mtime"}
 """Time in seconds since epoch, defaults to 0"""
+
+DURATION_TAGS = {"~#length"}
+"""Duration in seconds"""
 
 SIZE_TAGS = {"~#filesize"}
 """Size in bytes, defaults to 0"""

--- a/quodlibet/query/_match.py
+++ b/quodlibet/query/_match.py
@@ -15,9 +15,8 @@ import operator
 import time
 from enum import auto, Enum
 from numbers import Real
-from typing import TypeVar, List, Iterable, Optional, Set
+from typing import TypeVar, List, Iterable, Optional
 
-from quodlibet import print_w
 from quodlibet.formats import FILESYSTEM_TAGS, TIME_TAGS
 from quodlibet.formats._audio import SIZE_TAGS, DURATION_TAGS
 from quodlibet.unisearch import compile

--- a/quodlibet/query/_match.py
+++ b/quodlibet/query/_match.py
@@ -1,7 +1,7 @@
 # Copyright 2004-2005 Joe Wreschnig, Michael Urman
 #           2011 Christoph Reiter
 #           2016 Ryan Dellenbaugh
-#        2016-20 Nick Boultbee
+#        2016-22 Nick Boultbee
 #           2018 Peter Strulo
 #
 # This program is free software; you can redistribute it and/or modify
@@ -13,10 +13,13 @@ from __future__ import annotations
 
 import operator
 import time
+from enum import auto, Enum
 from numbers import Real
-from typing import TypeVar, List, Iterable
+from typing import TypeVar, List, Iterable, Optional, Set
 
+from quodlibet import print_w
 from quodlibet.formats import FILESYSTEM_TAGS, TIME_TAGS
+from quodlibet.formats._audio import SIZE_TAGS, DURATION_TAGS
 from quodlibet.unisearch import compile
 from quodlibet.util import parse_date
 from senf import fsn2text, fsnative
@@ -237,6 +240,9 @@ class Numcmp(Node):
         self._expr = expr
         self._op = self.operators[op]
         self._expr2 = expr2
+        units = expr2.units()
+        if units and isinstance(expr, NumexprTag) and not expr.valid_for_units(units):
+            raise ParseError(f"Wrong units for {expr}")
 
     def search(self, data):
         time_ = time.time()
@@ -282,6 +288,10 @@ class Numexpr:
         values instead of the number values."""
         return False
 
+    def units(self) -> Optional[Units]:
+        """Returns optional (converted) units for this number"""
+        return None
+
 
 class NumexprTag(Numexpr):
     """Numeric tag"""
@@ -289,6 +299,10 @@ class NumexprTag(Numexpr):
     def __init__(self, tag: str):
         self._tag = tag
         self._ftag = "~#" + self._tag
+
+    def valid_for_units(self, units: Units) -> bool:
+        """Returns true if the given unit is valid for this expression's tag"""
+        return self._ftag in UNITS_TO_TAGS[units]
 
     def evaluate(self, data, time, use_date):
         if self._tag == 'date':
@@ -409,11 +423,15 @@ class NumexprGroup(Numexpr):
 class NumexprNumber(Numexpr):
     """Number in numeric expression"""
 
-    def __init__(self, value: Real):
+    def __init__(self, value: Real, units: Units = None):
         self._value = float(value)
+        self._units = units
 
     def evaluate(self, data, time, use_date):
         return self._value
+
+    def units(self) -> Optional[Units]:
+        return self._units
 
     def __repr__(self):
         return "<NumexprNumber value=%.2f>" % (self._value)
@@ -456,11 +474,19 @@ class NumexprNumberOrDate(Numexpr):
                 (self.number, self.date))
 
 
+class Units(Enum):
+    SECONDS = auto()
+    BYTES = auto()
+
+
+UNITS_TO_TAGS = {Units.SECONDS: TIME_TAGS | DURATION_TAGS, Units.BYTES: SIZE_TAGS}
+
+
 def numexprUnit(value, unit):
     """Process numeric units and return NumexprNumber"""
 
     unit = unit.lower().strip()
-
+    converted = Units.SECONDS
     # Time units
     if unit.startswith("second"):
         value = value
@@ -479,15 +505,18 @@ def numexprUnit(value, unit):
     # Size units
     elif unit.startswith("g"):
         value *= 1024 ** 3
+        converted = Units.BYTES
     elif unit.startswith("m"):
         value *= 1024 ** 2
+        converted = Units.BYTES
     elif unit.startswith("k"):
         value *= 1024
+        converted = Units.BYTES
     elif unit.startswith("b"):
-        pass
+        converted = Units.SECONDS
     elif unit:
         raise ParseError("No such unit: %r" % unit)
-    return NumexprNumber(value)
+    return NumexprNumber(value, converted)
 
 
 def numexprTagOrSpecial(tag):

--- a/quodlibet/query/_parser.py
+++ b/quodlibet/query/_parser.py
@@ -1,6 +1,6 @@
 # Copyright 2004-2005 Joe Wreschnig, Michael Urman
-#           2016 Ryan Dellenbaugh
-#           2017 Nick Boultbee
+#                2016 Ryan Dellenbaugh
+#           2017-2022 Nick Boultbee
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -11,7 +11,7 @@ import codecs
 import re
 
 from . import _match as match
-from ._match import ParseError
+from ._match import ParseError, Units
 from quodlibet.util import re_escape
 
 
@@ -183,7 +183,7 @@ class QueryParser:
             if self.accept(':'):
                 # time like 4:15
                 number2 = float(self.expect_re(DIGITS))
-                expr = match.NumexprNumber(60 * number + number2)
+                expr = match.NumexprNumber(60 * number + number2, units=Units.SECONDS)
             elif self.accept_re(WORD):
                 # Number with units like 7 minutes
                 expr = match.numexprUnit(number, self.last_match)

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -164,12 +164,12 @@ class TQuery_is_valid(TestCase):
         self.failUnless(Query("#(date < 2010 - 4)").valid)
         self.failUnless(Query("#(date > 0000)").valid)
         self.failUnless(Query("#(date > 00004)").valid)
-        self.failUnless(Query("#(t > 3 minutes)").valid)
         self.failUnless(Query("#(added > today)").valid)
         self.failUnless(Query("#(length < 5:00)").valid)
         self.failUnless(Query("#(filesize > 5M)").valid)
         self.failUnless(Query("#(added < 7 days ago)").valid)
 
+    def test_numexpr_failures(self):
         self.failIf(Query("#(3*4)").valid)
         self.failIf(Query("#(t = 3 + )").valid)
         self.failIf(Query("#(t = -)").valid)
@@ -177,6 +177,11 @@ class TQuery_is_valid(TestCase):
         self.failIf(Query("#(t < ()").valid)
         self.failIf(Query("#((t +) - 1 > 8)").valid)
         self.failIf(Query("#(t += 8)").valid)
+
+    def test_numexpr_fails_for_wrong_units(self):
+        self.failIf(Query("#(t > 3 minutes)").valid)
+        self.failIf(Query("#(size < 3 minutes)").valid)
+        self.failIf(Query("#(date = 3 GB)").valid)
 
 
 class TQuery(TestCase):


### PR DESCRIPTION
 * Track units for tags, accessible via new `Numexpr.units()`
 * Validate that expressions using these make sense for the tag, unlike `#(date > 10MB)`
 * Update / extend unit tests given this altered behaviour

Fixes #3927
