### PR TITLE
Disable ordering when active order disappears

### DIFF
--- a/quodlibet/qltk/playorder.py
+++ b/quodlibet/qltk/playorder.py
@@ -174,6 +174,8 @@ class ToggledPlayOrderMenu(Gtk.Box):
         self.__orders = values
         if self.__current not in self.orders:
             self.__current = None
+            # if current order has become invalid, deactivate
+            self.enabled = False
         self.__rebuild_menu()
 
     @property

--- a/tests/test_qltk_playorder.py
+++ b/tests/test_qltk_playorder.py
@@ -106,3 +106,7 @@ class TToggledPlayOrderMenu(TestCase):
     def test_set_orders(self):
         self.tpom.set_orders([])
         self.failIf(self.tpom.current)
+
+    def test_playorder_disables_when_order_disappears(self):
+        self.tpom.orders = Orders([OrderWeighted, FakeOrder])
+        self.failIf(self.tpom.enabled)


### PR DESCRIPTION
When you disable a plugin-based play order or repeat mode, the UI is refreshed so that it will stop showing the mode in the menu. However, this change is only visual. The mode remains active until the app is restarted or the user actively changes the mode.

I considered several ways of fixing this, but I ended up opting to just disable the play mode entirely until the user takes action. This is the only thing that makes sense, because a user who has been using "queue only" mode probably doesn't want to be switched to "shuffle" mode just because they decide to disable the plugin.

Fixes #4155.

Check-list
----------

 * [x] There is a linked issue discussing the motivations for this feature or bugfix
 * [x] Unit tests have been added where possible
 * [x] I've added / updated documentation for any user-facing features.
 * [x] Performance seems to be comparable or better than current `master`