### PR TITLE
Disable editing for Soundcloud tracks

### DIFF
--- a/quodlibet/browsers/soundcloud/library.py
+++ b/quodlibet/browsers/soundcloud/library.py
@@ -159,7 +159,7 @@ class SoundcloudFile(RemoteFile):
         if k is None:
             return ["~rating", "~#rating"]
         else:
-            return "rating" in k
+            return k.endswith("rating")
 
     def write(self):
         if not self.client or not self.client.online:

--- a/quodlibet/browsers/soundcloud/main.py
+++ b/quodlibet/browsers/soundcloud/main.py
@@ -130,7 +130,7 @@ class SoundcloudBrowser(Browser, util.InstanceTracker):
         self.show()
 
     def Menu(self, songs, library, items):
-        return SongsMenu(library, songs, download=True, items=items)
+        return SongsMenu(library, songs, edit=False, download=True, items=items)
 
     @property
     def online(self):

--- a/quodlibet/qltk/songsmenu.py
+++ b/quodlibet/qltk/songsmenu.py
@@ -268,8 +268,8 @@ class SongsMenu(Gtk.Menu):
         PluginManager.instance.register_handler(cls.plugins)
 
     def __init__(self, library, songs, plugins=True, playlists=True, queue=True,
-                 remove=True, delete=False, edit=True, ratings=True, show_files=True,
-                 download=False, items=None, accels=True,
+                 remove=True, delete=False, edit=True, info=True, ratings=True,
+                 show_files=True, download=False, items=None, accels=True,
                  removal_confirmer=None, folder_chooser=None):
         super().__init__()
         # The library may actually be a librarian; if it is, use it,
@@ -388,6 +388,7 @@ class SongsMenu(Gtk.Menu):
             b.connect('activate', song_properties_cb)
             self.append(b)
 
+        if info:
             b = qltk.MenuItem(_("_Information"), Icons.DIALOG_INFORMATION)
             b.set_sensitive(bool(songs))
             if accels:

--- a/tests/test_browsers_soundcloud.py
+++ b/tests/test_browsers_soundcloud.py
@@ -8,7 +8,7 @@ from unittest import TestCase
 
 from gi.repository import Gtk
 
-from quodlibet import config, _
+from quodlibet import config
 from quodlibet import const
 from quodlibet.browsers.soundcloud import SoundcloudBrowser
 from quodlibet.browsers.soundcloud.api import SoundcloudApiClient

--- a/tests/test_browsers_soundcloud.py
+++ b/tests/test_browsers_soundcloud.py
@@ -3,17 +3,19 @@
 # the Free Software Foundation; either version 2 of the License, or
 # (at your option) any later version.
 
+import time
 from unittest import TestCase
 
-import time
+from gi.repository import Gtk
 
-from quodlibet import config
+from quodlibet import config, _
+from quodlibet import const
+from quodlibet.browsers.soundcloud import SoundcloudBrowser
 from quodlibet.browsers.soundcloud.api import SoundcloudApiClient
 from quodlibet.browsers.soundcloud.query import SoundcloudQuery, convert_time
-
-from quodlibet import const
 from quodlibet.query import QueryType
 from quodlibet.util.dprint import print_d
+from tests.test_browsers__base import TBrowserBase
 
 NONE = set([])
 
@@ -70,6 +72,19 @@ class TestExtract(TestCase):
         self.failUnlessEqual(terms[term], expected,
                              msg="terms[%s] wasn't %r. Full terms: %r"
                                  % (term, expected, terms))
+
+
+class TestMenu(TBrowserBase):
+    Kind = SoundcloudBrowser
+
+    def test_songsmenu_has_information_but_no_edit(self):
+        menu = self.b.Menu([], self.library, [])
+        assert menu
+        items = [item.get_label() for item in menu.get_children()
+                 if type(item) is not Gtk.SeparatorMenuItem]
+        assert _("_Rating") in items
+        assert _("_Information") in items, "Should have included Information"
+        assert _("Edit _Tags") not in items, "Shouldn't have included edit"
 
 
 class TestHttpsDefault(TestCase):

--- a/tests/test_browsers_soundcloud.py
+++ b/tests/test_browsers_soundcloud.py
@@ -82,9 +82,10 @@ class TestMenu(TBrowserBase):
         assert menu
         items = [item.get_label() for item in menu.get_children()
                  if type(item) is not Gtk.SeparatorMenuItem]
-        assert _("_Rating") in items
-        assert _("_Information") in items, "Should have included Information"
-        assert _("Edit _Tags") not in items, "Shouldn't have included edit"
+        # We're always in en_US
+        assert "_Rating" in items
+        assert "_Information" in items, "Should have included Information"
+        assert "Edit _Tags" not in items, "Shouldn't have included edit"
 
 
 class TestHttpsDefault(TestCase):

--- a/tests/test_qltk_songsmenu.py
+++ b/tests/test_qltk_songsmenu.py
@@ -120,12 +120,12 @@ class TSongsMenu(TestCase):
         # TODO: some useful assertions, without needing a UI
 
     def empty_menu_with(self, plugins=False, playlists=False, queue=False,
-                        remove=False, delete=False, edit=False, ratings=False,
-                        show_files=False, download=False,
+                        remove=False, delete=False, edit=False, info=False,
+                        ratings=False, show_files=False, download=False,
                         removal_confirmer=None, folder_chooser=None):
         return SongsMenu(self.library, self.songs, plugins=plugins, playlists=playlists,
                          queue=queue, remove=remove, delete=delete, edit=edit,
-                         ratings=ratings, show_files=show_files,
+                         info=info, ratings=ratings, show_files=show_files,
                          removal_confirmer=removal_confirmer,
                          download=download, folder_chooser=folder_chooser)
 


### PR DESCRIPTION
* This was never going to be useful anyway
* But we _do_ want track information, so separate these two options everywhere.
* Add new test for this [songsmenu] too

Fixes #4092