### PR TITLE
Add CLI args: --set-pattern and --set-pattern-help

### DIFF
--- a/quodlibet/cli.py
+++ b/quodlibet/cli.py
@@ -86,6 +86,8 @@ def process_arguments(argv):
         _("a music library and player"),
         _("[option]"))
 
+    options.add("set-pattern", help="Set template for --print-* commands")
+    options.add("set-pattern-help", help="Show help for --set-pattern")
     options.add("print-playing", help=_("Print the playing song and exit"))
     options.add("start-playing", help=_("Begin playing immediately"))
     options.add("start-hidden", help=_("Don't show any windows on start"))
@@ -239,6 +241,13 @@ def process_arguments(argv):
             queue(command, filename)
         elif command == "enqueue-files":
             queue(command, arg)
+        elif command == "set-pattern":
+            try:
+                queue(command, args[0])
+            except IndexError:
+                queue(command)
+        elif command == "set-pattern-help":
+            queue(command)
         elif command == "play-file":
             if uri_is_valid(arg) and arg.startswith("quodlibet://"):
                 # TODO: allow handling of URIs without --play-file

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -46,6 +46,18 @@ class TCommands(TestCase):
         app.player.seek(234.56 * 1000)
         assert self.__send("print-playing <~#elapsed>") == "234.56\n"
 
+    def test_set_pattern(self):
+        app.player.info = AudioFile(
+            {"album": "foo",
+             "artist": "artist",
+             "title": "title",
+             "~filename": fsnative("/dev/null"),
+             })
+        self.__send("set-pattern <album>-bar")
+        assert self.__send("print-playing") == "foo-bar\n"
+        self.__send("set-pattern")
+        assert self.__send("print-playing") == "artist - foo - title\n"
+
     def test_player(self):
         self.__send("previous")
         self.__send("force-previous")


### PR DESCRIPTION
Because of #3031, it's now a two-step process to get, for example, the filenames of the songs in the queue:

  $ quodlibet --set-pattern '<~filename>'
  $ quodlibet --print-queue

Closes #1979
Closes #3080

Check-list
----------

 * [x] There is a linked issue discussing the motivations for this feature or bugfix
 * [x] Unit tests have been added where possible
 * [ ] I've added / updated documentation for any user-facing features.
 * [x] Performance seems to be comparable or better than current `master`


What this change is adding / fixing
-----------------------------------
<!-- A high-level description of the changes.
Hopefully the commits are atomic and well described, but this is the overall
summary of the change, to other developers / maintainers, plus any TODOs. -->

It allows the user to configure the output format of the --print-* cli commands.

It has a negligible performance impact because, for example,  it uses `Pattern('<~filename>').format(song)` instead of `song("~filename")`.  For a queue of 500 songs, the difference is lost in the noise:
```
$ # The PR version is running
$ time ./quodlibet.py --print-queue > /tmp/q

real    0m0.298s
user    0m0.249s
sys     0m0.035s
$ # Switch to the master, restart QL
$ time ./quodlibet.py --print-queue > /tmp/q2

real    0m0.320s
user    0m0.284s
sys     0m0.024s
$ wc -l /tmp/q
500 /tmp/q
$ diff /tmp/q /tmp/q2
$ # Empty the queue
$ time ./quodlibet.py --print-queue > /tmp/q3

real    0m0.307s
user    0m0.275s
sys     0m0.029s
$ cat /tmp/q3

$ 
```

In the discussion of #1979, the desire for "format=json" has been mentioned.  This is a potential TODO, but it can later be achieved by adding support for a new tag like:  `<~json>`.

I haven't updated the documentation (the *.rst files),  I wait for some feedback first.