### PR TITLE
Remove glib2fsn() and fsn2glib()

### DIFF
--- a/quodlibet/ext/songsmenu/playlist.py
+++ b/quodlibet/ext/songsmenu/playlist.py
@@ -17,7 +17,7 @@ from os.path import relpath
 from quodlibet.plugins.playlist import PlaylistPlugin
 from quodlibet import _
 from quodlibet import util, qltk
-from quodlibet.util.path import glib2fsn, get_home_dir
+from quodlibet.util.path import get_home_dir
 from quodlibet.qltk.msg import ConfirmFileReplace
 from quodlibet.qltk import Icons
 from quodlibet.plugins.songsmenu import SongsMenuPlugin
@@ -81,7 +81,7 @@ class PlaylistExport(PlaylistPlugin, SongsMenuPlugin):
         response = dialog.run()
 
         if response == Gtk.ResponseType.OK:
-            file_path = glib2fsn(dialog.get_filename())
+            file_path = dialog.get_filename()
             dir_path = os.path.dirname(file_path)
 
             file_format = dialog.get_filter().get_name()

--- a/quodlibet/qltk/chooser.py
+++ b/quodlibet/qltk/chooser.py
@@ -14,7 +14,7 @@ from senf import fsnative, path2fsn, fsn2bytes, bytes2fsn
 from quodlibet import _
 from quodlibet import config
 from quodlibet.qltk import get_top_parent, gtk_version
-from quodlibet.util.path import fsn2glib, glib2fsn, get_home_dir
+from quodlibet.util.path import get_home_dir
 from quodlibet.util import is_windows
 
 
@@ -75,7 +75,7 @@ def _run_chooser(parent, chooser):
         List[fsnative]
     """
 
-    chooser.set_current_folder(fsn2glib(get_current_dir()))
+    chooser.set_current_folder(get_current_dir())
     chooser.set_transient_for(get_top_parent(parent))
 
     if _response is not None:
@@ -86,11 +86,11 @@ def _run_chooser(parent, chooser):
         response = chooser.run()
 
     if response == Gtk.ResponseType.ACCEPT:
-        result = [glib2fsn(fn) for fn in chooser.get_filenames()]
+        result = [fn for fn in chooser.get_filenames()]
 
         current_dir = chooser.get_current_folder()
         if current_dir:
-            set_current_dir(glib2fsn(current_dir))
+            set_current_dir(current_dir)
     else:
         result = []
     chooser.destroy()
@@ -170,7 +170,7 @@ def create_chooser_filter(name, patterns):
     filter_ = Gtk.FileFilter()
     filter_.set_name(name)
     for pattern in sorted(set(patterns)):
-        filter_.add_pattern(fsn2glib(path2fsn(pattern)))
+        filter_.add_pattern(path2fsn(pattern))
     return filter_
 
 

--- a/quodlibet/qltk/filesel.py
+++ b/quodlibet/qltk/filesel.py
@@ -25,7 +25,7 @@ from quodlibet.qltk.x import ScrolledWindow, Paned
 from quodlibet.qltk.models import ObjectStore, ObjectTreeStore
 from quodlibet.qltk import Icons
 from quodlibet.util.path import listdir, \
-    glib2fsn, xdg_get_user_dirs, get_home_dir, xdg_get_config_home
+    xdg_get_user_dirs, get_home_dir, xdg_get_config_home
 from quodlibet.util import connect_obj
 
 
@@ -130,7 +130,7 @@ def get_drives():
     for mount in Gio.VolumeMonitor.get().get_mounts():
         path = mount.get_root().get_path()
         if path is not None:
-            paths.append(glib2fsn(path))
+            paths.append(path)
     if os.name != "nt":
         paths.append("/")
     return sorted(paths)
@@ -375,7 +375,6 @@ class DirectoryTree(RCMHintedTreeView, MultiDragTreeView):
         if not dir_:
             return
 
-        dir_ = glib2fsn(dir_)
         fullpath = os.path.realpath(os.path.join(directory, dir_))
 
         try:

--- a/quodlibet/util/path.py
+++ b/quodlibet/util/path.py
@@ -41,18 +41,6 @@ def mkdir(dir_, *args):
             raise
 
 
-def glib2fsn(path):
-    """Takes a glib filename and returns a fsnative path"""
-
-    return path
-
-
-def fsn2glib(path):
-    """Takes a fsnative path and returns a glib filename"""
-
-    return path
-
-
 def uri2gsturi(uri):
     """Takes a correct uri and returns a gstreamer-compatible uri"""
     if not is_windows():
@@ -235,7 +223,7 @@ def xdg_get_system_data_dirs():
         from gi.repository import GLib
         dirs = []
         for dir_ in GLib.get_system_data_dirs():
-            dirs.append(glib2fsn(dir_))
+            dirs.append(dir_)
         return dirs
 
     data_dirs = os.getenv("XDG_DATA_DIRS")
@@ -249,7 +237,7 @@ def xdg_get_system_data_dirs():
 def xdg_get_cache_home():
     if os.name == "nt":
         from gi.repository import GLib
-        return glib2fsn(GLib.get_user_cache_dir())
+        return GLib.get_user_cache_dir()
 
     data_home = os.getenv("XDG_CACHE_HOME")
     if data_home:
@@ -261,7 +249,7 @@ def xdg_get_cache_home():
 def xdg_get_data_home():
     if os.name == "nt":
         from gi.repository import GLib
-        return glib2fsn(GLib.get_user_data_dir())
+        return GLib.get_user_data_dir()
 
     data_home = os.getenv("XDG_DATA_HOME")
     if data_home:
@@ -273,7 +261,7 @@ def xdg_get_data_home():
 def xdg_get_config_home():
     if os.name == "nt":
         from gi.repository import GLib
-        return glib2fsn(GLib.get_user_config_dir())
+        return GLib.get_user_config_dir()
 
     data_home = os.getenv("XDG_CONFIG_HOME")
     if data_home:

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -24,7 +24,7 @@ from quodlibet.util import format_time_long as f_t_l, format_time_preferred, \
     format_time_display, format_time_seconds
 from quodlibet.util import re_escape
 from quodlibet.util.library import set_scan_dirs, get_scan_dirs
-from quodlibet.util.path import fsn2glib, glib2fsn, \
+from quodlibet.util.path import \
     parse_xdg_user_dirs, xdg_get_system_data_dirs, escape_filename, \
     strip_win32_incompat_from_path, xdg_get_cache_home, \
     xdg_get_data_home, unexpand, xdg_get_user_dirs, \
@@ -796,10 +796,6 @@ class TPathHandling(TestCase):
     def test_main(self):
         v = fsnative(u"foo")
         self.assertTrue(isinstance(v, fsnative))
-
-        v2 = glib2fsn(fsn2glib(v))
-        self.assertTrue(isinstance(v2, fsnative))
-        self.assertEqual(v, v2)
 
         v3 = bytes2fsn(fsn2bytes(v, "utf-8"), "utf-8")
         self.assertTrue(isinstance(v3, fsnative))


### PR DESCRIPTION
This is a Python 2 leftover where paths to and from glib were
utf-8 encoded bytes/str.


