### PR TITLE
Add "edit" button to column tag editor window

### DIFF
--- a/po/quodlibet.pot
+++ b/po/quodlibet.pot
@@ -161,7 +161,7 @@ msgstr ""
 #: quodlibet/ext/songsmenu/duplicates.py:345
 #: quodlibet/ext/songsmenu/filterall.py:48 quodlibet/qltk/bookmarks.py:101
 #: quodlibet/qltk/cbes.py:96 quodlibet/qltk/data_editors.py:97
-#: quodlibet/qltk/data_editors.py:326 quodlibet/qltk/pluginwin.py:101
+#: quodlibet/qltk/data_editors.py:329 quodlibet/qltk/pluginwin.py:101
 #: quodlibet/qltk/pluginwin.py:443 quodlibet/qltk/prefs.py:784
 #: quodlibet/qltk/textedit.py:163 quodlibet/update.py:149
 msgid "_Close"
@@ -228,7 +228,7 @@ msgstr ""
 #: quodlibet/qltk/cbes.py:85 quodlibet/qltk/cbes.py:92
 #: quodlibet/qltk/data_editors.py:79 quodlibet/qltk/data_editors.py:92
 #: quodlibet/qltk/data_editors.py:303 quodlibet/qltk/data_editors.py:316
-#: quodlibet/qltk/data_editors.py:324 quodlibet/qltk/edittags.py:555
+#: quodlibet/qltk/data_editors.py:327 quodlibet/qltk/edittags.py:555
 #: quodlibet/qltk/edittags.py:743 quodlibet/qltk/maskedbox.py:48
 #: quodlibet/qltk/maskedbox.py:88 quodlibet/qltk/queue.py:479
 #: quodlibet/qltk/scanbox.py:38 quodlibet/qltk/scanbox.py:66
@@ -4886,7 +4886,7 @@ msgid "Too many arguments"
 msgstr ""
 
 #: quodlibet/operon/commands.py:55 quodlibet/operon/commands.py:91
-#: quodlibet/operon/commands.py:478 quodlibet/qltk/data_editors.py:372
+#: quodlibet/operon/commands.py:478 quodlibet/qltk/data_editors.py:375
 msgid "Description"
 msgstr ""
 
@@ -5381,16 +5381,24 @@ msgstr ""
 msgid "_Add…"
 msgstr ""
 
-#: quodlibet/qltk/data_editors.py:363
+#: quodlibet/qltk/data_editors.py:319
+msgid "_Edit"
+msgstr ""
+
+#: quodlibet/qltk/data_editors.py:366
 msgid "Tag expression"
 msgstr ""
 
-#: quodlibet/qltk/data_editors.py:393
+#: quodlibet/qltk/data_editors.py:396 quodlibet/qltk/data_editors.py:406
 msgid "Tag expression e.g. people:real or ~album~year"
 msgstr ""
 
-#: quodlibet/qltk/data_editors.py:394
+#: quodlibet/qltk/data_editors.py:397
 msgid "Enter new tag"
+msgstr ""
+
+#: quodlibet/qltk/data_editors.py:407
+msgid "Edit tag"
 msgstr ""
 
 #: quodlibet/qltk/delete.py:37

--- a/quodlibet/qltk/data_editors.py
+++ b/quodlibet/qltk/data_editors.py
@@ -316,6 +316,9 @@ class TagListEditor(qltk.Window):
         remove = Button(_("_Remove"), Icons.LIST_REMOVE)
         remove.connect("clicked", self.__remove)
         vbbox.pack_start(remove, False, True, 0)
+        edit = Button(_("_Edit"), Icons.LIST_EDIT)
+        edit.connect("clicked", self.__edit)
+        vbbox.pack_start(edit, False, True, 0)
         hbox.pack_start(vbbox, False, True, 0)
         vbox.pack_start(hbox, True, True, 0)
 
@@ -397,6 +400,16 @@ class TagListEditor(qltk.Window):
         new = dialog.run()
         if new:
             self.model.append(row=[new])
+
+    def __edit(self, *args):
+        path, col = self.view.get_cursor()
+        tooltip = _('Tag expression e.g. people:real or ~album~year')
+        dialog = GetStringDialog(self, _("Edit tag"), "",
+                                 button_icon=None,
+                                 tooltip=tooltip)
+        edited = dialog.run(text=self.model[path][0])
+        if edited:
+            self.model[path][0] = edited
 
     def __popup(self, view, menu):
         return view.popup_menu(menu, 0, Gtk.get_current_event_time()).show()

--- a/quodlibet/qltk/data_editors.py
+++ b/quodlibet/qltk/data_editors.py
@@ -404,7 +404,7 @@ class TagListEditor(qltk.Window):
     def __edit(self, *args):
         path, col = self.view.get_cursor()
         tooltip = _('Tag expression e.g. people:real or ~album~year')
-        dialog = GetStringDialog(self, _("Edit tag"), "",
+        dialog = GetStringDialog(self, _("Edit tag expression"), "",
                                  button_icon=None,
                                  tooltip=tooltip)
         edited = dialog.run(text=self.model[path][0])

--- a/quodlibet/qltk/icons.py
+++ b/quodlibet/qltk/icons.py
@@ -81,6 +81,7 @@ class Icons(str):
     INSERT_IMAGE = "insert-image"
     INSERT_TEXT = "insert-text"
     LIST_ADD = "list-add"  # "_Add"
+    LIST_EDIT = "list-edit"  # "_Edit"
     LIST_REMOVE = "list-remove"  # "_Remove"
     MEDIA_EJECT = "media-eject"
     MEDIA_OPTICAL = "media-optical"  # "_CD-ROM"

--- a/quodlibet/qltk/icons.py
+++ b/quodlibet/qltk/icons.py
@@ -81,7 +81,7 @@ class Icons(str):
     INSERT_IMAGE = "insert-image"
     INSERT_TEXT = "insert-text"
     LIST_ADD = "list-add"  # "_Add"
-    LIST_EDIT = "list-edit"  # "_Edit"
+    LIST_EDIT = "document-edit"  # "_Edit"
     LIST_REMOVE = "list-remove"  # "_Remove"
     MEDIA_EJECT = "media-eject"
     MEDIA_OPTICAL = "media-optical"  # "_CD-ROM"


### PR DESCRIPTION
Instead of forcing "inline" editing in the Tag List Editor, which can be confusing, add a button that edits the selected tag pattern.
