### PR TITLE
Clarify how tag splitting is setup

### DIFF
--- a/docs/guide/editing_tags.rst
+++ b/docs/guide/editing_tags.rst
@@ -108,7 +108,8 @@ and then selecting the appropriate split in the ``Split Tag`` menu.
 There are in general two types of tag splitting possible: splitting on a single
 character and *subtag* splitting (extracting values in enclosures). The
 separating characters for both can be configured in the *Tags* tab in the
-preferences.
+preferences. (Note that the "Split on" values in the configure dialog are space
+seperated).
 
 Splitting on a single character - like ``,`` or ``&`` - will split a tag into
 multiple tags of the same type, but with different values. An example of this

--- a/docs/guide/editing_tags.rst
+++ b/docs/guide/editing_tags.rst
@@ -108,8 +108,9 @@ and then selecting the appropriate split in the ``Split Tag`` menu.
 There are in general two types of tag splitting possible: splitting on a single
 character and *subtag* splitting (extracting values in enclosures). The
 separating characters for both can be configured in the *Tags* tab in the
-preferences. (Note that the "Split on" values in the configure dialog are space
-seperated).
+preferences.
+(Note that the "Split on" values in the configure dialog are space-separated)
+separated).
 
 Splitting on a single character - like ``,`` or ``&`` - will split a tag into
 multiple tags of the same type, but with different values. An example of this

--- a/docs/guide/editing_tags.rst
+++ b/docs/guide/editing_tags.rst
@@ -109,8 +109,7 @@ There are in general two types of tag splitting possible: splitting on a single
 character and *subtag* splitting (extracting values in enclosures). The
 separating characters for both can be configured in the *Tags* tab in the
 preferences.
-(Note that the "Split on" values in the configure dialog are space-separated)
-separated).
+Note that the "Split on" values in the configure dialog are space-separated.
 
 Splitting on a single character - like ``,`` or ``&`` - will split a tag into
 multiple tags of the same type, but with different values. An example of this


### PR DESCRIPTION
I added a ; to the list of tag split chars. After this neither ; nor , worked.
It took a while to realise there was actually a space between the values in the preferences/configuration dialog value box.

Check-list
----------

 * [ ] There is a linked issue discussing the motivations for this feature or bugfix
 * [ ] Unit tests have been added where possible
 * [x] I've added / updated documentation for any user-facing features.
 * [ ] Performance seems to be comparable or better than current `master`


What this change is adding / fixing
-----------------------------------
<!-- A high-level description of the changes.
Hopefully the commits are atomic and well described, but this is the overall
summary of the change, to other developers / maintainers, plus any TODOs. -->

