### PR TITLE
operon: hopefully better fix for flaky mtime tests

### DIFF
--- a/quodlibet/operon/commands.py
+++ b/quodlibet/operon/commands.py
@@ -234,7 +234,6 @@ class EditCommand(Command):
         try:
             try:
                 os.write(fd, dump)
-                os.fsync(fd)
             finally:
                 os.close(fd)
 

--- a/quodlibet/operon/commands.py
+++ b/quodlibet/operon/commands.py
@@ -227,15 +227,15 @@ class EditCommand(Command):
         # write to tmp file
         fd, path = tempfile.mkstemp(suffix=".txt")
 
-        # XXX: copy mtime here so we can test for changes in tests by
-        # setting a out of date mtime on the source song file
-        copy_mtime(args[0], path)
-
         try:
             try:
                 os.write(fd, dump)
             finally:
                 os.close(fd)
+
+            # XXX: copy mtime here so we can test for changes in tests by
+            # setting a out of date mtime on the source song file
+            copy_mtime(args[0], path)
 
             # only parse the result if the editor returns 0 and the mtime has
             # changed

--- a/tests/test_operon.py
+++ b/tests/test_operon.py
@@ -8,8 +8,6 @@
 import os
 import sys
 
-import pytest
-
 from quodlibet.util import is_osx, is_windows
 from senf import fsnative, path2fsn
 
@@ -357,7 +355,6 @@ class TOperonEdit(TOperonBase):
         os.environ["VISUAL"] = "false"
         self.check_false(["edit", self.f], False, True)
 
-    @pytest.mark.flaky(max_runs=4, min_passes=1)
     def test_dry_run(self):
         if os.name == "nt" or sys.platform == "darwin":
             return
@@ -378,7 +375,6 @@ class TOperonEdit(TOperonBase):
         self.assertEqual(sorted(old_items), sorted(realitems(self.s)))
 
     @skipIf(is_windows() or is_osx(), "Linux only, uses truncate")
-    @pytest.mark.flaky(max_runs=4, min_passes=1)
     def test_remove_all(self):
 
         os.environ["VISUAL"] = "truncate -s 0"


### PR DESCRIPTION
on a second thought the old fix didn't make much sense... but I also don't understand why mtime changes are so async in newer ubuntu..