### PR TITLE
builtin cover: fix handling of invalid glob ranges with Python 3.10.5+

### DIFF
--- a/tests/test_util_cover.py
+++ b/tests/test_util_cover.py
@@ -105,15 +105,9 @@ class TCoverManager(TestCase):
         config.set("albumart", "force_filename", str(True))
         config.set("albumart", "filename", "[a-2].jpg")
 
-        # Should match
-        f = self.add_file("[a-2].jpg")
-        assert path_equal(
-            os.path.abspath(self._find_cover(self.song).name), f)
-
-        # Should not crash
-        f = self.add_file("test.jpg")
-        assert not path_equal(
-            os.path.abspath(self._find_cover(self.song).name), f)
+        # Invalid glob range, should not match anything
+        self.add_file("a.jpg")
+        assert self._find_cover(self.song) is None
 
     def test_invalid_glob_path(self):
         config.set("albumart", "force_filename", str(True))


### PR DESCRIPTION
Previously Python would raise if an invalid range was given
to glob, but with 3.10.5 they fixed it to not match anything.
https://github.com/python/cpython/issues/89973

Our tests depended on the previous logic and treating the glob pattern
as a literal file name in that case.

One could argue that this is wrong since a range that doesn't contain anything
should also not match anything, so wrap glob() to make it not match for all
Python versions in that case and adjust the tests accordingly.

This should fix the Windows CI, which is currently the only job using 3.10.5
