### PR TITLE
Edit tags: Hide multi-line tags if selected

### DIFF
--- a/quodlibet/config.py
+++ b/quodlibet/config.py
@@ -1,5 +1,5 @@
 # Copyright 2004-2008 Joe Wreschnig
-#           2009-2020 Nick Boultbee
+#           2009-2022 Nick Boultbee
 #           2011-2014 Christoph Reiter
 #           2018-2019 Peter Strulo
 #                2022 Jej@github

--- a/quodlibet/config.py
+++ b/quodlibet/config.py
@@ -303,6 +303,11 @@ INITIAL: Dict[str, Dict[str, str]] = {
         # show all tags, or just "human-readable" ones
         "alltags": "true",
 
+        # Show multi-line tags
+        "show_multi_line_tags": "true",
+        # Which tags can be multi-line (comma-separated)
+        "multi_line_tags": "lyrics,comment",
+
         # Skip dialog to save or revert changes
         "auto_save_changes": "false",
 

--- a/quodlibet/ext/events/advanced_preferences.py
+++ b/quodlibet/ext/events/advanced_preferences.py
@@ -148,6 +148,10 @@ class AdvancedPreferences(EventPlugin):
                 "Search tags:",
                 ("Tags which get searched in addition to "
                  "the ones present in the song list. Separate with \",\"")),
+            text_config("editing", "multi_line_tags",
+                        "Multi-line tags:",
+                        ("Tags to consider as multi-line (delimited by \\n) "
+                         "rather than multi-valued (comma-separated)")),
             text_config("settings", "rating_symbol_full", "Rating symbol (full):"),
             text_config("settings", "rating_symbol_blank", "Rating symbol (blank):"),
             text_config(

--- a/quodlibet/ext/events/advanced_preferences.py
+++ b/quodlibet/ext/events/advanced_preferences.py
@@ -1,5 +1,5 @@
 # Copyright 2015    Christoph Reiter
-#           2016-21 Nick Boultbee
+#           2016-22 Nick Boultbee
 #           2019    Peter Strulo
 #           2022    Jej@github
 #

--- a/quodlibet/qltk/edittags.py
+++ b/quodlibet/qltk/edittags.py
@@ -1,5 +1,5 @@
 # Copyright 2004-2012 Joe Wreschnig, Michael Urman, Iñigo Serna
-#           2011-2020 Nick Boultbee
+#           2011-2022 Nick Boultbee
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -527,8 +527,19 @@ class EditTags(Gtk.VBox):
             _("Show _programmatic tags"), 'editing', 'alltags', populate=True,
             tooltip=_("Access all tags, including machine-generated "
                       "ones e.g. MusicBrainz or Replay Gain tags"))
-        cb.connect('toggled', self.__all_tags_toggled)
-        self.pack_start(cb, False, True, 0)
+        cb.connect('toggled', self.__checkbox_toggled)
+        hb = Gtk.HBox()
+        hb.pack_start(cb, False, True, 0)
+
+        cb = ConfigCheckButton(
+            _("Show _multi-line tags"),
+            "editing",
+            "show_multi_line_tags",
+            populate=True,
+            tooltip=_("Show potentially multi-line tags (e.g 'lyrics') here too"))
+        cb.connect('toggled', self.__checkbox_toggled)
+        hb.pack_start(cb, False, True, 12)
+        self.pack_start(hb, False, True, 0)
 
         # Add and Remove [tags] buttons
         buttonbox = Gtk.HBox(spacing=18)
@@ -592,7 +603,7 @@ class EditTags(Gtk.VBox):
         for child in self.get_children():
             child.show_all()
 
-    def __all_tags_toggled(self, *args):
+    def __checkbox_toggled(self, *args):
         self._update()
 
     def __view_key_press_event(self, view, event):
@@ -759,8 +770,8 @@ class EditTags(Gtk.VBox):
             msg = _("Unable to add <b>%s</b>") % util.escape(tag)
             msg += "\n\n"
             msg += _("The files currently"
-                    " selected do not support multiple values for <b>%s</b>."
-                    ) % util.escape(tag)
+                     " selected do not support multiple values for <b>%s</b>."
+                     ) % util.escape(tag)
             qltk.ErrorMessage(self, title, msg).run()
             return
 
@@ -1052,6 +1063,10 @@ class EditTags(Gtk.VBox):
 
         if not config.getboolean("editing", "alltags"):
             keys = filter(lambda k: k not in MACHINE_TAGS, keys)
+
+        if not config.getboolean("editing", "show_multi_line_tags"):
+            tags = config.getstringlist("editing", "multi_line_tags")
+            keys = filter(lambda k: k not in tags, keys)
 
         if not songs:
             keys = []


### PR DESCRIPTION
 * New checkbox to control whether to _see_ these tags at all, c.f. _all tags_ one next to it.
 * We can actually move lyrics (has its own editor) etc to this window via #1068, thus removing most use cases for any cleverer editors
 * Add advanced prefs entry to control which tags get hidden (`multi_line_tags`)

This fixes #280
