### PR TITLE
Modernise some tests (extracted out of other PRs)

### DIFF
--- a/tests/test_browsers_filesystem.py
+++ b/tests/test_browsers_filesystem.py
@@ -3,23 +3,27 @@
 # the Free Software Foundation; either version 2 of the License, or
 # (at your option) any later version.
 
-from tests import TestCase
+from typing import Generator
 
+import pytest
+
+import quodlibet.config
 from quodlibet.browsers.filesystem import FileSystem
 from quodlibet.library import SongLibrary
-import quodlibet.config
 
 
-class TFileSystem(TestCase):
-    def setUp(self):
-        quodlibet.config.init()
-        self.bar = FileSystem(SongLibrary())
+@pytest.fixture
+def bar() -> Generator[FileSystem, None, None]:
+    quodlibet.config.init()
+    bar = FileSystem(SongLibrary())
+    yield bar
+    bar.destroy()
+    quodlibet.config.quit()
 
-    def test_can_filter(self):
+
+class TestFileSystem:
+
+    def test_can_filter(self, bar):
         for key in ["foo", "title", "fake~key", "~woobar", "~#huh"]:
-            self.failIf(self.bar.can_filter(key))
-        self.failUnless(self.bar.can_filter("~dirname"))
-
-    def tearDown(self):
-        self.bar.destroy()
-        quodlibet.config.quit()
+            assert not bar.can_filter(key)
+        assert bar.can_filter("~dirname")

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -5,6 +5,8 @@
 
 import time
 
+import pytest
+
 from quodlibet import config
 from quodlibet.formats import AudioFile
 from quodlibet.plugins import Plugin
@@ -15,106 +17,105 @@ from senf import fsnative
 from tests import TestCase, skip
 
 
-class TQuery_is_valid(TestCase):
+class TestQuery_is_valid:
     def test_re(self):
-        self.failUnless(Query('t = /an re/').valid)
-        self.failUnless(Query('t = /an re/c').valid)
-        self.failUnless(Query('t = /an\\/re/').valid)
-        self.failIf(Query('t = /an/re/').valid)
-        self.failUnless(Query('t = /aaa/lsic').valid)
-        self.failIf(Query('t = /aaa/icslx').valid)
+        assert Query('t = /an re/').valid
+        assert Query('t = /an re/c').valid
+        assert Query('t = /an\\/re/').valid
+        assert not Query('t = /an/re/').valid
+        assert Query('t = /aaa/lsic').valid
+        assert not Query('t = /aaa/icslx').valid
 
     def test_str(self):
-        self.failUnless(Query('t = "a str"').valid)
-        self.failUnless(Query('t = "a str"c').valid)
-        self.failUnless(Query('t = "a\\"str"').valid)
+        assert Query('t = "a str"').valid
+        assert Query('t = "a str"c').valid
+        assert Query('t = "a\\"str"').valid
         # there's no equivalent failure for strings since 'str"' would be
         # read as a set of modifiers
 
     def test_tag(self):
-        self.failUnless(Query('t = tag').valid)
-        self.failUnless(Query('t = !tag').valid)
-        self.failUnless(Query('t = |(tag, bar)').valid)
-        self.failUnless(Query('t = a"tag"').valid)
-        self.failIf(Query('t = a, tag').valid)
-        self.failUnless(Query('tag with spaces = tag').valid)
+        assert Query('t = tag').valid
+        assert Query('t = !tag').valid
+        assert Query('t = |(tag, bar)').valid
+        assert Query('t = a"tag"').valid
+        assert not Query('t = a, tag').valid
+        assert Query('tag with spaces = tag').valid
 
     def test_empty(self):
-        self.failUnless(Query('').valid)
-        self.failUnless(Query('').is_parsable)
-        self.failUnless(Query(''))
+        assert Query('').valid
+        assert Query('').is_parsable
+        assert Query('')
 
     def test_emptylist(self):
-        self.failIf(Query("a = &()").valid)
-        self.failIf(Query("a = |()").valid)
-        self.failIf(Query("|()").valid)
-        self.failIf(Query("&()").valid)
+        assert not Query("a = &()").valid
+        assert not Query("a = |()").valid
+        assert not Query("|()").valid
+        assert not Query("&()").valid
 
     def test_nonsense(self):
-        self.failIf(Query('a string').valid)
-        self.failIf(Query('t = #(a > b)').valid)
-        self.failIf(Query("=a= = /b/").valid)
-        self.failIf(Query("a = &(/b//").valid)
-        self.failIf(Query("(a = &(/b//)").valid)
+        assert not Query('a string').valid
+        assert not Query('t = #(a > b)').valid
+        assert not Query("=a= = /b/").valid
+        assert not Query("a = &(/b//").valid
+        assert not Query("(a = &(/b//)").valid
 
     def test_trailing(self):
-        self.failIf(Query('t = /an re/)').valid)
-        self.failIf(Query('|(a, b = /a/, c, d = /q/) woo').valid)
+        assert not Query('t = /an re/)').valid
+        assert not Query('|(a, b = /a/, c, d = /q/) woo').valid
 
     def test_not(self):
-        self.failUnless(Query('t = !/a/').valid)
-        self.failUnless(Query('t = !!/a/').valid)
-        self.failUnless(Query('!t = "a"').valid)
-        self.failUnless(Query('!!t = "a"').valid)
-        self.failUnless(Query('t = !|(/a/, !"b")').valid)
-        self.failUnless(Query('t = !!|(/a/, !"b")').valid)
-        self.failUnless(Query('!|(t = /a/)').valid)
+        assert Query('t = !/a/').valid
+        assert Query('t = !!/a/').valid
+        assert Query('!t = "a"').valid
+        assert Query('!!t = "a"').valid
+        assert Query('t = !|(/a/, !"b")').valid
+        assert Query('t = !!|(/a/, !"b")').valid
+        assert Query('!|(t = /a/)').valid
 
     def test_taglist(self):
-        self.failUnless(Query('a, b = /a/').valid)
-        self.failUnless(Query('a, b, c = |(/a/)').valid)
-        self.failUnless(Query('|(a, b = /a/, c, d = /q/)').valid)
-        self.failIf(Query('a = /a/, b').valid)
+        assert Query('a, b = /a/').valid
+        assert Query('a, b, c = |(/a/)').valid
+        assert Query('|(a, b = /a/, c, d = /q/)').valid
+        assert not Query('a = /a/, b').valid
 
     def test_andor(self):
-        self.failUnless(Query('a = |(/a/, /b/)').valid)
-        self.failUnless(Query('a = |(/b/)').valid)
-        self.failUnless(Query('|(a = /b/, c = /d/)').valid)
+        assert Query('a = |(/a/, /b/)').valid
+        assert Query('a = |(/b/)').valid
+        assert Query('|(a = /b/, c = /d/)').valid
 
-        self.failUnless(Query('a = &(/a/, /b/)').valid)
-        self.failUnless(Query('a = &(/b/)').valid)
-        self.failUnless(Query('&(a = /b/, c = /d/)').valid)
+        assert Query('a = &(/a/, /b/)').valid
+        assert Query('a = &(/b/)').valid
+        assert Query('&(a = /b/, c = /d/)').valid
 
     def test_numcmp(self):
-        self.failUnless(Query("#(t < 3)").valid)
-        self.failUnless(Query("#(t <= 3)").valid)
-        self.failUnless(Query("#(t > 3)").valid)
-        self.failUnless(Query("#(t >= 3)").valid)
-        self.failUnless(Query("#(t = 3)").valid)
-        self.failUnless(Query("#(t != 3)").valid)
+        assert Query("#(t < 3)").valid
+        assert Query("#(t <= 3)").valid
+        assert Query("#(t > 3)").valid
+        assert Query("#(t >= 3)").valid
+        assert Query("#(t = 3)").valid
+        assert Query("#(t != 3)").valid
 
-        self.failIf(Query("#(t !> 3)").valid)
-        self.failIf(Query("#(t >> 3)").valid)
+        assert not Query("#(t !> 3)").valid
+        assert not Query("#(t >> 3)").valid
 
     def test_numcmp_func(self):
-        self.assertTrue(Query("#(t:min < 3)").valid)
-        self.assertTrue(
-            Query("&(#(playcount:min = 0), #(added < 1 month ago))").valid)
+        assert Query("#(t:min < 3)").valid
+        assert Query("&(#(playcount:min = 0), #(added < 1 month ago))").valid
 
     def test_trinary(self):
-        self.failUnless(Query("#(2 < t < 3)").valid)
-        self.failUnless(Query("#(2 >= t > 3)").valid)
+        assert Query("#(2 < t < 3)").valid
+        assert Query("#(2 >= t > 3)").valid
         # useless, but valid
-        self.failUnless(Query("#(5 > t = 2)").valid)
+        assert Query("#(5 > t = 2)").valid
 
     def test_list(self):
-        self.failUnless(Query("#(t < 3, t > 9)").valid)
-        self.failUnless(Query("t = &(/a/, /b/)").valid)
-        self.failUnless(Query("s, t = |(/a/, /b/)").valid)
-        self.failUnless(Query("|(t = /a/, s = /b/)").valid)
+        assert Query("#(t < 3, t > 9)").valid
+        assert Query("t = &(/a/, /b/)").valid
+        assert Query("s, t = |(/a/, /b/)").valid
+        assert Query("|(t = /a/, s = /b/)").valid
 
     def test_nesting(self):
-        self.failUnless(Query("|(s, t = &(/a/, /b/),!#(2 > q > 3))").valid)
+        assert Query("|(s, t = &(/a/, /b/),!#(2 > q > 3))").valid
 
     class FakeQueryPlugin(QueryPlugin):
         PLUGIN_NAME = "name"
@@ -154,34 +155,34 @@ class TQuery_is_valid(TestCase):
         assert not Query("@ )").valid
 
     def test_numexpr(self):
-        self.failUnless(Query("#(t < 3*4)").valid)
-        self.failUnless(Query("#(t * (1+r) < 7)").valid)
-        self.failUnless(Query("#(0 = t)").valid)
-        self.failUnless(Query("#(t < r < 9)").valid)
-        self.failUnless(Query("#((t-9)*r < -(6*2) = g*g-1)").valid)
-        self.failUnless(Query("#(t + 1 + 2 + -4 * 9 > g*(r/4 + 6))").valid)
-        self.failUnless(Query("#(date < 2010-4)").valid)
-        self.failUnless(Query("#(date < 2010 - 4)").valid)
-        self.failUnless(Query("#(date > 0000)").valid)
-        self.failUnless(Query("#(date > 00004)").valid)
-        self.failUnless(Query("#(added > today)").valid)
-        self.failUnless(Query("#(length < 5:00)").valid)
-        self.failUnless(Query("#(filesize > 5M)").valid)
-        self.failUnless(Query("#(added < 7 days ago)").valid)
+        assert Query("#(t < 3*4)").valid
+        assert Query("#(t * (1+r) < 7)").valid
+        assert Query("#(0 = t)").valid
+        assert Query("#(t < r < 9)").valid
+        assert Query("#((t-9)*r < -(6*2) = g*g-1)").valid
+        assert Query("#(t + 1 + 2 + -4 * 9 > g*(r/4 + 6))").valid
+        assert Query("#(date < 2010-4)").valid
+        assert Query("#(date < 2010 - 4)").valid
+        assert Query("#(date > 0000)").valid
+        assert Query("#(date > 00004)").valid
+        assert Query("#(added > today)").valid
+        assert Query("#(length < 5:00)").valid
+        assert Query("#(filesize > 5M)").valid
+        assert Query("#(added < 7 days ago)").valid
 
     def test_numexpr_failures(self):
-        self.failIf(Query("#(3*4)").valid)
-        self.failIf(Query("#(t = 3 + )").valid)
-        self.failIf(Query("#(t = -)").valid)
-        self.failIf(Query("#(-4 <)").valid)
-        self.failIf(Query("#(t < ()").valid)
-        self.failIf(Query("#((t +) - 1 > 8)").valid)
-        self.failIf(Query("#(t += 8)").valid)
+        assert not Query("#(3*4)").valid
+        assert not Query("#(t = 3 + )").valid
+        assert not Query("#(t = -)").valid
+        assert not Query("#(-4 <)").valid
+        assert not Query("#(t < ()").valid
+        assert not Query("#((t +) - 1 > 8)").valid
+        assert not Query("#(t += 8)").valid
 
     def test_numexpr_fails_for_wrong_units(self):
-        self.failIf(Query("#(t > 3 minutes)").valid)
-        self.failIf(Query("#(size < 3 minutes)").valid)
-        self.failIf(Query("#(date = 3 GB)").valid)
+        assert not Query("#(t > 3 minutes)").valid
+        assert not Query("#(size < 3 minutes)").valid
+        assert not Query("#(date = 3 GB)").valid
 
 
 class TQuery(TestCase):
@@ -216,8 +217,8 @@ class TQuery(TestCase):
         assert Query("album=/./").search(self.s2)
 
     def test_inequality(self):
-        self.failUnless(Query("album!=foo").search(self.s1))
-        self.failIf(Query("album!=foo").search(self.s2))
+        assert Query("album!=foo").search(self.s1)
+        assert not Query("album!=foo").search(self.s2)
 
     @skip("Enable for basic benchmarking of Query")
     def test_inequality_performance(self):
@@ -242,37 +243,35 @@ class TQuery(TestCase):
         for i in range(repeats):
             assert Query("album=!foo the bar").search(self.s1)
         not_val_time = (time.time() - t1)
-        self.assertAlmostEqual(ineq_time, not_val_time, places=1)
+        assert ineq_time == pytest.approx(not_val_time, abs=0.1)
 
     def test_repr(self):
         query = Query("foo = bar", [])
-        self.assertEqual(
-            repr(query).replace("u'", "'"),
-            "<Query string='foo = bar' type=VALID star=[]>")
+        r = repr(query).replace("u'", "'")
+        assert r == "<Query string='foo = bar' type=VALID star=[]>"
 
         query = Query("bar", ["foo"])
-        self.assertEqual(
-            repr(query).replace("u'", "'"),
-            "<Query string='&(/bar/d)' type=TEXT star=['foo']>")
+        r = repr(query).replace("u'", "'")
+        assert r == "<Query string='&(/bar/d)' type=TEXT star=['foo']>"
 
     def test_2007_07_27_synth_search(self):
         song = AudioFile({"~filename": fsnative(u"foo/64K/bar.ogg")})
         query = Query("~dirname = !64K")
-        self.failIf(query.search(song), "%r, %r" % (query, song))
+        assert not query.search(song), "%r, %r" % (query, song)
 
     def test_empty(self):
-        self.failIf(Query("foobar = /./").search(self.s1))
+        assert not Query("foobar = /./").search(self.s1)
 
     def test_gte(self):
-        self.failUnless(Query("#(track >= 11)").search(self.s2))
+        assert Query("#(track >= 11)").search(self.s2)
 
     def test_re(self):
         for s in ["album = /i hate/", "artist = /pi*/", "title = /x.y/"]:
-            self.failUnless(Query(s).search(self.s1))
-            self.failIf(Query(s).search(self.s2))
+            assert Query(s).search(self.s1)
+            assert not Query(s).search(self.s2)
         f = Query("artist = /mu|piman/").search
-        self.failUnless(f(self.s1))
-        self.failUnless(f(self.s2))
+        assert f(self.s1)
+        assert f(self.s2)
 
     def test_re_escape(self):
         af = AudioFile({"foo": "\""})
@@ -282,128 +281,128 @@ class TQuery(TestCase):
 
     def test_not(self):
         for s in ["album = !hate", "artist = !pi"]:
-            self.failIf(Query(s).search(self.s1))
-            self.failUnless(Query(s).search(self.s2))
+            assert not Query(s).search(self.s1)
+            assert Query(s).search(self.s2)
 
     def test_abbrs(self):
         for s in ["b = /i hate/", "a = /pi*/", "t = /x.y/"]:
-            self.failUnless(Query(s).search(self.s1))
-            self.failIf(Query(s).search(self.s2))
+            assert Query(s).search(self.s1)
+            assert not Query(s).search(self.s2)
 
     def test_str(self):
         for k in self.s2.keys():
             v = self.s2[k]
-            self.failUnless(Query('%s = "%s"' % (k, v)).search(self.s2))
-            self.failIf(Query('%s = !"%s"' % (k, v)).search(self.s2))
+            assert Query('%s = "%s"' % (k, v)).search(self.s2)
+            assert not Query('%s = !"%s"' % (k, v)).search(self.s2)
 
     def test_numcmp(self):
-        self.failIf(Query("#(track = 0)").search(self.s1))
-        self.failIf(Query("#(notatag = 0)").search(self.s1))
-        self.failUnless(Query("#(track = 12)").search(self.s2))
+        assert not Query("#(track = 0)").search(self.s1)
+        assert not Query("#(notatag = 0)").search(self.s1)
+        assert Query("#(track = 12)").search(self.s2)
 
     def test_trinary(self):
-        self.failUnless(Query("#(11 < track < 13)").search(self.s2))
-        self.failUnless(Query("#(11 < track <= 12)").search(self.s2))
-        self.failUnless(Query("#(12 <= track <= 12)").search(self.s2))
-        self.failUnless(Query("#(12 <= track < 13)").search(self.s2))
-        self.failUnless(Query("#(13 > track > 11)").search(self.s2))
-        self.failUnless(Query("#(20 > track < 20)").search(self.s2))
+        assert Query("#(11 < track < 13)").search(self.s2)
+        assert Query("#(11 < track <= 12)").search(self.s2)
+        assert Query("#(12 <= track <= 12)").search(self.s2)
+        assert Query("#(12 <= track < 13)").search(self.s2)
+        assert Query("#(13 > track > 11)").search(self.s2)
+        assert Query("#(20 > track < 20)").search(self.s2)
 
     def test_not_2(self):
         for s in ["album = !/i hate/", "artist = !/pi*/", "title = !/x.y/"]:
-            self.failUnless(Query(s).search(self.s2))
-            self.failIf(Query(s).search(self.s1))
+            assert Query(s).search(self.s2)
+            assert not Query(s).search(self.s1)
 
     def test_case(self):
-        self.failUnless(Query("album = /i hate/").search(self.s1))
-        self.failUnless(Query("album = /I Hate/").search(self.s1))
-        self.failUnless(Query("album = /i Hate/").search(self.s1))
-        self.failUnless(Query("album = /i Hate/i").search(self.s1))
-        self.failUnless(Query(u"title = /ångström/").search(self.s4))
-        self.failIf(Query("album = /i hate/c").search(self.s1))
-        self.failIf(Query(u"title = /ångström/c").search(self.s4))
+        assert Query("album = /i hate/").search(self.s1)
+        assert Query("album = /I Hate/").search(self.s1)
+        assert Query("album = /i Hate/").search(self.s1)
+        assert Query("album = /i Hate/i").search(self.s1)
+        assert Query(u"title = /ångström/").search(self.s4)
+        assert not Query("album = /i hate/c").search(self.s1)
+        assert not Query(u"title = /ångström/c").search(self.s4)
 
     def test_re_and(self):
-        self.failUnless(Query("album = &(/ate/,/est/)").search(self.s1))
-        self.failIf(Query("album = &(/ate/, /ets/)").search(self.s1))
-        self.failIf(Query("album = &(/tate/, /ets/)").search(self.s1))
+        assert Query("album = &(/ate/,/est/)").search(self.s1)
+        assert not Query("album = &(/ate/, /ets/)").search(self.s1)
+        assert not Query("album = &(/tate/, /ets/)").search(self.s1)
 
     def test_re_or(self):
-        self.failUnless(Query("album = |(/ate/,/est/)").search(self.s1))
-        self.failUnless(Query("album = |(/ate/,/ets/)").search(self.s1))
-        self.failIf(Query("album = |(/tate/, /ets/)").search(self.s1))
+        assert Query("album = |(/ate/,/est/)").search(self.s1)
+        assert Query("album = |(/ate/,/ets/)").search(self.s1)
+        assert not Query("album = |(/tate/, /ets/)").search(self.s1)
 
     def test_newlines(self):
-        self.failUnless(Query("a = /\n/").search(self.s3))
-        self.failUnless(Query("a = /\\n/").search(self.s3))
-        self.failIf(Query("a = /\n/").search(self.s2))
-        self.failIf(Query("a = /\\n/").search(self.s2))
+        assert Query("a = /\n/").search(self.s3)
+        assert Query("a = /\\n/").search(self.s3)
+        assert not Query("a = /\n/").search(self.s2)
+        assert not Query("a = /\\n/").search(self.s2)
 
     def test_exp_and(self):
-        self.failUnless(Query("&(album = ate, artist = man)").search(self.s1))
-        self.failIf(Query("&(album = ate, artist = nam)").search(self.s1))
-        self.failIf(Query("&(album = tea, artist = nam)").search(self.s1))
+        assert Query("&(album = ate, artist = man)").search(self.s1)
+        assert not Query("&(album = ate, artist = nam)").search(self.s1)
+        assert not Query("&(album = tea, artist = nam)").search(self.s1)
 
     def test_exp_or(self):
-        self.failUnless(Query("|(album = ate, artist = man)").search(self.s1))
-        self.failUnless(Query("|(album = ate, artist = nam)").search(self.s1))
-        self.failIf(Query("&(album = tea, artist = nam)").search(self.s1))
+        assert Query("|(album = ate, artist = man)").search(self.s1)
+        assert Query("|(album = ate, artist = nam)").search(self.s1)
+        assert not Query("&(album = tea, artist = nam)").search(self.s1)
 
     def test_dumb_search(self):
-        self.failUnless(Query("ate man").search(self.s1))
-        self.failUnless(Query("Ate man").search(self.s1))
-        self.failIf(Query("woo man").search(self.s1))
-        self.failIf(Query("not crazy").search(self.s1))
+        assert Query("ate man").search(self.s1)
+        assert Query("Ate man").search(self.s1)
+        assert not Query("woo man").search(self.s1)
+        assert not Query("not crazy").search(self.s1)
 
     def test_dumb_search_value(self):
-        self.failUnless(Query("|(ate, foobar)").search(self.s1))
-        self.failUnless(Query("!!|(ate, foobar)").search(self.s1))
-        self.failUnless(Query("&(ate, te)").search(self.s1))
-        self.failIf(Query("|(foo, bar)").search(self.s1))
-        self.failIf(Query("&(ate, foobar)").search(self.s1))
-        self.failIf(Query("! !&(ate, foobar)").search(self.s1))
-        self.failIf(Query("&blah").search(self.s1))
-        self.failUnless(Query("&blah oh").search(self.s5))
-        self.failUnless(Query("!oh no").search(self.s5))
-        self.failIf(Query("|blah").search(self.s1))
+        assert Query("|(ate, foobar)").search(self.s1)
+        assert Query("!!|(ate, foobar)").search(self.s1)
+        assert Query("&(ate, te)").search(self.s1)
+        assert not Query("|(foo, bar)").search(self.s1)
+        assert not Query("&(ate, foobar)").search(self.s1)
+        assert not Query("! !&(ate, foobar)").search(self.s1)
+        assert not Query("&blah").search(self.s1)
+        assert Query("&blah oh").search(self.s5)
+        assert Query("!oh no").search(self.s5)
+        assert not Query("|blah").search(self.s1)
         # https://github.com/quodlibet/quodlibet/issues/1056
-        self.failUnless(Query("&(ate, piman)").search(self.s1))
+        assert Query("&(ate, piman)").search(self.s1)
 
     def test_dumb_search_value_negate(self):
-        self.failUnless(Query("!xyz").search(self.s1))
-        self.failUnless(Query("!!!xyz").search(self.s1))
-        self.failUnless(Query(" !!!&(xyz, zyx)").search(self.s1))
-        self.failIf(Query("!man").search(self.s1))
+        assert Query("!xyz").search(self.s1)
+        assert Query("!!!xyz").search(self.s1)
+        assert Query(" !!!&(xyz, zyx)").search(self.s1)
+        assert not Query("!man").search(self.s1)
 
-        self.failUnless(Query("&(tests,piman)").search(self.s1))
-        self.failUnless(Query("&(tests,!nope)").search(self.s1))
-        self.failIf(Query("&(tests,!!nope)").search(self.s1))
-        self.failIf(Query("&(tests,!piman)").search(self.s1))
-        self.failUnless(Query("&(tests,|(foo,&(pi,!nope)))").search(self.s1))
+        assert Query("&(tests,piman)").search(self.s1)
+        assert Query("&(tests,!nope)").search(self.s1)
+        assert not Query("&(tests,!!nope)").search(self.s1)
+        assert not Query("&(tests,!piman)").search(self.s1)
+        assert Query("&(tests,|(foo,&(pi,!nope)))").search(self.s1)
 
     def test_dumb_search_regexp(self):
-        self.failUnless(Query("/(x|H)ate/").search(self.s1))
-        self.failUnless(Query("'PiMan'").search(self.s1))
-        self.failIf(Query("'PiMan'c").search(self.s1))
-        self.failUnless(Query("!'PiMan'c").search(self.s1))
-        self.failIf(Query("!/(x|H)ate/").search(self.s1))
+        assert Query("/(x|H)ate/").search(self.s1)
+        assert Query("'PiMan'").search(self.s1)
+        assert not Query("'PiMan'c").search(self.s1)
+        assert Query("!'PiMan'c").search(self.s1)
+        assert not Query("!/(x|H)ate/").search(self.s1)
 
     def test_unslashed_search(self):
-        self.failUnless(Query("artist=piman").search(self.s1))
-        self.failUnless(Query(u"title=ång").search(self.s4))
-        self.failIf(Query("artist=mu").search(self.s1))
-        self.failIf(Query(u"title=äng").search(self.s4))
+        assert Query("artist=piman").search(self.s1)
+        assert Query(u"title=ång").search(self.s4)
+        assert not Query("artist=mu").search(self.s1)
+        assert not Query(u"title=äng").search(self.s4)
 
     def test_synth_search(self):
-        self.failUnless(Query("~dirname=/dir1/").search(self.s1))
-        self.failUnless(Query("~dirname=/dir2/").search(self.s2))
-        self.failIf(Query("~dirname=/dirty/").search(self.s1))
-        self.failIf(Query("~dirname=/dirty/").search(self.s2))
+        assert Query("~dirname=/dir1/").search(self.s1)
+        assert Query("~dirname=/dir2/").search(self.s2)
+        assert not Query("~dirname=/dirty/").search(self.s1)
+        assert not Query("~dirname=/dirty/").search(self.s2)
 
     def test_search_almostequal(self):
         a, b = AudioFile({"~#rating": 0.771}), AudioFile({"~#rating": 0.769})
-        self.failUnless(Query("#(rating = 0.77)").search(a))
-        self.failUnless(Query("#(rating = 0.77)").search(b))
+        assert Query("#(rating = 0.77)").search(a)
+        assert Query("#(rating = 0.77)").search(b)
 
     def test_and_or_neg_operator(self):
         union = Query("|(foo=bar,bar=foo)")
@@ -415,82 +414,80 @@ class TQuery(TestCase):
         tests = [inter | tag, tag | tag, neg | neg, tag | inter, neg | union,
                  union | union, inter | inter, numcmp | numcmp, numcmp | union]
 
-        self.failIf(
-            list(filter(lambda x: not isinstance(x, match.Union), tests)))
+        assert not [x for x in tests if not isinstance(x, match.Union)]
 
         tests = [inter & tag, tag & tag, neg & neg, tag & inter, neg & union,
                  union & union, inter & inter, numcmp & numcmp, numcmp & inter]
 
-        self.failIf(
-            list(filter(lambda x: not isinstance(x, match.Inter), tests)))
+        assert not [x for x in tests if not isinstance(x, match.Inter)]
 
-        self.assertTrue(isinstance(-neg, match.Tag))
+        assert isinstance(-neg, match.Tag)
 
         true = Query("")
-        self.assertTrue(isinstance(true | inter, match.True_))
-        self.assertTrue(isinstance(inter | true, match.True_))
-        self.assertTrue(isinstance(true & inter, match.Inter))
-        self.assertTrue(isinstance(inter & true, match.Inter))
-        self.assertTrue(isinstance(true & true, match.True_))
-        self.assertTrue(isinstance(true | true, match.True_))
-        self.assertTrue(isinstance(-true, match.Neg))
+        assert isinstance(true | inter, match.True_)
+        assert isinstance(inter | true, match.True_)
+        assert isinstance(true & inter, match.Inter)
+        assert isinstance(inter & true, match.Inter)
+        assert isinstance(true & true, match.True_)
+        assert isinstance(true | true, match.True_)
+        assert isinstance(-true, match.Neg)
 
     def test_filter(self):
         q = Query("artist=piman")
-        self.assertEqual(q.filter([self.s1, self.s2]), [self.s1])
-        self.assertEqual(q.filter(iter([self.s1, self.s2])), [self.s1])
+        assert q.filter([self.s1, self.s2]) == [self.s1]
+        assert q.filter(iter([self.s1, self.s2])) == [self.s1]
 
         q = Query("")
-        self.assertEqual(q.filter([self.s1, self.s2]), [self.s1, self.s2])
-        self.assertEqual(
-            q.filter(iter([self.s1, self.s2])), [self.s1, self.s2])
+        assert q.filter([self.s1, self.s2]), [self.s1 == self.s2]
+        assert q.filter(iter([self.s1, self.s2])), [self.s1 == self.s2]
 
     def test_match_all(self):
-        self.failUnless(Query("").matches_all)
-        self.failUnless(Query("    ").matches_all)
-        self.failIf(Query("foo").matches_all)
+        assert Query("").matches_all
+        assert Query("    ").matches_all
+        assert not Query("foo").matches_all
 
     def test_utf8(self):
         # also handle undecoded values
-        self.assertTrue(Query(u"utf8=Ångström").search(self.s4))
+        assert Query(u"utf8=Ångström").search(self.s4)
 
     def test_fs_utf8(self):
-        self.failUnless(Query(u"~filename=foü.ogg").search(self.s3))
-        self.failUnless(Query(u"~filename=öä").search(self.s3))
-        self.failUnless(Query(u"~dirname=öäü").search(self.s3))
-        self.failUnless(Query(u"~basename=ü.ogg").search(self.s3))
+        assert Query(u"~filename=foü.ogg").search(self.s3)
+        assert Query(u"~filename=öä").search(self.s3)
+        assert Query(u"~dirname=öäü").search(self.s3)
+        assert Query(u"~basename=ü.ogg").search(self.s3)
 
     def test_filename_utf8_fallback(self):
-        self.failUnless(Query(u"filename=foü.ogg").search(self.s3))
-        self.failUnless(Query(u"filename=öä").search(self.s3))
+        assert Query(u"filename=foü.ogg").search(self.s3)
+        assert Query(u"filename=öä").search(self.s3)
 
     def test_mountpoint_utf8_fallback(self):
-        self.failUnless(Query(u"mountpoint=foü").search(self.s3))
-        self.failUnless(Query(u"mountpoint=öä").search(self.s3))
+        assert Query(u"mountpoint=foü").search(self.s3)
+        assert Query(u"mountpoint=öä").search(self.s3)
 
     def test_mountpoint_no_value(self):
         af = AudioFile({"~filename": fsnative(u"foo")})
         assert not Query(u"~mountpoint=bla").search(af)
 
     def test_star_numeric(self):
-        self.assertRaises(ValueError, Query, u"foobar", star=["~#mtime"])
+        with pytest.raises(ValueError):
+            Query(u"foobar", star=["~#mtime"])
 
     def test_match_diacriticals_explcit(self):
         assert Query(u'title=angstrom').search(self.s4)
-        self.failIf(Query(u'title="Ångstrom"').search(self.s4))
-        self.failUnless(Query(u'title="Ångstrom"d').search(self.s4))
-        self.failUnless(Query(u'title=Ångström').search(self.s4))
-        self.failUnless(Query(u'title="Ångström"').search(self.s4))
-        self.failUnless(Query(u'title=/Ångström/').search(self.s4))
-        self.failUnless(Query(u'title="Ångstrom"d').search(self.s4))
-        self.failUnless(Query(u'title=/Angstrom/d').search(self.s4))
-        self.failUnless(Query(u'""d').search(self.s4))
+        assert not Query(u'title="Ångstrom"').search(self.s4)
+        assert Query(u'title="Ångstrom"d').search(self.s4)
+        assert Query(u'title=Ångström').search(self.s4)
+        assert Query(u'title="Ångström"').search(self.s4)
+        assert Query(u'title=/Ångström/').search(self.s4)
+        assert Query(u'title="Ångstrom"d').search(self.s4)
+        assert Query(u'title=/Angstrom/d').search(self.s4)
+        assert Query(u'""d').search(self.s4)
 
     def test_match_diacriticals_dumb(self):
-        self.assertTrue(Query(u'Angstrom').search(self.s4))
-        self.assertTrue(Query(u'Ångström').search(self.s4))
-        self.assertTrue(Query(u'Ångstrom').search(self.s4))
-        self.assertFalse(Query(u'Ängström').search(self.s4))
+        assert Query(u'Angstrom').search(self.s4)
+        assert Query(u'Ångström').search(self.s4)
+        assert Query(u'Ångstrom').search(self.s4)
+        assert not Query(u'Ängström').search(self.s4)
 
     def test_match_diacriticals_invalid_or_unsupported(self):
         # these fall back to test dumb searches:
@@ -500,53 +497,50 @@ class TQuery(TestCase):
         Query(u'/(<)?(\\w+@\\w+(?:\\.\\w+)+)(?(1)>)/d')
 
     def test_numexpr(self):
-        self.failUnless(Query("#(length = 224)").search(self.s1))
-        self.failUnless(Query("#(length = 3:44)").search(self.s1))
-        self.failUnless(Query("#(length = 3 minutes + 44 seconds)")
-                        .search(self.s1))
-        self.failUnless(Query("#(playcount > skipcount)").search(self.s1))
-        self.failUnless(Query("#(playcount < 2 * skipcount)").search(self.s1))
-        self.failUnless(Query("#(length > 3 minutes)").search(self.s1))
-        self.failUnless(Query("#(3:00 < length < 4:00)").search(self.s1))
-        self.failUnless(Query("#(40 seconds < length/5 < 1 minute)")
-                        .search(self.s1))
-        self.failUnless(Query("#(2+3 * 5 = 17)").search(self.s1))
-        self.failUnless(Query("#(playcount / 0 > 0)").search(self.s1))
+        assert Query("#(length = 224)").search(self.s1)
+        assert Query("#(length = 3:44)").search(self.s1)
+        assert Query("#(length = 3 minutes + 44 seconds)").search(self.s1)
+        assert Query("#(playcount > skipcount)").search(self.s1)
+        assert Query("#(playcount < 2 * skipcount)").search(self.s1)
+        assert Query("#(length > 3 minutes)").search(self.s1)
+        assert Query("#(3:00 < length < 4:00)").search(self.s1)
+        assert Query("#(40 seconds < length/5 < 1 minute)").search(self.s1)
+        assert Query("#(2+3 * 5 = 17)").search(self.s1)
+        assert Query("#(playcount / 0 > 0)").search(self.s1)
 
-        self.failIf(Query("#(track + 1 != 13)").search(self.s2))
+        assert not Query("#(track + 1 != 13)").search(self.s2)
 
     def test_numexpr_date(self):
-        self.failUnless(Query("#(length < 2005-07-19)").search(self.s1))
-        self.failUnless(Query("#(date > 2005-07-19)").search(self.s1))
-        self.failUnless(Query("#(2005-11-24 < 2005-07-19)").search(self.s1))
-        self.failUnless(Query("#(date = (2007-05-19) + 5 days)")
-                        .search(self.s1))
-        self.failUnless(Query("#(date - 5 days = 2007-05-19)").search(self.s1))
-        self.failUnless(Query("#(2010-02-18 > date)").search(self.s1))
-        self.failUnless(Query("#(2010 > date)").search(self.s1))
-        self.failUnless(Query("#(date > 4)").search(self.s1))
-        self.failUnless(Query("#(date > 0004)").search(self.s1))
-        self.failUnless(Query("#(date > 0000)").search(self.s1))
+        assert Query("#(length < 2005-07-19)").search(self.s1)
+        assert Query("#(date > 2005-07-19)").search(self.s1)
+        assert Query("#(2005-11-24 < 2005-07-19)").search(self.s1)
+        assert Query("#(date = (2007-05-19) + 5 days)").search(self.s1)
+        assert Query("#(date - 5 days = 2007-05-19)").search(self.s1)
+        assert Query("#(2010-02-18 > date)").search(self.s1)
+        assert Query("#(2010 > date)").search(self.s1)
+        assert Query("#(date > 4)").search(self.s1)
+        assert Query("#(date > 0004)").search(self.s1)
+        assert Query("#(date > 0000)").search(self.s1)
 
     def test_ignore_characters(self):
         try:
             config.set("browsers", "ignored_characters", "-")
-            self.failUnless(Query("Foo the Bar - mu").search(self.s2))
+            assert Query("Foo the Bar - mu").search(self.s2)
             config.set("browsers", "ignored_characters", "1234")
-            self.failUnless(Query("4Fo13o 2th2e3 4Bar4").search(self.s2))
+            assert Query("4Fo13o 2th2e3 4Bar4").search(self.s2)
         finally:
             config.reset("browsers", "ignored_characters")
 
 
-class TQuery_get_type(TestCase):
+class TestQuery_get_type:
     def test_red(self):
         for p in ["a = /w", "|(sa#"]:
-            self.failUnlessEqual(QueryType.INVALID, Query(p).type)
+            assert Query(p).type == QueryType.INVALID
 
     def test_black(self):
         for p in ["a test", "more test hooray"]:
-            self.failUnlessEqual(QueryType.TEXT, Query(p).type)
+            assert Query(p).type == QueryType.TEXT
 
     def test_green(self):
         for p in ["a = /b/", "&(a = b, c = d)", "/abc/", "!x", "!&(abc, def)"]:
-            self.failUnlessEqual(QueryType.VALID, Query(p).type)
+            assert Query(p).type == QueryType.VALID


### PR DESCRIPTION
For a few files / classes:
 * Switch to native asserts where possible, mostly regex-replace friendly actually
 * Use `skipIf` a bit more rather than just `return` which doesn't record anything (TODO: maybe use pytest `mark` here too)
 * Convert a few `TestCase` classes to just plain wrappers with fixtures