### PR TITLE
Fix display pattern not updating in browsers

### DIFF
--- a/quodlibet/browsers/_base.py
+++ b/quodlibet/browsers/_base.py
@@ -299,27 +299,27 @@ class DisplayPatternMixin:
         print_d("Loading pattern from %s" % cls._PATTERN_FN)
         try:
             with open(cls._PATTERN_FN, "r", encoding="utf-8") as f:
-                cls.__pattern_text = f.read().rstrip()
+                pattern_text = f.read().rstrip()
         except EnvironmentError as e:
             print_d("Couldn't load pattern for %s (%s), using default." %
                     (cls.__name__, e))
-            cls.__pattern_text = cls._DEFAULT_PATTERN_TEXT
-        cls.__refresh_pattern()
+            pattern_text = cls._DEFAULT_PATTERN_TEXT
+        cls.__refresh_pattern(pattern_text)
 
     def update_pattern(self, pattern_text):
         """Saves `pattern_text` to disk (and caches)"""
         if pattern_text == self.__pattern_text:
             return
-        self.__pattern_text = pattern_text
-        self.__refresh_pattern()
+        self.__refresh_pattern(pattern_text)
         self.refresh_all()
         print_d(f"Saving pattern for {self} at {self._PATTERN_FN}")
         with open(self._PATTERN_FN, "w", encoding="utf-8") as f:
             f.write(pattern_text + "\n")
 
     @classmethod
-    def __refresh_pattern(cls):
-        cls.__pattern = XMLFromMarkupPattern(cls.__pattern_text)
+    def __refresh_pattern(cls, pattern_text):
+        cls.__pattern_text = pattern_text
+        cls.__pattern = XMLFromMarkupPattern(pattern_text)
 
     @property
     def display_pattern(self):

--- a/tests/test_browsers__base.py
+++ b/tests/test_browsers__base.py
@@ -222,6 +222,14 @@ class TDisplayPatternMixin(TestCase):
         dpm.load_pattern()
         self.failUnlessEqual(dpm.display_pattern_text, self.TEST_PATTERN)
 
+    def test_updating_pattern(self):
+        dpm = DummyDPM()
+        dpm.load_pattern()
+        dpm.update_pattern("static")
+        self.failUnlessEqual(
+            dpm.display_pattern % FakeDisplayItem(),
+            "static")
+
     def test_markup(self):
         dpm = DummyDPM()
         dpm.load_pattern()


### PR DESCRIPTION
Check-list
----------

 * [ ] There is a linked issue discussing the motivations for this feature or bugfix
 * [x] Unit tests have been added where possible
 * [x] I've added / updated documentation for any user-facing features.
 * [x] Performance seems to be comparable or better than current `master`


What this change is adding / fixing
-----------------------------------
The compiled display pattern never was updated and as a result browsers could not use it to update item labels. 
The new pattern string was saved to an instance attribute (`self.__pattern_text`) but compiled from a class attribute (`cls.__pattern_text`).