### PR TITLE
Draft: Global undo

### DIFF
--- a/quodlibet/_main.py
+++ b/quodlibet/_main.py
@@ -63,6 +63,9 @@ class Application:
     is_restarting = False
     """True if the program should restart after quitting"""
 
+    undo_store = None
+    """The global UndoStore"""
+
     @property
     def icon_name(self):
         return self.id

--- a/quodlibet/browsers/playlists/main.py
+++ b/quodlibet/browsers/playlists/main.py
@@ -335,10 +335,9 @@ class PlaylistsBrowser(Browser, DisplayPatternMixin):
             self.pl_lib.add([pl])
             self.reinsert_pl(pl)
             self._select_playlist(playlist, scroll=True)
-        undo_id = quodlibet.app.undo_store.checkpoint(undelete, args=[playlist])
+        quodlibet.app.undo_store.checkpoint(undelete, args=[playlist])
         self.__removed(self.pl_lib, [playlist])
         playlist.delete()
-        # self.refresh_all()
 
     def __playlist_deleted(self, row) -> None:
         self.model.remove(row.iter)
@@ -594,8 +593,8 @@ class PlaylistsBrowser(Browser, DisplayPatternMixin):
             qltk.ErrorMessage(
                 None, _("Unable to rename playlist"), s).run()
         else:
-           self.reinsert_pl(playlist)
-           self._select_playlist(playlist, scroll=True)
+            self.reinsert_pl(playlist)
+            self._select_playlist(playlist, scroll=True)
 
     def __import(self, activator, library):
         formats = ["*.pls", "*.m3u", "*.m3u8"]

--- a/quodlibet/browsers/playlists/util.py
+++ b/quodlibet/browsers/playlists/util.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2021 Nick Boultbee
+# Copyright 2014-2022 Nick Boultbee
 #                2022 TheMelmacian
 #
 # This program is free software; you can redistribute it and/or modify
@@ -12,9 +12,7 @@ from quodlibet import _, print_w
 from quodlibet import formats
 from quodlibet.qltk import Icons
 from quodlibet.qltk.getstring import GetStringDialog
-from quodlibet.qltk.msg import ConfirmationPrompt
 from quodlibet.qltk.wlw import WaitLoadWindow
-from quodlibet.util import escape
 from quodlibet.util.path import uri_is_valid
 from urllib.response import addinfourl
 from senf import uri2fsn, fsn2text, path2fsn, bytes2fsn, text2fsn

--- a/quodlibet/browsers/playlists/util.py
+++ b/quodlibet/browsers/playlists/util.py
@@ -20,30 +20,6 @@ from urllib.response import addinfourl
 from senf import uri2fsn, fsn2text, path2fsn, bytes2fsn, text2fsn
 
 
-def confirm_remove_playlist_dialog_invoke(
-    parent, playlist, Confirmer=ConfirmationPrompt):
-    """Creates and invokes a confirmation dialog that asks the user whether or not
-       to go forth with the deletion of the selected playlist.
-
-       Confirmer needs to accept the arguments for constructing a dialog,
-       have a run-method returning a response, and have a RESPONSE_INVOKE
-       attribute.
-
-       returns the result of comparing the result of run to RESPONSE_INVOKE
-    """
-    title = (_("Are you sure you want to delete the playlist '%s'?")
-             % escape(playlist.name))
-    description = (_("All information about the selected playlist "
-                     "will be deleted and can not be restored."))
-    ok_text = _("_Delete")
-    ok_icon = Icons.EDIT_DELETE
-
-    dialog = Confirmer(parent, title, description, ok_text, ok_icon)
-    prompt = dialog.run()
-    response = (prompt == Confirmer.RESPONSE_INVOKE)
-    return response
-
-
 class GetPlaylistName(GetStringDialog):
     def __init__(self, parent):
         super().__init__(

--- a/quodlibet/main.py
+++ b/quodlibet/main.py
@@ -1,6 +1,6 @@
 # Copyright 2004-2005 Joe Wreschnig, Michael Urman, Iñigo Serna
 #           2012,2013 Christoph Reiter
-#           2010-2021 Nick Boultbee
+#           2010-2022 Nick Boultbee
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -49,6 +49,9 @@ def main(argv=None):
     app.id = "io.github.quodlibet.QuodLibet"
     app.process_name = "quodlibet"
     quodlibet.set_application_info(app)
+
+    from quodlibet.qltk.undo import UndoStore
+    app.undo_store = UndoStore()
 
     library_path = os.path.join(quodlibet.get_user_dir(), "songs")
 

--- a/quodlibet/qltk/__init__.py
+++ b/quodlibet/qltk/__init__.py
@@ -14,12 +14,13 @@ from urllib.parse import urlparse
 
 import gi
 gi.require_version("Gtk", "3.0")
-gi.require_version("Gdk", "3.0")
-gi.require_version('PangoCairo', '1.0')
 
-from gi.repository import Gtk, Gdk, GLib, GObject, PangoCairo
+from gi.repository import Gtk
+from gi.repository import Gdk
+from gi.repository import GLib, GObject, PangoCairo
 from senf import fsn2bytes, bytes2fsn, uri2fsn
 
+from quodlibet.util import print_d, print_w, is_windows, is_osx
 
 
 def show_uri(label, uri):

--- a/quodlibet/qltk/__init__.py
+++ b/quodlibet/qltk/__init__.py
@@ -14,13 +14,12 @@ from urllib.parse import urlparse
 
 import gi
 gi.require_version("Gtk", "3.0")
+gi.require_version("Gdk", "3.0")
+gi.require_version('PangoCairo', '1.0')
 
-from gi.repository import Gtk
-from gi.repository import Gdk
-from gi.repository import GLib, GObject, PangoCairo
+from gi.repository import Gtk, Gdk, GLib, GObject, PangoCairo
 from senf import fsn2bytes, bytes2fsn, uri2fsn
 
-from quodlibet.util import print_d, print_w, is_windows, is_osx
 
 
 def show_uri(label, uri):

--- a/quodlibet/qltk/undo.py
+++ b/quodlibet/qltk/undo.py
@@ -1,0 +1,62 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+
+import random
+from collections import OrderedDict
+from typing import Callable, Any, Dict, Iterable, Optional
+
+from quodlibet import print_d, print_w
+
+UndoFunction = Callable[[Iterable[Any], Dict[str, Any]], Any]
+UndoID = str
+
+
+class Undo:
+
+    def __init__(self, undo: UndoFunction, undo_id: str = None,
+                 args: Optional[Iterable[Any]] = None,
+                 kwargs: Optional[Dict[str, Any]] = None) -> None:
+        self._id = undo_id
+        self.undo = undo
+        self.args = args or []
+        self.kwargs = kwargs or {}
+
+    def run(self) -> Any:
+        return self.undo(*self.args, **self.kwargs)
+
+
+class UndoStore:
+    """Abstracts generic undo operations"""
+
+    def __init__(self) -> None:
+        self.undos: OrderedDict[UndoID, Undo] = OrderedDict()
+
+    def checkpoint(self, undo_fn: UndoFunction, args=None, kwargs=None,
+                   _id: str = None) -> UndoID:
+        redo_id = _id or f"id-{random.randint(int(1e9), int(1e10))}"
+        self.undos[redo_id] = Undo(undo_fn, _id, args, kwargs)
+        print_d(f"Added redo for {redo_id}")
+        print_d(f"Now have: {self.undos}")
+        return redo_id
+
+    def undo(self, undo_id: UndoID = None) -> bool:
+        try:
+            undo_id = undo_id or list(self.undos.keys())[-1]
+        except IndexError:
+            # Nothing to undo
+            return False
+        try:
+            undo = self.undos[undo_id]
+        except KeyError:
+            print_w(f"Unknown undoID: {undo_id}")
+            return False
+        else:
+            print_d(f"Undoing {undo_id!r}")
+            undo.run()
+        del self.undos[undo_id]
+        return True
+
+
+_GLOBAL_UNDO = UndoStore()

--- a/quodlibet/qltk/undo.py
+++ b/quodlibet/qltk/undo.py
@@ -57,6 +57,3 @@ class UndoStore:
             undo.run()
         del self.undos[undo_id]
         return True
-
-
-_GLOBAL_UNDO = UndoStore()

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -114,6 +114,7 @@ def init_fake_app():
     from quodlibet.library.librarians import SongLibrarian
     from quodlibet.qltk.quodlibetwindow import QuodLibetWindow, PlayerOptions
     from quodlibet.util.cover import CoverManager
+    from quodlibet.qltk.undo import UndoStore
 
     browsers.init()
     app.name = "Quod Libet"
@@ -124,6 +125,7 @@ def init_fake_app():
     app.cover_manager = CoverManager()
     app.window = QuodLibetWindow(app.library, app.player, headless=True)
     app.player_options = PlayerOptions(app.window)
+    app.undo_store = UndoStore()
 
 
 def destroy_fake_app():


### PR DESCRIPTION
Add a global undo & use in playlist browser

* Define undo as a callable with params and an ID, seems neatest
* Add an ordered undo store
* Integrate with `quodlibet.app`
* Use this to remove delete playlist confirmations via Ctrl-Z (fake) accel. Seems to work nicely!
* Also fix a playlist deletion bug? 

### TODOS
* [x] Add integration test with playlist deletion
* [ ] extract / confirm deletion bug on default
* [ ] Integrate with all other playlist confirm things
* [ ] Add human-readable description for undo action
* [ ] Some kind of `TaskController` integration? Or native notification?
* [ ] Better exposing of keyboard accels. 
* [ ] Put in a menu somewhere too?
* [ ] Docs

Fixes #4063 