### PR TITLE
Allow auto-playing added songs in Queue Only mode

### DIFF
--- a/quodlibet/player/_base.py
+++ b/quodlibet/player/_base.py
@@ -191,7 +191,7 @@ class BasePlayer(GObject.GObject, Equalizer):
 
         raise NotImplementedError
 
-    def setup(self, source, song, seek_pos):
+    def setup(self, source, song, seek_pos, explicit=True):
         """Connect to a PlaylistModel, and load a song.
 
         seek_pos in millisecs
@@ -201,7 +201,7 @@ class BasePlayer(GObject.GObject, Equalizer):
         if self._source is None:
             self.emit("song-started", song)
         self._source = source
-        self.go_to(song, explicit=True)
+        self.go_to(song, explicit)
         if seek_pos:
             self.seek(seek_pos)
 

--- a/quodlibet/qltk/quodlibetwindow.py
+++ b/quodlibet/qltk/quodlibetwindow.py
@@ -1348,7 +1348,7 @@ class QuodLibetWindow(Window, PersistentWindowMixin, AppWindow):
             seek_pos = config.getfloat("memory", "seek", 0)
             config.set("memory", "seek", 0)
             if song is not None:
-                player.setup(self.playlist, song, seek_pos)
+                player.setup(self.playlist, song, seek_pos, False)
 
             if self.__restore_cb:
                 self.__restore_cb()


### PR DESCRIPTION
When Queue Only mode is enabled, the user has multiple
neutral methods to add a song to the queue: both
Ctrl+Enter and the right click menu. Double clicking a
song usually indicates intent to play it immediately.

Queue Only mode changes the double click action to add
the song to the queue instead, but some users might like
Quod Libet to respect their intent and jump to the newly
added queue item and begin playing it. This adds the
ability to do that to the Queue Only plugin, and puts it
behind a preference.

Fixes #3381.

Implementation notes:

The code for jumping in the queue is specifically designed
to jump to the first added item in the queue. This is to
make implementing a double click action for albums easier
in the future. (QL will need to jump to the first song in
the added album.)

A change had to be made to the player code, because it was
emitting an explicit go_to when the main window restores
the last playing song when starting up and this was getting
caught by the plugin. Intuitively, restoring a previously
playing song is an implicit action by the player.

Check-list
----------

 * [x] There is a linked issue discussing the motivations for this feature or bugfix
 * [ ] Unit tests have been added where possible
 * [ ] I've added / updated documentation for any user-facing features.

Note isn't really any documentation or tests for this plugin unfortunately, so I have not added anything pertaining to this change.