### PR TITLE
Clip images for rounded border

### DIFF
--- a/quodlibet/qltk/image.py
+++ b/quodlibet/qltk/image.py
@@ -75,28 +75,32 @@ def add_border(pixbuf, color, width=1, radius=0):
     Can not fail.
     """
 
-    w, h = pixbuf.get_width(), pixbuf.get_height()
-    w += width * 2
-    h += width * 2
+    pi = math.pi
+
+    def new_border_path(ctx, w, h, r, margin=0):
+        d = r + margin
+        ctx.new_path()
+        ctx.arc(w - d, d, r, -pi / 2, 0)
+        ctx.arc(w - d, h - d, r, 0, pi / 2)
+        ctx.arc(d, h - d, r, pi / 2, pi)
+        ctx.arc(d, d, r, pi, pi * 3 / 2)
+        ctx.close_path()
+
+    w = pixbuf.get_width() + width * 2
+    h = pixbuf.get_height() + width * 2
+    r = min(radius, min(w, h) / 2)
+
     surface = cairo.ImageSurface(cairo.FORMAT_ARGB32, w, h)
     ctx = cairo.Context(surface)
 
-    pi = math.pi
-    r = min(radius, min(w, h) / 2)
-    ctx.new_path()
-    ctx.arc(w - r, r, r, -pi / 2, 0)
-    ctx.arc(w - r, h - r, r, 0, pi / 2)
-    ctx.arc(r, h - r, r, pi / 2, pi)
-    ctx.arc(r, r, r, pi, pi * 3 / 2)
-    ctx.close_path()
-
-    Gdk.cairo_set_source_pixbuf(ctx, pixbuf, width, width)
-    ctx.clip_preserve()
+    new_border_path(ctx, w, h, r + width)
+    ctx.clip()
+    ctx.set_source_rgba(color.red, color.green, color.blue, color.alpha)
     ctx.paint()
 
-    ctx.set_source_rgba(color.red, color.green, color.blue, color.alpha)
-    ctx.set_line_width(width * 2)
-    ctx.stroke()
+    new_border_path(ctx, w, h, r, width)
+    Gdk.cairo_set_source_pixbuf(ctx, pixbuf, width, width)
+    ctx.fill()
 
     return Gdk.pixbuf_get_from_surface(surface, 0, 0, w, h)
 


### PR DESCRIPTION
The function `add_border` now first creates a wide path along the
edge of the final image to draw the border, then it creates a narrower
path in which to draw the original image. This way the border-radius is
actually applied to the original image, which was not the case before.

Check-list
----------

 * [x] There is a linked issue discussing the motivations for this feature or bugfix
 * [x] Unit tests have been added where possible
 * [x] I've added / updated documentation for any user-facing features.
 * [x] Performance seems to be comparable or better than current `master`


What this change is adding / fixing
-----------------------------------

Fixes #4117.

The runtime -- summed over 10000 runs -- is even consistently 0.3 seconds lower, so this shouldn't impact performance.