### PR TITLE
Header bar layout for main window

### DIFF
--- a/quodlibet/qltk/controls.py
+++ b/quodlibet/qltk/controls.py
@@ -176,11 +176,11 @@ class PlayPauseButton(Gtk.Button):
     }
 
     def __init__(self):
-        super().__init__(relief=Gtk.ReliefStyle.NONE)
+        super().__init__()
         self._pause_image = SymbolicIconImage("media-playback-pause",
-                                               Gtk.IconSize.LARGE_TOOLBAR)
+                                               Gtk.IconSize.BUTTON)
         self._play_image = SymbolicIconImage("media-playback-start",
-                                             Gtk.IconSize.LARGE_TOOLBAR)
+                                             Gtk.IconSize.BUTTON)
         self._set_active(False)
         self.connect("clicked", self._on_clicked)
 


### PR DESCRIPTION
Check-list
----------

 * [ ] There is a linked issue discussing the motivations for this feature or bugfix
 * [ ] Unit tests have been added where possible
 * [ ] I've added / updated documentation for any user-facing features.
 * [ ] Performance seems to be comparable or better than current `master`


What this change is adding / fixing
-----------------------------------

This is sort of a proof of concept for #2297. There's much more to do, most importantly it should be configurable. 

I tried to find a reasonable grouping and position for each menu item. 
For some I was unable to do so, they ended up in a vertical bar on the left:
* Stop after this song (this could go into a context menu on the play/pause button; it would be consistent with the use of context menus on other buttons)
* Jump to playing song
* Filters

Some were omitted:
* Edit bookmarks (that's in the context menu of the seek-button)
* Edit tags (that's in the context menu of the song-text area)
* Information (also in context menu of song-text area)
* Quit (at least with gnome-shell this would be available through the application menu)
* Playback controls (not sure why those are duplicated in the menu? maybe somebody can explain)
* Pre-defined filters (those should be saved searches, but that's out of scope here)