### PR TITLE
Audiofeeds: handle non-feed URLs

### DIFF
--- a/quodlibet/browsers/audiofeeds.py
+++ b/quodlibet/browsers/audiofeeds.py
@@ -140,13 +140,12 @@ class Feed(list):
         try:
             with urlopen(req, timeout=5) as head:
                 # Some requests don't support status, e.g. file://
-                if hasattr(head, "status") and head.status and head.status >= 400:
-                    print_w(f"Feed URL {self.uri!r} ({head.url}) "
-                            f"returned HTTP {head.status}")
-                    return False
-                print_d(f"Feed URL {self.uri!r} ({head.url}) "
-                        f"returned HTTP {head.status}, "
-                        f"with content {head.headers.get('Content-Type')}")
+                if hasattr(head, "status"):
+                    print_d(f"Feed URL {self.uri!r} ({head.url}) "
+                            f"returned HTTP {head.status}, "
+                            f"with content {head.headers.get('Content-Type')}")
+                    if head.status and head.status >= 400:
+                        return False
                 if head.headers.get("Content-Type").lower().startswith("audio"):
                     print_w("Looks like an audio stream / radio, not a audio feed.")
                     return False

--- a/quodlibet/browsers/audiofeeds.py
+++ b/quodlibet/browsers/audiofeeds.py
@@ -139,12 +139,14 @@ class Feed(list):
         req = Request(self.uri, method="HEAD")
         try:
             with urlopen(req, timeout=5) as head:
+                # Some requests don't support status, e.g. file://
+                if hasattr(head, "status") and head.status and head.status >= 400:
+                    print_w(f"Feed URL {self.uri!r} ({head.url}) "
+                            f"returned HTTP {head.status}")
+                    return False
                 print_d(f"Feed URL {self.uri!r} ({head.url}) "
                         f"returned HTTP {head.status}, "
                         f"with content {head.headers.get('Content-Type')}")
-                # Some requests don't support status, e.g. file://
-                if hasattr(head, "status") and head.status and head.status >= 400:
-                    return False
                 if head.headers.get("Content-Type").lower().startswith("audio"):
                     print_w("Looks like an audio stream / radio, not a audio feed.")
                     return False

--- a/quodlibet/browsers/audiofeeds.py
+++ b/quodlibet/browsers/audiofeeds.py
@@ -143,7 +143,7 @@ class Feed(list):
                         f"returned HTTP {head.status}, "
                         f"with content {head.headers.get('Content-Type')}")
                 # Some requests don't support status, e.g. file://
-                if head.status and head.status >= 400:
+                if hasattr(head, "status") and head.status and head.status >= 400:
                     return False
                 if head.headers.get("Content-Type").lower().startswith("audio"):
                     print_w("Looks like an audio stream / radio, not a audio feed.")


### PR DESCRIPTION
 * Test (HEAD) URLs before
 * Also, use urllib to do HTTP, not feedparser, as per their recommendations
 * And set sensible low timeouts
 * Some more logging around all this

Fixes #4107