### PR TITLE
Natural sorting

### DIFF
--- a/po/quodlibet.pot
+++ b/po/quodlibet.pot
@@ -4740,10 +4740,10 @@ msgstr ""
 
 #. then (try to) load all new files
 #: quodlibet/library/file.py:151 quodlibet/library/file.py:161
-#: quodlibet/library/file.py:226 quodlibet/library/file.py:245
-#: quodlibet/library/file.py:348 quodlibet/library/file.py:403
+#: quodlibet/library/file.py:228 quodlibet/library/file.py:247
+#: quodlibet/library/file.py:350 quodlibet/library/file.py:405
 #: quodlibet/qltk/information.py:272 quodlibet/qltk/prefs.py:700
-#: quodlibet/util/library.py:124
+#: quodlibet/util/library.py:121
 msgid "Library"
 msgstr ""
 
@@ -4755,20 +4755,20 @@ msgstr ""
 msgid "Scanning library"
 msgstr ""
 
-#: quodlibet/library/file.py:225
+#: quodlibet/library/file.py:227
 #, python-format
 msgid "Scanning %s"
 msgstr ""
 
-#: quodlibet/library/file.py:245
+#: quodlibet/library/file.py:247
 msgid "Loading files"
 msgstr ""
 
-#: quodlibet/library/file.py:348
+#: quodlibet/library/file.py:350
 msgid "Moving library files"
 msgstr ""
 
-#: quodlibet/library/file.py:403
+#: quodlibet/library/file.py:405
 msgid "Removing library files"
 msgstr ""
 

--- a/quodlibet/qltk/filesel.py
+++ b/quodlibet/qltk/filesel.py
@@ -28,6 +28,7 @@ from quodlibet.util.path import listdir, \
     glib2fsn, xdg_get_user_dirs, get_home_dir, xdg_get_config_home
 from quodlibet.util import connect_obj
 
+from natsort import os_sort_key
 
 def search_func(model, column, key, iter_, handledirs):
     check = model.get_value(iter_, 0)
@@ -200,9 +201,9 @@ class DirectoryTree(RCMHintedTreeView, MultiDragTreeView):
                 return 0
 
             # Otherwise, files are sorted by their paths
-            a_val = m.get_value(a, 0)
-            b_val = m.get_value(b, 0)
-            return 1 if a_val > b_val else -1
+            a_key = os_sort_key(m.get_value(a, 0))
+            b_key = os_sort_key(m.get_value(b, 0))
+            return 1 if a_key > b_key else -1
 
         model.set_sort_func(0, compare)
         model.set_sort_column_id(0, Gtk.SortType.ASCENDING)

--- a/quodlibet/qltk/filesel.py
+++ b/quodlibet/qltk/filesel.py
@@ -215,14 +215,14 @@ class DirectoryTree(RCMHintedTreeView, MultiDragTreeView):
 
                 def __le__(self, other):
                     # If both keys are the same type (int or string), compare normally
-                    if type(self.v) == type(other.v):
+                    if isinstance(other.v, type(self.v)):
                         return self.v <= other.v
 
                     # Otherwise, ints come first
                     return isinstance(self.v, int)
 
             def string_to_key(s):
-                # Break up the string into components
+                # Break up the string into parsed components
                 k = [KeyElem.parse(v) for v in split(r"(\d+)", s)]
 
                 # Add the original string to the end, to preserve case information

--- a/quodlibet/qltk/filesel.py
+++ b/quodlibet/qltk/filesel.py
@@ -190,6 +190,8 @@ class DirectoryTree(RCMHintedTreeView, MultiDragTreeView):
                    will result in a separator.
         """
 
+        # todo: All improvements to sorting should ideally be done by the model
+        # (GTK has built-in functionality for doing this type of thing)
         model = ObjectTreeStore()
         super().__init__(model=model)
 
@@ -221,6 +223,9 @@ class DirectoryTree(RCMHintedTreeView, MultiDragTreeView):
 
         if folders is None:
             folders = []
+
+        # todo: Natural sorting of top level folders could go here
+        folders.reverse()
 
         for path in folders:
             niter = model.append(None, [path])
@@ -462,7 +467,8 @@ class DirectoryTree(RCMHintedTreeView, MultiDragTreeView):
                 while model.iter_has_child(iter):
                     model.remove(model.iter_children(iter))
                 folder = model[iter][0]
-                for path in listdir(folder):
+                # todo: Natural sorting of sub-folders could be done here
+                for path in reversed(listdir(folder)):
                     try:
                         if not os.path.isdir(path):
                             continue


### PR DESCRIPTION
Check-list
----------

 * [x] There is a linked issue discussing the motivations for this feature or bugfix (see: #3627)
 * [ ] Unit tests have been added where possible
 * [ ] I've added / updated documentation for any user-facing features.
 * [ ] Performance seems to be comparable or better than current `master`


What this change is adding / fixing
-----------------------------------
Replaces the sorting function used by the file system browser, so that directories appear in a more intuitive order:
```
Example5/
example1/
example10
example2/
```
becomes
```
example1/
example2/
Example5/
example10
```

Next Steps
---------------
The current solution is functional, but there are a few additional changes that could be included:
- Apply the same sorting function to other Gtk.TreeViews (e.g. Playlists or Songs could be sorted naturally when put in alphabetical order)
- Add an option to enable or disable this behavior
- Add a context menu to quickly switch between different sorting approaches (natural, ascii order, case-ignoring) by right clicking on the column header
- Benchmark performance on very large directory structures (natural sorting uses regex and integer parsing, so it definitely comes with at least a small performance penalty)
