### PR TITLE
Make songs heading entries editable (#4046)

### DIFF
--- a/quodlibet/ext/songsmenu/wikipedia.py
+++ b/quodlibet/ext/songsmenu/wikipedia.py
@@ -1,5 +1,6 @@
 # Copyright 2005 Inigo Serna
 #           2018 Phoenix Dailey, Fredrik Strupe
+#           2022 Nick Boultbee
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -63,12 +64,10 @@ class WikiSearch(SongsMenuPlugin):
 
         def _open_editor(widget):
             def _editor_closed(widget):
-                tags = widget.get_strings()
-                config.setlist("plugins", "wiki_tags", tags)
+                config.setlist("plugins", "wiki_tags", widget.tags)
 
             tags = config.getlist("plugins", "wiki_tags", self.DEFAULT_TAGS)
-            editor = TagListEditor(_("Edit Tags"),
-                        [] if tags == [''] else tags)
+            editor = TagListEditor(_("Edit Tags"), [] if tags == [''] else tags)
             editor.set_transient_for(get_top_parent(parent))
             editor.connect('destroy', _editor_closed)
             editor.show()

--- a/quodlibet/qltk/data_editors.py
+++ b/quodlibet/qltk/data_editors.py
@@ -1,9 +1,10 @@
-# Copyright 2012-2016 Nick Boultbee
+# Copyright 2012-2022 Nick Boultbee
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation; either version 2 of the License, or
 # (at your option) any later version.
+from typing import Iterable
 
 from gi.repository import Gtk
 from gi.repository import Pango
@@ -16,7 +17,7 @@ from quodlibet.qltk.x import MenuItem, Button, Align
 from quodlibet.qltk import Icons
 from quodlibet.query import Query
 from quodlibet.util.json_data import JSONObjectDict
-from quodlibet.util import connect_obj
+from quodlibet.util import connect_obj, escape
 from quodlibet.qltk.getstring import GetStringDialog
 
 
@@ -267,7 +268,6 @@ class TagListEditor(qltk.Window):
     def __init__(self, title, values=None):
         super().__init__()
         self.use_header_bar()
-        self.data = values or []
         self.set_border_width(12)
         self.set_title(title)
         self.set_default_size(self._WIDTH, self._HEIGHT)
@@ -277,12 +277,17 @@ class TagListEditor(qltk.Window):
 
         # Set up the model for this widget
         self.model = Gtk.ListStore(str)
-        self.__fill_values()
+        self.__fill_values(values or [])
+
+        def on_row_activated(view, path, column):
+            self._renderer.set_property('editable', True)
+            view.set_cursor(path, view.get_columns()[0], start_editing=True)
 
         # Main view
         view = self.view = HintedTreeView(model=self.model)
         view.set_fixed_height_mode(True)
         view.set_headers_visible(False)
+        view.connect("row-activated", on_row_activated)
 
         sw = Gtk.ScrolledWindow()
         sw.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
@@ -329,6 +334,13 @@ class TagListEditor(qltk.Window):
         self.add(vbox)
         self.get_child().show_all()
 
+    def __start_editing(self, _render, editable, path):
+        editable.set_text(self.model[path][0])
+
+    def __edited(self, _render, path, new_name):
+        self.model[path][0] = new_name
+        self.model.row_changed(path, self.model.get_iter(path))
+
     def __setup_column(self, view):
         def tag_cdf(column, cell, model, iter, data):
             row = model[iter]
@@ -338,31 +350,41 @@ class TagListEditor(qltk.Window):
         def desc_cdf(column, cell, model, iter, data):
             row = model[iter]
             if row:
-                cell.set_property('text', util.tag(row[0]))
+                escaped = escape(util.tag(row[0]))
+                cell.set_property('markup', f"<i>{escaped}</i>")
 
-        render = Gtk.CellRendererText()
-        column = Gtk.TreeViewColumn(_("Tag expression"), render)
-        column.set_cell_data_func(render, tag_cdf)
+        def __create_cell_renderer():
+            r = Gtk.CellRendererText()
+            r.connect('editing-started', self.__start_editing)
+            r.connect('edited', self.__edited)
+            return r
+
+        self._renderer = renderer = __create_cell_renderer()
+        column = Gtk.TreeViewColumn(_("Tag expression"), renderer)
+        column.set_cell_data_func(renderer, tag_cdf)
         column.set_sizing(Gtk.TreeViewColumnSizing.FIXED)
         column.set_expand(True)
         view.append_column(column)
 
-        render = Gtk.CellRendererText()
-        render.set_property('ellipsize', Pango.EllipsizeMode.END)
-        column = Gtk.TreeViewColumn(_("Description"), render)
-        column.set_cell_data_func(render, desc_cdf)
+        renderer = Gtk.CellRendererText()
+        renderer.set_property('ellipsize', Pango.EllipsizeMode.END)
+        renderer.set_property('sensitive', False)
+        column = Gtk.TreeViewColumn(_("Description"), renderer)
+        column.set_cell_data_func(renderer, desc_cdf)
         column.set_sizing(Gtk.TreeViewColumnSizing.FIXED)
         column.set_expand(True)
+
         view.append_column(column)
         view.set_headers_visible(True)
 
-    def __fill_values(self):
-        for s in self.data:
+    def __fill_values(self, data: Iterable[str]):
+        for s in data:
             self.model.append(row=[s])
 
-    def get_strings(self):
-        strings = [row[0] for row in self.model if row]
-        return strings
+    @property
+    def tags(self):
+        """Returns the tag names as edited"""
+        return [row[0] for row in self.model if row]
 
     def __remove(self, *args):
         self.view.remove_selection()

--- a/tests/test_qltk_data_editors.py
+++ b/tests/test_qltk_data_editors.py
@@ -8,21 +8,21 @@ from tests import TestCase
 from quodlibet.qltk.data_editors import TagListEditor
 
 
-class TMultiStringEditor(TestCase):
+class TTagListEditor(TestCase):
 
     def setUp(self):
         config.init()
 
     def test_no_strings(self):
         mse = TagListEditor("title")
-        self.failUnlessEqual(mse.get_strings(), [])
+        self.failUnlessEqual(mse.tags, [])
         self.failUnlessEqual(mse.get_title(), "title")
         mse.destroy()
 
     def test_defaulting(self):
         defaults = ["one", "two three"]
         mse = TagListEditor("title", defaults)
-        self.failUnlessEqual(mse.get_strings(), defaults)
+        self.failUnlessEqual(mse.tags, defaults)
         mse.destroy()
 
     def tearDown(self):


### PR DESCRIPTION
* Rename `get_strings()` -> `tags` for brevity and clarity
* Redo the UI for description to indicate better that it's _not_ editable
* And indicate it's human text (by italics but YMMV)
* Rethink around column ordering to accommodate this. Seems nicer now in all my manual testing
 TODO: more manual testing

Fixes #4046

