### PR TITLE
Fix crash when using covergrid + default art size

### DIFF
--- a/quodlibet/browsers/covergrid/main.py
+++ b/quodlibet/browsers/covergrid/main.py
@@ -157,7 +157,10 @@ class CoverGridContainer(ScrolledWindow):
 
 def _get_cover_size():
     mag = config.getfloat("browsers", "covergrid_magnification", 3.)
-    return mag * config.getint("browsers", "cover_size", 48)
+    size = config.getint("browsers", "cover_size")
+    if size <= 0:
+        size = 48
+    return mag * size
 
 
 class CoverGrid(Browser, util.InstanceTracker, DisplayPatternMixin):


### PR DESCRIPTION
The default config value for browsers.cover_size is -1. The new covergrid code works fine when the config value is absent, but with this default it will crash after requesting a negative size from `GdkPixbuf.Pixbuf.new_from_file_at_size`.