### PR TITLE
Corrected description of ~people internal tag.

### DIFF
--- a/docs/guide/tags/internal_tags.rst
+++ b/docs/guide/tags/internal_tags.rst
@@ -32,7 +32,7 @@ The ``~people`` Internal Tag
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The internal ``~people`` tag combines the following tags to one: 
-``albumartist``, ``artist``, ``author``, ``composer``, ``~performers``, 
+``artist``, ``albumartist``, ``author``, ``composer``, ``~performers``, 
 ``originalartist``, ``lyricist``, ``arranger``, ``conductor`` in this exact 
 order.
 


### PR DESCRIPTION
Check-list
----------

 * [x] There is a linked issue discussing the motivations for this feature or bugfix
 * [x] Unit tests have been added where possible
 * [x] I've added / updated documentation for any user-facing features.
 * [x] Performance seems to be comparable or better than current `master`


What this change is adding / fixing
-----------------------------------
In https://github.com/quodlibet/quodlibet/issues/3327, I pointed out the [docs](https://quodlibet.readthedocs.io/en/latest/guide/tags/internal_tags.html) say the ~people internal tag combines albumartist, artist, (etc), in that order. But the [code](https://github.com/quodlibet/quodlibet/blob/master/quodlibet/formats/_audio.py#L50) has the opposite order for those two. It was [pointed out](https://github.com/quodlibet/quodlibet/issues/3327#issuecomment-817193438) this was intentional, so I'm fixing the docs.