### PR TITLE
Fix add playlists errors (#3973)

### DIFF
--- a/quodlibet/browsers/playlists/util.py
+++ b/quodlibet/browsers/playlists/util.py
@@ -1,4 +1,5 @@
 # Copyright 2014-2021 Nick Boultbee
+#                2022 TheMelmacian
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -15,6 +16,7 @@ from quodlibet.qltk.msg import ConfirmationPrompt
 from quodlibet.qltk.wlw import WaitLoadWindow
 from quodlibet.util import escape
 from quodlibet.util.path import uri_is_valid
+from urllib.response import addinfourl
 from senf import uri2fsn, fsn2text, path2fsn, bytes2fsn, text2fsn
 
 
@@ -124,7 +126,11 @@ def _name_for(filename):
 
 def _dir_for(filelike):
     try:
-        return os.path.dirname(path2fsn(filelike.name))
+        if isinstance(filelike, addinfourl):
+            # if the "filelike" was created via urlopen it is wrapped in an addinfourl object
+            return os.path.dirname(path2fsn(filelike.fp.name))
+        else:
+            return os.path.dirname(path2fsn(filelike.name))
     except AttributeError:
         # Probably a URL
         return text2fsn(u'')

--- a/quodlibet/browsers/playlists/util.py
+++ b/quodlibet/browsers/playlists/util.py
@@ -102,11 +102,14 @@ def __create_playlist(name, source_dir, files, songs_lib, pl_lib):
                 song = _af_for(filename, songs_lib, source_dir)
 
         # Only add existing (not None) files to the playlist.
-        # Otherwise multiple errors are thrown when the files are accessed to update the displayed track infos.
+        # Otherwise multiple errors are thrown when the files are accessed
+        # to update the displayed track infos.
         if song is not None:
             songs.append(song)
-        elif os.path.exists(filename) or os.path.exists(os.path.join(source_dir, filename)):
-            print_w(f"Can't add file to playlist: Unsupported file format. '{filename}'")
+        elif (os.path.exists(filename)
+                or os.path.exists(os.path.join(source_dir, filename))):
+            print_w("Can't add file to playlist:"
+                    f" Unsupported file format. '{filename}'")
         else:
             print_w(f"Can't add file to playlist: File not found. '{filename}'")
 
@@ -138,7 +141,8 @@ def _name_for(filename):
 def _dir_for(filelike):
     try:
         if isinstance(filelike, addinfourl):
-            # if the "filelike" was created via urlopen it is wrapped in an addinfourl object
+            # if the "filelike" was created via urlopen
+            # it is wrapped in an addinfourl object
             return os.path.dirname(path2fsn(filelike.fp.name))
         else:
             return os.path.dirname(path2fsn(filelike.name))

--- a/tests/data/test.m3u8
+++ b/tests/data/test.m3u8
@@ -1,0 +1,7 @@
+#EXTM3U
+#EXTINF:0,lame.mp3
+lame.mp3
+#EXTINF:0,test.wav
+test.wav
+#EXTINF:2,Quod Libet - 110Hz test track
+sine-110hz.flac

--- a/tests/data/test.m3u8
+++ b/tests/data/test.m3u8
@@ -5,3 +5,7 @@ lame.mp3
 test.wav
 #EXTINF:2,Quod Libet - 110Hz test track
 sine-110hz.flac
+#EXTINF:0,non existing file
+non_existing_audio_file.mp3
+#EXTINF:0,no audio file
+image.jpg

--- a/tests/test_playlist_util.py
+++ b/tests/test_playlist_util.py
@@ -11,15 +11,14 @@ from urllib.response import addinfourl
 
 from quodlibet.browsers.playlists.util import _dir_for, parse_m3u
 from quodlibet.library import SongFileLibrary
-from quodlibet.library.playlist import _DEFAULT_PLAYLIST_DIR, PlaylistLibrary
+from quodlibet.library.playlist import PlaylistLibrary
 from quodlibet.util.collection import Playlist
-from quodlibet.util.path import _normalize_path
 from quodlibet.util.urllib import urlopen
-from tests import _TEMP_DIR, TestCase, get_data_path
+from tests import TestCase, get_data_path
 
 
 class TPlaylistUtil(TestCase):
-    
+
     PLAYLIST_FILE_PATH = get_data_path('test.m3u8')
     sfLib: SongFileLibrary = None
     plLib: PlaylistLibrary = None
@@ -33,8 +32,8 @@ class TPlaylistUtil(TestCase):
         self.sfLib.destroy()
 
     def test_dir_for(self):
-        # uri format of files added via drag and drop or add button (Gtk.SelectionData.get_uris()):
-        # file:///path/to/file.ext
+        # uri format of files added via drag and drop or add button
+        # (Gtk.SelectionData.get_uris()): file:///path/to/file.ext
         url_based_file: addinfourl = urlopen("file:///" + self.PLAYLIST_FILE_PATH)
         reader_based_file: BufferedReader = open(self.PLAYLIST_FILE_PATH, "rb")
 
@@ -43,14 +42,16 @@ class TPlaylistUtil(TestCase):
             self.assertEqual(
                 os.path.realpath(os.path.dirname(self.PLAYLIST_FILE_PATH)),
                 os.path.realpath(dir_of_url_based_file),
-                "determining the directory of url based files should result in a correct path"
+                "determining the directory of url based files"
+                " should result in a correct path"
             )
 
             dir_of_reader_based_file: str = _dir_for(reader_based_file)
             self.assertEqual(
                 os.path.realpath(os.path.dirname(self.PLAYLIST_FILE_PATH)),
                 os.path.realpath(dir_of_reader_based_file,),
-                "determining the directory of reader based files should result in a correct path"
+                "determining the directory of reader based files"
+                " should result in a correct path"
             )
 
         finally:
@@ -65,13 +66,19 @@ class TPlaylistUtil(TestCase):
             try:
                 playlist = parse_m3u(file, fileName, self.sfLib, self.plLib)
             except:
-                assert False, "parsing m3u8 playlists in correct format should not cause errors"
+                assert False, ("parsing m3u8 playlists in correct format"
+                               " should not cause errors")
 
-        self.assertIsNotNone(playlist, "parsing an m3u8 playlist in the correct format should result in a playlist")
+        self.assertIsNotNone(playlist, ("parsing an m3u8 playlist in the correct format"
+                                        " should result in a playlist"))
         # the test.m3u8 contains:
-        #   - 3 existing and supported audio files from the tests/data folder: lame.mp3, test.wav, sine-110hz.flac
+        #   - 3 existing and supported audio files from the tests/data folder:
+        #     lame.mp3, test.wav, sine-110hz.flac
         #   - 1 non existing file: non_existing_audio_file.mp3
         #   - 1 not supported file: test.jpg
         # parsing the file correctly should result in a playlist with 3 entries
-        self.assertEqual(3, len(playlist), "only existing files should be added to the playlist")
-
+        self.assertEqual(
+            3,
+            len(playlist),
+            "only existing files should be added to the playlist"
+        )

--- a/tests/test_playlist_util.py
+++ b/tests/test_playlist_util.py
@@ -41,15 +41,15 @@ class TPlaylistUtil(TestCase):
         try:
             dir_of_url_based_file: str = _dir_for(url_based_file)
             self.assertEqual(
-                _normalize_path(self.PLAYLIST_FILE_PATH),
-                os.path.join(_normalize_path(dir_of_url_based_file), "test.m3u8"),
+                os.path.realpath(os.path.dirname(self.PLAYLIST_FILE_PATH)),
+                os.path.realpath(dir_of_url_based_file),
                 "determining the directory of url based files should result in a correct path"
             )
 
             dir_of_reader_based_file: str = _dir_for(reader_based_file)
             self.assertEqual(
-                _normalize_path(self.PLAYLIST_FILE_PATH),
-                os.path.join(_normalize_path(dir_of_reader_based_file), "test.m3u8"),
+                os.path.realpath(os.path.dirname(self.PLAYLIST_FILE_PATH)),
+                os.path.realpath(dir_of_reader_based_file,),
                 "determining the directory of reader based files should result in a correct path"
             )
 

--- a/tests/test_playlist_util.py
+++ b/tests/test_playlist_util.py
@@ -1,0 +1,58 @@
+# Copyright 2022 TheMelmacian
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+
+import os
+from io import BufferedReader
+from urllib.response import addinfourl
+
+from quodlibet.browsers.playlists.util import _dir_for, parse_m3u
+from quodlibet.library import SongFileLibrary
+from quodlibet.library.playlist import _DEFAULT_PLAYLIST_DIR, PlaylistLibrary
+from quodlibet.util.collection import Playlist
+from quodlibet.util.path import _normalize_path
+from quodlibet.util.urllib import urlopen
+from tests import _TEMP_DIR, TestCase, get_data_path
+
+
+class TPlaylistUtil(TestCase):
+    
+    PLAYLIST_FILE_PATH = get_data_path('test.m3u8')
+    sfLib: SongFileLibrary = None
+    plLib: PlaylistLibrary = None
+
+    def setUp(self):
+        self.sfLib = SongFileLibrary()
+        self.plLib = PlaylistLibrary(self.sfLib)
+
+    def tearDown(self):
+        self.plLib.destroy()
+        self.sfLib.destroy()
+
+    def test_dir_for(self):
+        # uri format of files added via drag and drop or add button (Gtk.SelectionData.get_uris()):
+        # file:///path/to/file.ext
+        url_based_file: addinfourl = urlopen("file:///" + self.PLAYLIST_FILE_PATH)
+        reader_based_file: BufferedReader = open(self.PLAYLIST_FILE_PATH, "rb")
+
+        try:
+            dir_of_url_based_file: str = _dir_for(url_based_file)
+            self.assertEqual(
+                _normalize_path(self.PLAYLIST_FILE_PATH),
+                os.path.join(_normalize_path(dir_of_url_based_file), "test.m3u8"),
+                "determining the directory of url based files should result in a correct path"
+            )
+
+            dir_of_reader_based_file: str = _dir_for(reader_based_file)
+            self.assertEqual(
+                _normalize_path(self.PLAYLIST_FILE_PATH),
+                os.path.join(_normalize_path(dir_of_reader_based_file), "test.m3u8"),
+                "determining the directory of reader based files should result in a correct path"
+            )
+
+        finally:
+            url_based_file.close()
+            reader_based_file.close()

--- a/tests/test_playlist_util.py
+++ b/tests/test_playlist_util.py
@@ -56,3 +56,22 @@ class TPlaylistUtil(TestCase):
         finally:
             url_based_file.close()
             reader_based_file.close()
+
+    def test_parse_m3u8(self):
+        fileName = os.path.basename(self.PLAYLIST_FILE_PATH)
+        playlist: Playlist = None
+
+        with open(self.PLAYLIST_FILE_PATH, "rb") as file:
+            try:
+                playlist = parse_m3u(file, fileName, self.sfLib, self.plLib)
+            except:
+                assert False, "parsing m3u8 playlists in correct format should not cause errors"
+
+        self.assertIsNotNone(playlist, "parsing an m3u8 playlist in the correct format should result in a playlist")
+        # the test.m3u8 contains:
+        #   - 3 existing and supported audio files from the tests/data folder: lame.mp3, test.wav, sine-110hz.flac
+        #   - 1 non existing file: non_existing_audio_file.mp3
+        #   - 1 not supported file: test.jpg
+        # parsing the file correctly should result in a playlist with 3 entries
+        self.assertEqual(3, len(playlist), "only existing files should be added to the playlist")
+


### PR DESCRIPTION
Check-list
----------

 * [x] There is a linked issue discussing the motivations for this feature or bugfix
 * [x] Unit tests have been added where possible


What this change is adding / fixing
-----------------------------------
This fixes the errors I encountered when I tried to add an m3u8 playlist file to the playlist browser via drag and drop as described in https://github.com/quodlibet/quodlibet/issues/3973

