### PR TITLE
Write XSPFs with proper namespace (internal v2)

### DIFF
--- a/quodlibet/const.py
+++ b/quodlibet/const.py
@@ -66,6 +66,9 @@ class MinVersions:
 VERSION_TUPLE = Version("", 4, 6, -1)
 VERSION = str(VERSION_TUPLE)
 
+QL_NAMESPACE = "https://quodlibet.github.io"
+"""A namespace for registering things against e.g. XMLNS"""
+
 # entry point for the user guide / wiki
 _DOCS_BASE_URL = "https://quodlibet.readthedocs.org/en/latest"
 ONLINE_HELP = _DOCS_BASE_URL + "/guide/index.html"

--- a/quodlibet/util/collection.py
+++ b/quodlibet/util/collection.py
@@ -719,7 +719,7 @@ class XSPFBackedPlaylist(FileBackedPlaylist):
                 print_w(f"Using legacy namespace for import of {self.path}")
             elif root.tag == "{" + XSPF_NS + "}playlist":
                 # Try correct format first
-                ns_mapping = {'': XSPF_NS}
+                ns_mapping = {"": XSPF_NS}
             else:
                 raise ValueError(f"Unknown playlist root of {root.tag}")
             node = root.find("title", namespaces=ns_mapping)
@@ -730,9 +730,9 @@ class XSPFBackedPlaylist(FileBackedPlaylist):
                 print_w(f"Playlist was named {node.text!r} in XML "
                         f"instead of {self.name!r} at {self.path!r}")
 
-            for node in tree.iterfind('.//track', namespaces=ns_mapping):
-                location = node.findtext('location', namespaces=ns_mapping).strip()
-                path = location.replace('\n', '').replace('\r', '')
+            for node in tree.iterfind(".//track", namespaces=ns_mapping):
+                location = node.findtext("location", namespaces=ns_mapping).strip()
+                path = location.replace("\n", "").replace("\r", "")
                 try:
                     # TODO: process relative URIs too?
                     path = uri2fsn(path)

--- a/tests/data/non-compliant.xspf
+++ b/tests/data/non-compliant.xspf
@@ -1,0 +1,6 @@
+<?xml version='1.0' encoding='utf-8'?>
+<playlist version="1"><title>100% 😈</title><date>2021-04-18T17:45:49.936318</date>
+  <trackList>
+    <track><location>/music/Funk &amp; Disco/Average White Band - Pickin' Up The Pieces/Average White Band - Your Love Is a Miracle.flac</location><title>Your Love Is a Miracle</title><creator>Average White Band</creator><album>Pickin' Up the Pieces: The Best of Average White Band (1974-1990)</album><trackNum>15</trackNum><duration>223866</duration></track>
+  </trackList>
+</playlist>

--- a/tests/test_util_collection.py
+++ b/tests/test_util_collection.py
@@ -27,15 +27,15 @@ from tests import TestCase, mkdtemp
 config.RATINGS = config.HardCodedRatingsPrefs()
 
 NUMERIC_SONGS = [
-    Fakesong({"~filename": fsnative("/fake1-\xf0.mp3"),
+    Fakesong({"~filename": fsnative("fake1-\xf0.mp3"),
               "~#length": 4, "~#added": 5, "~#lastplayed": 1,
               "~#bitrate": 200, "date": "100", "~#rating": 0.1,
               "originaldate": "2004-01-01", "~#filesize": 101}),
-    Fakesong({"~filename": fsnative("/fake2.mp3"),
+    Fakesong({"~filename": fsnative("fake2.mp3"),
               "~#length": 7, "~#added": 7, "~#lastplayed": 88,
               "~#bitrate": 220, "date": "99", "~#rating": 0.3,
               "originaldate": "2002-01-01", "~#filesize": 202}),
-    Fakesong({"~filename": fsnative("/fake3.mp3"),
+    Fakesong({"~filename": fsnative("fake3.mp3"),
               "~#length": 1, "~#added": 3, "~#lastplayed": 43,
               "~#bitrate": 60, "date": "33", "~#rating": 0.5,
               "tracknumber": "4/6", "discnumber": "1/2"})
@@ -562,7 +562,8 @@ class TFileBackedPlaylist(TPlaylist):
 
     def test_difficult_names(self):
         lib = FileLibrary("foobar")
-        lib.add(NUMERIC_SONGS)
+        tempdir = mkdtemp()
+        self.add_songs_in_temp_dir(lib, tempdir, NUMERIC_SONGS)
         name = "c:?\"problem?\" / foo* / 100% ə! COM"
         with self.wrap(name, lib) as pl:
             pl.extend(NUMERIC_SONGS)
@@ -570,6 +571,12 @@ class TFileBackedPlaylist(TPlaylist):
             assert pl.songs == NUMERIC_SONGS
             with self.wrap(name, lib) as pl2:
                 assert pl2.songs == NUMERIC_SONGS
+
+    def add_songs_in_temp_dir(self, lib, tempdir, songs):
+        for l in songs:
+            l["~filename"] = os.path.join(tempdir, l["~filename"])
+            l.sanitize()
+            lib.add([l])
 
     def test_symmetric(self):
         P = self.Playlist

--- a/tests/test_util_collection.py
+++ b/tests/test_util_collection.py
@@ -680,17 +680,18 @@ class TXSPFBackedPlaylist(TFileBackedPlaylist):
             last_location = tracks[-1].find("location", namespaces={"": XSPF_NS}).text
             assert uri2fsn(last_location) == some_path
 
-    def test_load_legacy_format(self):
+    def test_load_legacy_format_to_xspf(self):
         playlist_fn = "old"
         songs_lib = FileLibrary()
         songs_lib.add(NUMERIC_SONGS)
         old_pl = FileBackedPlaylist(self.temp, playlist_fn)
         old_pl.extend(NUMERIC_SONGS)
         pl = XSPFBackedPlaylist.from_playlist(old_pl, songs_lib=songs_lib, pl_lib=None)
-        assert {s("~filename") for s in pl.songs} == {s("~filename") for s in
-                                                      NUMERIC_SONGS}
+        expected_filenames = {s("~filename") for s in NUMERIC_SONGS}
+        assert {s("~filename") for s in pl.songs} == expected_filenames
 
-    def test_load_non_compliant_xspf(self):
+    def test_v1_load_non_compliant_xspf(self):
+        """See #3983"""
         songs_lib = FileLibrary()
         test_filename = ("/music/Funk & Disco/"
                          "Average White Band - Pickin' Up The Pieces/"

--- a/tests/test_util_collection.py
+++ b/tests/test_util_collection.py
@@ -642,7 +642,7 @@ class TFileBackedPlaylist(TPlaylist):
         assert not lib.emitted, "Deleting again caused library signals"
 
 
-class TXPSFBackedPlaylist(TFileBackedPlaylist):
+class TXSPFBackedPlaylist(TFileBackedPlaylist):
     Playlist = XSPFBackedPlaylist
 
     def setUp(self):

--- a/tests/test_util_collection.py
+++ b/tests/test_util_collection.py
@@ -673,9 +673,9 @@ class TXSPFBackedPlaylist(TFileBackedPlaylist):
 
             assert exists(pl.path), "File doesn't exist"
             root = ElementTree().parse(pl.path)
-            assert root.tag == '{http://xspf.org/ns/0/}playlist'
-            tracks = root.findall(".//track", namespaces={'': XSPF_NS})
-            assert len(tracks) == len(NUMERIC_SONGS) + 1, "Hmm found %s" % tracks
+            assert root.tag == "{http://xspf.org/ns/0/}playlist"
+            tracks = root.findall(".//track", namespaces={"": XSPF_NS})
+            assert len(tracks) == len(NUMERIC_SONGS) + 1, f"Hmm found {tracks}"
             # Should now write compliant local URLs
             last_location = tracks[-1].find("location", namespaces={"": XSPF_NS}).text
             assert uri2fsn(last_location) == some_path


### PR DESCRIPTION
* But.. convert on read, as anything else would be pretty horrible. Logic is slightly icky but has been working here OK for ages at least
* Persist locations as actual URLs, as intended
* Add a <meta> for version number (just for futureproofing currently)
* Warn in logs if `<title>` isn't found
* Catch more loading errors
* Add test for legacy format
* Update write test to ensure namespace is written
* Add test for current (non-compliant) files to prove they load
* Add MBID as `<identifier>` to XSPF if present, seems about right

Fixes #3983

Check-list
----------

 * [x] There is a linked issue discussing the motivations for this feature or bugfix
 * [x] Unit tests have been added where possible
 * [ ] I've added / updated documentation for any user-facing features.
 * [x] Performance seems to be comparable or better than current `master`


