### PR TITLE
Playlist browser: throw if no PL library

### DIFF
--- a/quodlibet/browsers/_base.py
+++ b/quodlibet/browsers/_base.py
@@ -1,6 +1,6 @@
 # Copyright 2004-2005 Joe Wreschnig, Michael Urman, Iñigo Serna
 #           2012 Christoph Reiter
-#           2016-2020 Nick Boultbee
+#           2016-2022 Nick Boultbee
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -129,6 +129,10 @@ class Filter:
                 value = random.choice(values)
                 query = util.build_filter_query(key, [value])
                 self.filter_text(query)
+
+
+class BrowserError(Exception):
+    pass
 
 
 class Browser(Gtk.Box, Filter):

--- a/tests/test_browsers_playlists.py
+++ b/tests/test_browsers_playlists.py
@@ -7,11 +7,13 @@ import os
 import shutil
 from pathlib import Path
 
+import pytest
 from gi.repository import Gdk, Gtk
 
 import quodlibet.config
 from quodlibet import app
 from quodlibet import qltk
+from quodlibet.browsers._base import BrowserError
 from quodlibet.browsers.playlists import PlaylistsBrowser
 from quodlibet.browsers.playlists.prefs import DEFAULT_PATTERN_TEXT
 from quodlibet.browsers.playlists.util import (parse_m3u,
@@ -374,7 +376,8 @@ class TPlaylistsBrowser(TestCase):
 
     def test_no_pl_lib(self):
         """Probably not possible in real runtime situations"""
-        assert PlaylistsBrowser(FileLibrary("no-playlists"))
+        with pytest.raises(BrowserError):
+            assert PlaylistsBrowser(FileLibrary("no-playlists"))
 
     @staticmethod
     def a_delete_event():


### PR DESCRIPTION
 * Throw a (new) exception if PL library isn't available (somehow) for playlist browser
 * Then, remove all the checks for this
 * Update the test
 * Hopefully this will stop #3988
   (but still unclear how this state came about, maybe some class-instance stuff)
 * Either way it's simpler now, and the non-Optional typing is correct now

Fixes #3988
