### PR TITLE
Improve UI / wording for buttons

### DIFF
--- a/quodlibet/browsers/audiofeeds.py
+++ b/quodlibet/browsers/audiofeeds.py
@@ -371,7 +371,7 @@ class AudioFeeds(Browser):
         swin.add(view)
         self.pack_start(swin, True, True, 0)
 
-        new = Button(_("_New"), Icons.LIST_ADD, Gtk.IconSize.MENU)
+        new = Button(_("_Add Feed…"), Icons.LIST_ADD, Gtk.IconSize.MENU)
         new.connect('clicked', self.__new_feed)
         view.get_selection().connect('changed', self.__changed)
         view.get_selection().set_mode(Gtk.SelectionMode.MULTIPLE)

--- a/quodlibet/browsers/playlists/main.py
+++ b/quodlibet/browsers/playlists/main.py
@@ -56,7 +56,7 @@ class PlaylistsBrowser(Browser, DisplayPatternMixin):
     _DEFAULT_PATTERN_TEXT = DEFAULT_PATTERN_TEXT
 
     def __init__(self, songs_lib: SongFileLibrary, Confirmer=ConfirmationPrompt):
-        super().__init__(spacing=6)
+        super().__init__(spacing=3)
         self._lists = ObjectModelSort(model=ObjectStore())
         self._lists.set_default_sort_func(ObjectStore._sort_on_value)
 
@@ -209,11 +209,10 @@ class PlaylistsBrowser(Browser, DisplayPatternMixin):
         self.pack_start(swin, True, True, 0)
 
     def __configure_buttons(self, library):
-        new_pl = qltk.Button(None, Icons.DOCUMENT_NEW, Gtk.IconSize.MENU)
+        new_pl = qltk.Button(_("_New"), Icons.DOCUMENT_NEW, Gtk.IconSize.MENU)
         new_pl.set_tooltip_text(_("New"))
         new_pl.connect('clicked', self.__new_playlist, library)
-        import_pl = qltk.Button(None, Icons.LIST_ADD,
-                                Gtk.IconSize.MENU)
+        import_pl = qltk.Button(_("_Import…"), Icons.DOCUMENT_OPEN, Gtk.IconSize.MENU)
         import_pl.set_tooltip_text(_("Import"))
         import_pl.connect('clicked', self.__import, library)
 
@@ -223,6 +222,7 @@ class PlaylistsBrowser(Browser, DisplayPatternMixin):
         fb.insert(new_pl, 0)
         fb.insert(import_pl, 1)
         fb.set_max_children_per_line(2)
+        fb.set_column_spacing(3)
 
         # The pref button is in its own flowbox instead of directly under the
         # HBox to make it the same height as the other buttons
@@ -231,8 +231,8 @@ class PlaylistsBrowser(Browser, DisplayPatternMixin):
         fb2.insert(pref, 0)
 
         hb = Gtk.HBox()
-        hb.pack_start(fb, True, True, 0)
-        hb.pack_start(fb2, False, False, 0)
+        hb.pack_start(fb, True, True, 3)
+        hb.pack_end(fb2, False, False, 0)
         self.pack_start(hb, False, False, 0)
 
     def __create_playlists_view(self, render):

--- a/quodlibet/browsers/playlists/util.py
+++ b/quodlibet/browsers/playlists/util.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2021 Nick Boultbee
+# Copyright 2014-2022 Nick Boultbee
 #                2022 TheMelmacian
 #
 # This program is free software; you can redistribute it and/or modify
@@ -49,7 +49,7 @@ class GetPlaylistName(GetStringDialog):
         super().__init__(
             parent, _("New Playlist"),
             _("Enter a name for the new playlist:"),
-            button_label=_("_Add"), button_icon=Icons.LIST_ADD)
+            button_label=_("_Create"), button_icon=Icons.DOCUMENT_NEW)
 
 
 def parse_m3u(filelike, pl_name, songs_lib=None, pl_lib=None):

--- a/quodlibet/qltk/data_editors.py
+++ b/quodlibet/qltk/data_editors.py
@@ -310,7 +310,7 @@ class TagListEditor(qltk.Window):
         vbbox = Gtk.VButtonBox()
         vbbox.set_layout(Gtk.ButtonBoxStyle.START)
         vbbox.set_spacing(6)
-        add = Button(_("_Add"), Icons.LIST_ADD)
+        add = Button(_("_Add…"), Icons.LIST_ADD)
         add.connect("clicked", self.__add)
         vbbox.pack_start(add, False, True, 0)
         remove = Button(_("_Remove"), Icons.LIST_REMOVE)

--- a/quodlibet/qltk/edittags.py
+++ b/quodlibet/qltk/edittags.py
@@ -546,7 +546,7 @@ class EditTags(Gtk.VBox):
         bbox1 = Gtk.HButtonBox()
         bbox1.set_spacing(6)
         bbox1.set_layout(Gtk.ButtonBoxStyle.START)
-        add = qltk.Button(_("_Add"), Icons.LIST_ADD)
+        add = qltk.Button(_("_Add…"), Icons.LIST_ADD)
         add.set_focus_on_click(False)
         self._add = add
         add.connect('clicked', self.__add_tag, model, library)


### PR DESCRIPTION
 * Aim towards the Gnome HIG a bit more
 * So add some missing ellipses
 * Also more consistent use of icons
 * For playlists browser, use names like all the other buttons (not just icons). This might not look as nice but IMO the icons were very unintuitive before and still I had to hover sometimes to remind which one to press...
 * Fix playlist button packing too

### Before (playlist browser)
![Screenshot from 2022-08-03 08-57-23](https://user-images.githubusercontent.com/3322808/182555831-f8483db7-80cb-4f7e-a775-cebe2f3c1bea.png)

### After (playlist browser)
![Screenshot from 2022-08-03 08-58-05](https://user-images.githubusercontent.com/3322808/182555925-02559a1c-5948-466b-9188-1ea65fa130c7.png)
