### PR TITLE
operon: fix flaky check for whether content had changed

### DIFF
--- a/quodlibet/operon/commands.py
+++ b/quodlibet/operon/commands.py
@@ -234,6 +234,7 @@ class EditCommand(Command):
         try:
             try:
                 os.write(fd, dump)
+                os.fsync(fd)
             finally:
                 os.close(fd)
 


### PR DESCRIPTION
It was noting the mtime before calling the editor and afterwards to compare
if anything had chanaged with the file.

The last mtime change was due to the write() and subsequent close() call,
but that doesn't guarantee that things are written, so in some cases the mtime
changed after the next stat() call, making the initial noted mtime wrong.

Fix by calling fsync() before getting the initial mtime.

(For some reason this only fails on newer Linux, so maybe something changed
there re buffering, or in the filesystem)

Fixes #3966
