### PR TITLE
Track List: Add shortcut Ctrl-Return to the searchbar

### DIFF
--- a/quodlibet/browsers/paned/main.py
+++ b/quodlibet/browsers/paned/main.py
@@ -146,7 +146,8 @@ class PanedBrowser(Browser, util.InstanceTracker):
         if (is_accel(event, "<Primary>Return") or
                 is_accel(event, "<Primary>KP_Enter")):
             songs = app.window.songlist.get_songs()
-            app.window.playlist.enqueue(songs)
+            limit = config.getint("browsers", "searchbar_enqueue_limit")
+            app.window.enqueue(songs, limit)
             return True
         return False
 

--- a/quodlibet/browsers/tracks.py
+++ b/quodlibet/browsers/tracks.py
@@ -9,10 +9,12 @@
 
 from gi.repository import Gtk, GLib
 
+from quodlibet import app
 from quodlibet import config
 from quodlibet import qltk
 from quodlibet import _
 from quodlibet.browsers import Browser
+from quodlibet.qltk import is_accel
 from quodlibet.qltk.ccb import ConfigCheckMenuItem
 from quodlibet.qltk.completion import LibraryTagCompletion
 from quodlibet.qltk.menubutton import MenuButton
@@ -81,6 +83,7 @@ class TrackList(Browser):
 
         sbb.connect('query-changed', self.__text_parse)
         sbb.connect('focus-out', self.__focus)
+        sbb.connect('key-press-event', self.__sb_key_pressed)
         self._sb_box = sbb
 
         prefs = PreferencesButton(sbb)
@@ -115,6 +118,14 @@ class TrackList(Browser):
 
     def __text_parse(self, bar, text):
         self.activate()
+
+    def __sb_key_pressed(self, entry, event):
+        if (is_accel(event, "<Primary>Return") or
+                is_accel(event, "<Primary>KP_Enter")):
+            songs = app.window.songlist.get_songs()
+            app.window.playlist.enqueue(songs)
+            return True
+        return False
 
     def save(self):
         config.settext("browsers", "query_text", self._get_text())

--- a/quodlibet/browsers/tracks.py
+++ b/quodlibet/browsers/tracks.py
@@ -123,7 +123,8 @@ class TrackList(Browser):
         if (is_accel(event, "<Primary>Return") or
                 is_accel(event, "<Primary>KP_Enter")):
             songs = app.window.songlist.get_songs()
-            app.window.playlist.enqueue(songs)
+            limit = config.getint("browsers", "searchbar_enqueue_limit")
+            app.window.enqueue(songs, limit)
             return True
         return False
 

--- a/quodlibet/config.py
+++ b/quodlibet/config.py
@@ -122,6 +122,9 @@ INITIAL: Dict[str, Dict[str, str]] = {
         # number of history entries in the search bar
         "searchbar_historic_entries": "8",
 
+        # confirmation limit on enqueuing songs from the search bar
+        "searchbar_enqueue_limit": "50",
+
         # panes in paned browser
         "panes":
             "~people\t<~year|[b][i]<~year>[/i][/b] - ><album>",

--- a/quodlibet/ext/events/advanced_preferences.py
+++ b/quodlibet/ext/events/advanced_preferences.py
@@ -217,6 +217,11 @@ class AdvancedPreferences(EventPlugin):
                 "browsers", "searchbar_historic_entries",
                 "Number of history entries in the search bar:",
                 "8 by default (restart advised)"),
+            int_config(
+                "browsers", "searchbar_enqueue_limit",
+                "Search bar confirmation limit for enqueue:",
+                ("Maximal size of the song list that can be enqueued from "
+                 "the search bar without confirmation.")),
             slider_config(
                 "player", "playcount_minimum_length_proportion",
                 "Minimum length proportion to consider a track as played:",

--- a/quodlibet/qltk/quodlibetwindow.py
+++ b/quodlibet/qltk/quodlibetwindow.py
@@ -22,6 +22,7 @@ from quodlibet import formats
 from quodlibet import qltk
 from quodlibet import util
 from quodlibet import app
+from quodlibet import ngettext
 from quodlibet import _
 from quodlibet.qltk.paned import ConfigRHPaned
 
@@ -757,6 +758,19 @@ class QuodLibetWindow(Window, PersistentWindowMixin, AppWindow):
         else:
             return False
 
+    def enqueue(self, songs, limit=0):
+        """Append `songs` to the queue
+
+        Ask for confimation if the number of songs exceeds `limit`.
+        """
+
+        if len(songs) > limit:
+            dialog = ConfirmEnqueue(self, len(songs))
+            if dialog.run() != Gtk.ResponseType.YES:
+                return
+
+        self.playlist.enqueue(songs)
+
     def __player_error(self, player, song, player_error):
         # it's modal, but mmkeys etc. can still trigger new ones
         if self._playback_error_dialog:
@@ -1387,3 +1401,19 @@ class QuodLibetWindow(Window, PersistentWindowMixin, AppWindow):
         t = self.browser.status_text(count=len(songs),
                                      time=util.format_time_preferred(length))
         self.statusbar.set_default_text(t)
+
+
+class ConfirmEnqueue(qltk.Message):
+    def __init__(self, parent, count):
+        title = ngettext("Are you sure you want to enqueue %d song?",
+                         "Are you sure you want to enqueue %d songs?",
+                         count) % count
+        description = ""
+
+        super().__init__(
+            Gtk.MessageType.WARNING, parent, title, description,
+            Gtk.ButtonsType.NONE)
+
+        self.add_button(_("_Cancel"), Gtk.ResponseType.CANCEL)
+        self.add_icon_button(_("_Enqueue"), Icons.LIST_ADD,
+                             Gtk.ResponseType.YES)


### PR DESCRIPTION
Ctrl-Return in the searchbar enqueues the complete songlist

Check-list
----------

 * [ ] There is a linked issue discussing the motivations for this feature or bugfix
 * [ ] Unit tests have been added where possible
 * [ ] I've added / updated documentation for any user-facing features.
 * [ ] Performance seems to be comparable or better than current `master`


What this change is adding / fixing
-----------------------------------
<!-- A high-level description of the changes.
Hopefully the commits are atomic and well described, but this is the overall
summary of the change, to other developers / maintainers, plus any TODOs. -->

This is a follow-up to #2745 and #2701, because after four years I'm finally starting to use the "Track List" browser.  I've now looked the rest of the browsers and I don't see how they could be extended with this feature.  This pull request copies code from the implementation of the panned browser, so it results in code duplication.  However, a substantial duplication is already present, so this PR doesn't change the status quo.  

Once again, I am not able to find a place where the change should be documented.  `docs/guide/shortcuts.rst` is the obvious target, but I just don't know where to write what.

If necessary, please, tell me how to refine the PR, and I'll do my best to update it.  Thanks again.

