### PR TITLE
Fix playlist renaming bug

### DIFF
--- a/quodlibet/browsers/playlists/main.py
+++ b/quodlibet/browsers/playlists/main.py
@@ -581,13 +581,16 @@ class PlaylistsBrowser(Browser, DisplayPatternMixin):
     def __edited(self, render, path, newname):
         return self._rename(path, newname)
 
-    def _rename(self, path, newname):
+    def _rename(self, path: Gtk.TreePath,
+                new_name: str, show_error: bool = True) -> bool:
         playlist = self._lists[path][0]
         try:
-            playlist.rename(newname)
-        except ValueError as s:
-            qltk.ErrorMessage(
-                None, _("Unable to rename playlist"), s).run()
+            playlist.rename(new_name)
+        except ValueError as e:
+            if show_error:
+                qltk.ErrorMessage(None, _("Unable to rename playlist"), str(e)).run()
+            print_w(f"Unable to rename playlist {playlist} ({e})")
+            return False
         else:
             row = self._lists[path]
             child_model = self.model
@@ -595,6 +598,7 @@ class PlaylistsBrowser(Browser, DisplayPatternMixin):
                 self._lists.convert_iter_to_child_iter(row.iter))
             child_model.append(row=[playlist])
             self._select_playlist(playlist, scroll=True)
+            return True
 
     def __import(self, activator, library):
         formats = ["*.pls", "*.m3u", "*.m3u8"]

--- a/quodlibet/qltk/msg.py
+++ b/quodlibet/qltk/msg.py
@@ -1,36 +1,38 @@
 # Copyright 2005 Joe Wreschnig, Michael Urman
-#           2021 Nick Boultbee
+#       2021-22 Nick Boultbee
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation; either version 2 of the License, or
 # (at your option) any later version.
 
-from gi.repository import Gtk
+from typing import Type
 
-from quodlibet.util import escape
-from senf import fsn2text, path2fsn
+from gi.repository import Gtk
 
 from quodlibet import _
 from quodlibet import util
-from quodlibet.qltk.icons import Icons
 from quodlibet.qltk import get_top_parent
+from quodlibet.qltk.icons import Icons
 from quodlibet.qltk.window import Dialog
+from quodlibet.util import escape
+from senf import fsn2text, path2fsn
 
 
 class Message(Gtk.MessageDialog, Dialog):
     """A message dialog that destroys itself after it is run, uses
     markup, and defaults to an 'OK' button."""
 
-    def __init__(self, kind, parent, title, description, buttons=Gtk.ButtonsType.OK,
-                 escape_desc=True):
+    def __init__(self, kind: Type, parent: Gtk.Widget, title: str, description: str,
+                 buttons: Gtk.ButtonsType = Gtk.ButtonsType.OK,
+                 escape_desc: bool = True):
         parent = get_top_parent(parent)
-        text = ("<span weight='bold' size='larger'>%s</span>\n\n%s"
-                % (escape(title), escape(description) if escape_desc else description))
+        markup = (f"<span weight='bold' size='larger'>{escape(title)}</span>\n\n"
+                  + escape(description) if escape_desc else description)
         super().__init__(
             transient_for=parent, modal=True, destroy_with_parent=True,
             message_type=kind, buttons=buttons)
-        self.set_markup(text)
+        self.set_markup(markup)
 
     def run(self, destroy=True):
         resp = super().run()
@@ -69,6 +71,7 @@ class CancelRevertSave(Gtk.MessageDialog, Dialog):
 
 class ErrorMessage(Message):
     """Like Message, but uses an error-indicating picture."""
+
     def __init__(self, *args, **kwargs):
         super().__init__(
             Gtk.MessageType.ERROR, *args, **kwargs)
@@ -76,6 +79,7 @@ class ErrorMessage(Message):
 
 class WarningMessage(Message):
     """Like Message, but uses an warning-indicating picture."""
+
     def __init__(self, *args, **kwargs):
         super().__init__(
             Gtk.MessageType.WARNING, *args, **kwargs)

--- a/tests/test_browsers_playlists.py
+++ b/tests/test_browsers_playlists.py
@@ -288,9 +288,12 @@ class TPlaylistsBrowser(TestCase):
 
     def test_rename(self):
         self.assertEquals(self.bar.playlists()[1], self.small)
-        self.bar._rename(0, "zBig")
+        assert self.bar._rename(0, "zBig")
         self.assertEquals(self.bar.playlists()[0], self.small)
         self.assertEquals(self.bar.playlists()[1].name, "zBig")
+
+    def test_rename_empty(self):
+        assert not self.bar._rename(0, "", show_error=False)
 
     def test_default_display_pattern(self):
         pattern_text = self.bar.display_pattern_text


### PR DESCRIPTION
 * Make the dialog optional but default
 * Add logging
 * Add test around (but not catching exactly) this
 * Fix naming
 * Add some typing all round that might have alerted to the root cause - Exception being passed instead of str
  (but probably not due to `*args`, sigh)

Fixes #4022
