### PR TITLE
Fix regression of --print-query

### DIFF
--- a/quodlibet/library/song.py
+++ b/quodlibet/library/song.py
@@ -81,7 +81,8 @@ class SongLibrary(Library[K, V], PicklingMixin):
 
         songs = self.values()
         if text != "":
-            songs = [s for s in songs if Query(text, star).search(s)]
+            search = Query(text, star).search
+            songs = [s for s in songs if search(s)]
         return songs
 
 


### PR DESCRIPTION
"quodlibet --print-query=asdf" results in a timeout if the music collection is large and the main quodlibet instance is started with the --debug flag because currently Query is unnecessarily instantiated for every song.  This commit fixes this, which results in a performance increase even without --debug.

I think commit e40270f70 introduced the regression.

Check-list
----------

 * [ ] There is a linked issue discussing the motivations for this feature or bugfix
 * [ ] Unit tests have been added where possible
 * [ ] I've added / updated documentation for any user-facing features.
 * [X] Performance seems to be comparable or better than current `master`


What this change is adding / fixing
-----------------------------------
<!-- A high-level description of the changes.
Hopefully the commits are atomic and well described, but this is the overall
summary of the change, to other developers / maintainers, plus any TODOs. -->

This is described above, but now I've actually looked at commit e40270f70 and it seems it consists of similar changes, so it might introduced other regressions.  Probably not, but it's hard for me to tell.
