### PR TITLE
Soundcloud: Better Stream fetching

### DIFF
--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -22,6 +22,7 @@ quodlibet/browsers/playlists/menu.py
 quodlibet/browsers/playlists/prefs.py
 quodlibet/browsers/playlists/util.py
 quodlibet/browsers/tracks.py
+quodlibet/browsers/soundcloud/library.py
 quodlibet/browsers/soundcloud/main.py
 quodlibet/browsers/soundcloud/util.py
 quodlibet/cli.py

--- a/quodlibet/browsers/soundcloud/api.py
+++ b/quodlibet/browsers/soundcloud/api.py
@@ -94,7 +94,7 @@ class SoundcloudApiClient(RestApi):
         'fetch-success': (GObject.SignalFlags.RUN_LAST, None, (object,)),
         'fetch-failure': (GObject.SignalFlags.RUN_LAST, None, (object,)),
         'songs-received': (GObject.SignalFlags.RUN_LAST, None, (object,)),
-        'stream-uri-received': (GObject.SignalFlags.RUN_LAST, None, (object,str)),
+        'stream-uri-received': (GObject.SignalFlags.RUN_LAST, None, (object, str)),
         'comments-received': (GObject.SignalFlags.RUN_LAST, None, (int, object,)),
         'authenticated': (GObject.SignalFlags.RUN_LAST, None, (object,)),
     }

--- a/quodlibet/browsers/soundcloud/main.py
+++ b/quodlibet/browsers/soundcloud/main.py
@@ -138,8 +138,7 @@ class SoundcloudBrowser(Browser, util.InstanceTracker):
 
     def _create_footer(self):
         hbox = Gtk.HBox()
-        button = Gtk.Button(always_show_image=True,
-                            relief=Gtk.ReliefStyle.NONE)
+        button = Gtk.Button(always_show_image=True, relief=Gtk.ReliefStyle.NONE)
         button.connect('clicked', lambda _: website(SITE_URL))
         button.set_tooltip_text(_("Go to %s" % SITE_URL))
         button.add(self._logo_image)
@@ -306,7 +305,7 @@ class SoundcloudBrowser(Browser, util.InstanceTracker):
         container.remove(self)
 
     def __changed(self, library, songs):
-        print_d("Updating view")
+        print_d(f"Updating view for {len(songs)} song(s)")
         self.activate()
 
     def __query_changed(self, bar, text, restore=False):
@@ -364,8 +363,7 @@ class SoundcloudBrowser(Browser, util.InstanceTracker):
                 search_it = it
             elif ((typ == FilterType.FAVORITES and text == "#(rating = 1.0)")
                     or (typ == FilterType.MINE and
-                         text == "soundcloud_user_id=%s"
-                         % self.api_client.user_id)):
+                        text == f"soundcloud_user_id={self.api_client.user_id}")):
                 self.view.get_selection().select_iter(it)
                 selected = True
                 break


### PR DESCRIPTION
 * Add a new signal from the API for an individual stream being received
 * Process _this_ like other signals in the library
 * Batch the changed signals based on time instead of all at once, to allow them to trickle through.
 * Only update ones with unfetched URIs
 * Add a background task to get all the stream URLs
 * Rate limit this to stop the 429s
 * Clean a few logging things too
 * Fix a couple of logout things...
