### PR TITLE
Fix image size scaling when cover is reloaded (Covergrid)

### DIFF
--- a/quodlibet/browsers/covergrid/main.py
+++ b/quodlibet/browsers/covergrid/main.py
@@ -307,17 +307,16 @@ class CoverGrid(Browser, util.InstanceTracker, DisplayPatternMixin):
 
     def __cover_changed(self, manager, songs):
         songs = set(songs)
-        cover_size = _get_cover_size()
 
-        for item in self.__model.itervalues():
+        for child in self.view:
             if not songs:
                 break
-            album = item.album
+            album = child.model.album
             if album is None:
                 continue
             match = songs & album.songs
             if match:
-                item.load_cover(cover_size, cancelable=self.__cover_cancel)
+                child.populate()
                 songs -= match
 
     def __update_filter(self, scroll_up=True):
@@ -347,9 +346,8 @@ class CoverGrid(Browser, util.InstanceTracker, DisplayPatternMixin):
             menu, widget, Gdk.BUTTON_SECONDARY, Gtk.get_current_event_time())
 
     def __refresh_cover(self, menuitem, view):
-        cover_size = _get_cover_size()
         for child in self.view.get_selected_children():
-            child.model.load_cover(cover_size, cancelable=self.__cover_cancel)
+            child.populate()
 
     def refresh_all(self):
         display_pattern = self.display_pattern


### PR DESCRIPTION
Check-list
----------

 * [x] There is a linked issue discussing the motivations for this feature or bugfix
 * [x] Unit tests have been added where possible
 * [x] I've added / updated documentation for any user-facing features.
 * [x] Performance seems to be comparable or better than current `master`


What this change is adding / fixing
-----------------------------------
Fixes issue described in https://github.com/quodlibet/quodlibet/pull/4101#issuecomment-1221389969. 
We let the album widget handle details of loading the album cover.