### PR TITLE
Fix crash in console when autocompleting

### DIFF
--- a/quodlibet/ext/songsmenu/console.py
+++ b/quodlibet/ext/songsmenu/console.py
@@ -523,9 +523,8 @@ class PythonConsole(Gtk.ScrolledWindow):
                             if i < noargs:
                                 sargs.append(spec.args[i])
                             else:
-                                sargs.append(spec.args[i] + '=' +
-                                             spec.defaults[i -
-                                                           noargs].__repr__())
+                                default_arg = repr(spec.defaults[i - noargs])
+                                sargs.append(spec.args[i] + '=' + default_arg)
 
                         details = " ({})".format(", ".join(sargs))
                         comp.append((name, details))


### PR DESCRIPTION
Some objects (like custom classes) don't have a defined `__repr__`. When an object like this is the default argument of a function, we currently receive an uncaught `TypeError` exception.

Instead, use `repr()` to get the string representation of the object. When `__repr__` isn't defined, it falls back to returning a reasonable representation of most objects.