### PR TITLE
Use XDG directories for storing user files

### DIFF
--- a/quodlibet/__init__.py
+++ b/quodlibet/__init__.py
@@ -29,7 +29,8 @@ from ._main import get_base_dir, is_release, app, \
 
 
 _, C_, N_, ngettext, npgettext, is_release, init, init_cli, print_e, \
-    get_base_dir, print_w, print_d, get_config_dir, app, set_application_info, \
+    get_base_dir, print_w, print_d, app, set_application_info, \
     init_plugins, enable_periodic_save, run, finish_first_session, \
-    get_image_dir, is_first_session, get_build_description, \
-    get_build_version, get_config_dir, get_data_dir, get_cache_dir, get_runtime_dir
+    get_image_dir, is_first_session, \
+    get_build_description, get_build_version, \
+    get_config_dir, get_data_dir, get_cache_dir, get_runtime_dir

--- a/quodlibet/__init__.py
+++ b/quodlibet/__init__.py
@@ -21,14 +21,15 @@ install_redirect_import_hook()
 from .util.i18n import _, C_, N_, ngettext, npgettext
 from .util.dprint import print_d, print_e, print_w
 from ._init import init_cli, init
-from ._main import get_base_dir, is_release, get_user_dir, app, \
+from ._main import get_base_dir, is_release, app, \
     set_application_info, init_plugins, enable_periodic_save, run, \
     finish_first_session, get_image_dir, is_first_session, \
-    get_build_description, get_build_version, get_cache_dir
+    get_build_description, get_build_version, \
+    get_config_dir, get_data_dir, get_cache_dir, get_runtime_dir
 
 
 _, C_, N_, ngettext, npgettext, is_release, init, init_cli, print_e, \
-    get_base_dir, print_w, print_d, get_user_dir, app, set_application_info, \
+    get_base_dir, print_w, print_d, app, set_application_info, \
     init_plugins, enable_periodic_save, run, finish_first_session, \
     get_image_dir, is_first_session, get_build_description, \
-    get_build_version, get_cache_dir
+    get_build_version, get_config_dir, get_data_dir, get_cache_dir, get_runtime_dir

--- a/quodlibet/__init__.py
+++ b/quodlibet/__init__.py
@@ -29,7 +29,7 @@ from ._main import get_base_dir, is_release, app, \
 
 
 _, C_, N_, ngettext, npgettext, is_release, init, init_cli, print_e, \
-    get_base_dir, print_w, print_d, app, set_application_info, \
+    get_base_dir, print_w, print_d, get_config_dir, app, set_application_info, \
     init_plugins, enable_periodic_save, run, finish_first_session, \
     get_image_dir, is_first_session, get_build_description, \
     get_build_version, get_config_dir, get_data_dir, get_cache_dir, get_runtime_dir

--- a/quodlibet/_main.py
+++ b/quodlibet/_main.py
@@ -247,6 +247,7 @@ def init_plugins(no_plugins=False):
     print_d("Starting plugin manager")
 
     from quodlibet import plugins
+    # FIXME: This should probably go to `~/.local/lib/quodlibet`
     folders = [os.path.join(get_base_dir(), "ext", kind)
                for kind in PLUGIN_DIRS]
     folders.append(os.path.join(get_user_dir(), "plugins"))
@@ -399,7 +400,7 @@ def run(window, before_quit=None):
     # gtk+ on osx is just too crashy
     if not is_osx():
         try:
-            faulthandling.enable(os.path.join(get_user_dir(), "faultdump"))
+            faulthandling.enable(os.path.join(get_cache_dir(), "faultdump"))
         except IOError:
             util.print_exc()
         else:

--- a/quodlibet/_main.py
+++ b/quodlibet/_main.py
@@ -268,9 +268,9 @@ def init_plugins(no_plugins=False):
     print_d("Starting plugin manager")
 
     from quodlibet import plugins
-    # FIXME: This should probably go to `~/.local/lib/quodlibet`
     folders = [os.path.join(get_base_dir(), "ext", kind)
                for kind in PLUGIN_DIRS]
+    folders.append(os.path.join(get_fallback_dir(), "plugins"))
     folders.append(os.path.join(get_config_dir(), "plugins"))
     print_d("Scanning folders: %s" % folders)
     pm = plugins.init(folders, no_plugins)

--- a/quodlibet/_main.py
+++ b/quodlibet/_main.py
@@ -136,8 +136,10 @@ def get_image_dir():
 def get_data_dir():
     """The directory to store things considered user-specific data files"""
 
-    fallback_dir = get_fallback_dir()
-    if fallback_dir:
+    fallback_dir, legacy = get_fallback_dir()
+    if legacy:
+        path = fallback_dir
+    elif fallback_dir:
         path = os.path.join(fallback_dir, "data")
     else:
         path = os.path.join(xdg_get_data_home(), "quodlibet")
@@ -150,8 +152,10 @@ def get_data_dir():
 def get_cache_dir():
     """The directory to store things which can be deleted at any time"""
 
-    fallback_dir = get_fallback_dir()
-    if fallback_dir:
+    fallback_dir, legacy = get_fallback_dir()
+    if legacy:
+        path = fallback_dir
+    elif fallback_dir:
         path = os.path.join(fallback_dir, "cache")
     else:
         path = os.path.join(xdg_get_cache_home(), "quodlibet")
@@ -164,8 +168,10 @@ def get_cache_dir():
 def get_runtime_dir():
     """The directory to store user-specific runtime files and other file objects"""
 
-    fallback_dir = get_fallback_dir()
-    if fallback_dir:
+    fallback_dir, legacy = get_fallback_dir()
+    if legacy:
+        path = fallback_dir
+    elif fallback_dir:
         path = os.path.join(fallback_dir, "runtime")
     else:
         path = os.path.join(xdg_get_runtime_dir(), "quodlibet")
@@ -178,8 +184,10 @@ def get_runtime_dir():
 def get_config_dir():
     """The directory to store user-specific configuration files"""
 
-    fallback_dir = get_fallback_dir()
-    if fallback_dir:
+    fallback_dir, legacy = get_fallback_dir()
+    if legacy:
+        path = fallback_dir
+    elif fallback_dir:
         path = os.path.join(fallback_dir, "config")  # TODO: Maybe without the config?
     else:
         path = os.path.join(xdg_get_config_home(), "quodlibet")
@@ -191,7 +199,7 @@ def get_config_dir():
 @cached_func
 def get_fallback_dir():
     """The fallback for non-Linux and ~/.quodlibet"""
-    USERDIR = None
+    USERDIR, legacy = None, False
 
     if os.name == "nt":
         USERDIR = os.path.join(windows.get_appdata_dir(), "Quod Libet")
@@ -200,7 +208,8 @@ def get_fallback_dir():
     else:  # Linux
         homedir = os.path.join(os.path.expanduser("~"), ".quodlibet")
         if os.path.exists(homedir):
-            USERDIR = homedir
+            # This is a legacy path
+            USERDIR, legacy = homedir, True
 
     # Bruteforce override
     if 'QUODLIBET_USERDIR' in os.environ:
@@ -211,7 +220,7 @@ def get_fallback_dir():
         USERDIR = os.path.normpath(os.path.join(
             os.path.dirname(path2fsn(sys.executable)), "..", "..", "config"))
 
-    return USERDIR
+    return USERDIR, legacy
 
 
 def is_release():

--- a/quodlibet/_main.py
+++ b/quodlibet/_main.py
@@ -270,7 +270,6 @@ def init_plugins(no_plugins=False):
     from quodlibet import plugins
     folders = [os.path.join(get_base_dir(), "ext", kind)
                for kind in PLUGIN_DIRS]
-    folders.append(os.path.join(get_fallback_dir(), "plugins"))
     folders.append(os.path.join(get_config_dir(), "plugins"))
     print_d("Scanning folders: %s" % folders)
     pm = plugins.init(folders, no_plugins)

--- a/quodlibet/_main.py
+++ b/quodlibet/_main.py
@@ -16,7 +16,7 @@ from quodlibet import const
 from quodlibet import build
 from quodlibet.util import cached_func, windows, set_process_title, is_osx
 from quodlibet.util.dprint import print_d
-from quodlibet.util.path import mkdir, xdg_get_config_home, xdg_get_cache_home
+from quodlibet.util.path import mkdir, xdg_get_config_home, xdg_get_data_home, xdg_get_cache_home
 
 
 PLUGIN_DIRS = ["editing", "events", "playorder", "songsmenu", "playlist",
@@ -131,8 +131,22 @@ def get_image_dir():
 
 
 @cached_func
+def get_data_dir():
+    """The directory to store things considered user-specific data files"""
+
+    if os.name == "nt" and build.BUILD_TYPE == u"windows-portable":
+        # avoid writing things to the host system for the portable build
+        path = os.path.join(get_user_dir(), "cache")
+    else:
+        path = os.path.join(xdg_get_data_home(), "quodlibet")
+
+    mkdir(path, 0o700)
+    return path
+
+
+@cached_func
 def get_cache_dir():
-    """The directory to store things into which can be deleted at any time"""
+    """The directory to store things which can be deleted at any time"""
 
     if os.name == "nt" and build.BUILD_TYPE == u"windows-portable":
         # avoid writing things to the host system for the portable build

--- a/quodlibet/_main.py
+++ b/quodlibet/_main.py
@@ -166,7 +166,8 @@ def get_cache_dir():
 
 @cached_func
 def get_runtime_dir():
-    """The directory to store user-specific runtime files and other file objects"""
+    """The directory to store user-specific runtime files and other file
+    objects"""
 
     fallback_dir, legacy = get_fallback_dir()
     if legacy:
@@ -188,7 +189,8 @@ def get_config_dir():
     if legacy:
         path = fallback_dir
     elif fallback_dir:
-        path = os.path.join(fallback_dir, "config")  # TODO: Maybe without the config?
+        # TODO: Maybe without the config?
+        path = os.path.join(fallback_dir, "config")
     else:
         path = os.path.join(xdg_get_config_home(), "quodlibet")
 

--- a/quodlibet/_main.py
+++ b/quodlibet/_main.py
@@ -138,7 +138,7 @@ def get_data_dir():
 
     if os.name == "nt" and build.BUILD_TYPE == u"windows-portable":
         # avoid writing things to the host system for the portable build
-        path = os.path.join(get_user_dir(), "cache")
+        path = os.path.join(get_config_dir(), "cache")
     else:
         path = os.path.join(xdg_get_data_home(), "quodlibet")
 
@@ -152,7 +152,7 @@ def get_cache_dir():
 
     if os.name == "nt" and build.BUILD_TYPE == u"windows-portable":
         # avoid writing things to the host system for the portable build
-        path = os.path.join(get_user_dir(), "cache")
+        path = os.path.join(get_config_dir(), "cache")
     else:
         path = os.path.join(xdg_get_cache_home(), "quodlibet")
 
@@ -166,7 +166,7 @@ def get_runtime_dir():
 
     if os.name == "nt" and build.BUILD_TYPE == u"windows-portable":
         # avoid writing things to the host system for the portable build
-        path = os.path.join(get_user_dir(), "runtime")
+        path = os.path.join(get_config_dir(), "runtime")
     else:
         path = os.path.join(xdg_get_runtime_dir(), "quodlibet")
 
@@ -175,8 +175,8 @@ def get_runtime_dir():
 
 
 @cached_func
-def get_user_dir():
-    """Place where QL saves its state, database, config etc."""
+def get_config_dir():
+    """The directory to store user-specific configuration files"""
 
     if os.name == "nt":
         USERDIR = os.path.join(windows.get_appdata_dir(), "Quod Libet")
@@ -250,7 +250,7 @@ def init_plugins(no_plugins=False):
     # FIXME: This should probably go to `~/.local/lib/quodlibet`
     folders = [os.path.join(get_base_dir(), "ext", kind)
                for kind in PLUGIN_DIRS]
-    folders.append(os.path.join(get_user_dir(), "plugins"))
+    folders.append(os.path.join(get_config_dir(), "plugins"))
     print_d("Scanning folders: %s" % folders)
     pm = plugins.init(folders, no_plugins)
     pm.rescan()

--- a/quodlibet/_main.py
+++ b/quodlibet/_main.py
@@ -16,7 +16,9 @@ from quodlibet import const
 from quodlibet import build
 from quodlibet.util import cached_func, windows, set_process_title, is_osx
 from quodlibet.util.dprint import print_d
-from quodlibet.util.path import mkdir, xdg_get_config_home, xdg_get_data_home, xdg_get_cache_home
+from quodlibet.util.path import mkdir, \
+        xdg_get_config_home, xdg_get_data_home, \
+        xdg_get_cache_home, xdg_get_runtime_dir
 
 
 PLUGIN_DIRS = ["editing", "events", "playorder", "songsmenu", "playlist",
@@ -153,6 +155,20 @@ def get_cache_dir():
         path = os.path.join(get_user_dir(), "cache")
     else:
         path = os.path.join(xdg_get_cache_home(), "quodlibet")
+
+    mkdir(path, 0o700)
+    return path
+
+
+@cached_func
+def get_runtime_dir():
+    """The directory to store user-specific runtime files and other file objects"""
+
+    if os.name == "nt" and build.BUILD_TYPE == u"windows-portable":
+        # avoid writing things to the host system for the portable build
+        path = os.path.join(get_user_dir(), "runtime")
+    else:
+        path = os.path.join(xdg_get_runtime_dir(), "quodlibet")
 
     mkdir(path, 0o700)
     return path

--- a/quodlibet/browsers/albums/main.py
+++ b/quodlibet/browsers/albums/main.py
@@ -424,7 +424,7 @@ class AlbumList(Browser, util.InstanceTracker, VisibleUpdate,
     __last_render = None
     __last_render_surface = None
 
-    _PATTERN_FN = os.path.join(quodlibet.get_user_dir(), "album_pattern")
+    _PATTERN_FN = os.path.join(quodlibet.get_data_dir(), "album_pattern")  # TODO: Maybe on the Config folder?
     _DEFAULT_PATTERN_TEXT = DEFAULT_PATTERN_TEXT
 
     name = _("Album List")

--- a/quodlibet/browsers/albums/main.py
+++ b/quodlibet/browsers/albums/main.py
@@ -424,7 +424,8 @@ class AlbumList(Browser, util.InstanceTracker, VisibleUpdate,
     __last_render = None
     __last_render_surface = None
 
-    _PATTERN_FN = os.path.join(quodlibet.get_data_dir(), "album_pattern")  # TODO: Maybe on the Config folder?
+    # TODO: Maybe on the Config folder?
+    _PATTERN_FN = os.path.join(quodlibet.get_data_dir(), "album_pattern")
     _DEFAULT_PATTERN_TEXT = DEFAULT_PATTERN_TEXT
 
     name = _("Album List")

--- a/quodlibet/browsers/covergrid/main.py
+++ b/quodlibet/browsers/covergrid/main.py
@@ -163,7 +163,7 @@ def _get_cover_size():
 class CoverGrid(Browser, util.InstanceTracker, DisplayPatternMixin):
     __model = None
 
-    _PATTERN_FN = os.path.join(quodlibet.get_user_dir(), "album_pattern")
+    _PATTERN_FN = os.path.join(quodlibet.get_data_dir(), "album_pattern")  # TODO: Maybe on the Config folder?
     _DEFAULT_PATTERN_TEXT = DEFAULT_PATTERN_TEXT
 
     name = _("Cover Grid")

--- a/quodlibet/browsers/covergrid/main.py
+++ b/quodlibet/browsers/covergrid/main.py
@@ -163,7 +163,8 @@ def _get_cover_size():
 class CoverGrid(Browser, util.InstanceTracker, DisplayPatternMixin):
     __model = None
 
-    _PATTERN_FN = os.path.join(quodlibet.get_data_dir(), "album_pattern")  # TODO: Maybe on the Config folder?
+    # TODO: Maybe on the Config folder?
+    _PATTERN_FN = os.path.join(quodlibet.get_data_dir(), "album_pattern")
     _DEFAULT_PATTERN_TEXT = DEFAULT_PATTERN_TEXT
 
     name = _("Cover Grid")

--- a/quodlibet/browsers/iradio.py
+++ b/quodlibet/browsers/iradio.py
@@ -50,8 +50,8 @@ from quodlibet.qltk.x import MenuItem, Align, ScrolledWindow, Button
 
 STATION_LIST_URL = \
     "https://quodlibet.github.io/radio/radiolist.bz2"
-STATIONS_FAV = os.path.join(quodlibet.get_user_dir(), "stations")
-STATIONS_ALL = os.path.join(quodlibet.get_user_dir(), "stations_all")
+STATIONS_FAV = os.path.join(quodlibet.get_data_dir(), "stations")
+STATIONS_ALL = os.path.join(quodlibet.get_cache_dir(), "stations_all")
 
 # TODO: - Ranking: reduce duplicate stations (max 3 URLs per station)
 #                  prefer stations that match a genre?

--- a/quodlibet/browsers/playlists/main.py
+++ b/quodlibet/browsers/playlists/main.py
@@ -51,7 +51,8 @@ class PlaylistsBrowser(Browser, DisplayPatternMixin):
     priority = 2
     replaygain_profiles = ["track"]
     __last_render = None
-    _PATTERN_FN = os.path.join(quodlibet.get_data_dir(), "playlist_pattern")  # TODO: Maybe on the Config folder?
+    # TODO: Maybe on the Config folder?
+    _PATTERN_FN = os.path.join(quodlibet.get_data_dir(), "playlist_pattern")
     _DEFAULT_PATTERN_TEXT = DEFAULT_PATTERN_TEXT
 
     def __init__(self, songs_lib: SongFileLibrary, Confirmer=ConfirmationPrompt):

--- a/quodlibet/browsers/playlists/main.py
+++ b/quodlibet/browsers/playlists/main.py
@@ -51,7 +51,7 @@ class PlaylistsBrowser(Browser, DisplayPatternMixin):
     priority = 2
     replaygain_profiles = ["track"]
     __last_render = None
-    _PATTERN_FN = os.path.join(quodlibet.get_user_dir(), "playlist_pattern")
+    _PATTERN_FN = os.path.join(quodlibet.get_data_dir(), "playlist_pattern")  # TODO: Maybe on the Config folder?
     _DEFAULT_PATTERN_TEXT = DEFAULT_PATTERN_TEXT
 
     def __init__(self, songs_lib: SongFileLibrary, Confirmer=ConfirmationPrompt):

--- a/quodlibet/browsers/playlists/util.py
+++ b/quodlibet/browsers/playlists/util.py
@@ -8,20 +8,20 @@
 
 import os
 
-from quodlibet import _, print_w
+from quodlibet import _, get_data_dir, print_w
 from quodlibet import formats
 from quodlibet.qltk import Icons
 from quodlibet.qltk.getstring import GetStringDialog
 from quodlibet.qltk.msg import ConfirmationPrompt
 from quodlibet.qltk.wlw import WaitLoadWindow
 from quodlibet.util import escape
-from quodlibet.util.path import uri_is_valid
+from quodlibet.util.path import mkdir, uri_is_valid
 from urllib.response import addinfourl
-from senf import uri2fsn, fsn2text, path2fsn, bytes2fsn, text2fsn
+from senf import fsnative, uri2fsn, fsn2text, path2fsn, bytes2fsn, text2fsn
 
 
 # Directory for playlist files
-PLAYLISTS = os.path.join(quodlibet.get_data_dir(), "playlists")
+PLAYLISTS = os.path.join(get_data_dir(), "playlists")
 assert isinstance(PLAYLISTS, fsnative)
 if not os.path.isdir(PLAYLISTS):
     mkdir(PLAYLISTS)

--- a/quodlibet/browsers/playlists/util.py
+++ b/quodlibet/browsers/playlists/util.py
@@ -20,6 +20,13 @@ from urllib.response import addinfourl
 from senf import uri2fsn, fsn2text, path2fsn, bytes2fsn, text2fsn
 
 
+# Directory for playlist files
+PLAYLISTS = os.path.join(quodlibet.get_data_dir(), "playlists")
+assert isinstance(PLAYLISTS, fsnative)
+if not os.path.isdir(PLAYLISTS):
+    mkdir(PLAYLISTS)
+
+
 def confirm_remove_playlist_dialog_invoke(
     parent, playlist, Confirmer=ConfirmationPrompt):
     """Creates and invokes a confirmation dialog that asks the user whether or not

--- a/quodlibet/browsers/podcasts.py
+++ b/quodlibet/browsers/podcasts.py
@@ -38,7 +38,7 @@ from quodlibet.util.path import uri_is_valid
 from quodlibet.util.picklehelper import pickle_load, pickle_dump, PickleError
 
 
-FEEDS = os.path.join(quodlibet.get_user_dir(), "feeds")
+FEEDS = os.path.join(quodlibet.get_data_dir(), "feeds")
 DND_URI_LIST, DND_MOZ_URL = range(2)
 
 # Migration path for pickle

--- a/quodlibet/config.py
+++ b/quodlibet/config.py
@@ -63,6 +63,7 @@ INITIAL: Dict[str, Dict[str, str]] = {
         "watch": "false"
     },
 
+    # TODO: Move this to a separate file in `get_cache_dir`
     # State about the player, to restore on startup
     "memory": {
 

--- a/quodlibet/config.py
+++ b/quodlibet/config.py
@@ -9,10 +9,13 @@
 # the Free Software Foundation; either version 2 of the License, or
 # (at your option) any later version.
 
+import logging
+from pathlib import Path
 from typing import Dict
 import shutil
 
 from quodlibet.util import enum
+from ._main import get_config_dir, get_data_dir
 from . import const
 from quodlibet.util.config import Config, Error
 from quodlibet.util import print_d, print_w
@@ -522,3 +525,33 @@ class DurationFormatPref:
 
 
 DURATION = DurationFormatPref()
+
+
+def migrate_legacy_data(move: bool):
+    cdir = Path(get_config_dir())
+    ddir = Path(get_data_dir())
+    folders = {
+        cdir / 'lists': ddir / 'lists',
+        cdir / 'playlists': ddir / 'playlists',
+    }
+    files = {
+        cdir / 'feeds': ddir / 'feeds',
+        cdir / 'stations': ddir / 'stations',
+    }
+    # Folders
+    # - Add to the files mapping
+    for fsrc, ftgt in folders.items():
+        if fsrc.is_dir():
+            if not ftgt.is_dir():
+                logging.critical('M Folder: %s', ftgt)  # TODO: `logging.info`
+                ftgt.mkdir()
+            for psrc in fsrc.iterdir():
+                assert psrc.is_file()
+                files[psrc] = ftgt / psrc.name
+    # Single files
+    for psrc, ptgt in files.items():
+        if psrc.exists() and not ptgt.exists():
+            logging.critical('M: %s » %s', psrc, ptgt)  # TODO: `logging.info`
+            shutil.copy(psrc, ptgt)
+            if move is True:
+                psrc.unlink()

--- a/quodlibet/errorreport/main.py
+++ b/quodlibet/errorreport/main.py
@@ -159,7 +159,7 @@ def errorhook(exc_info=None):
         return
 
     # write error and logs to disk
-    dump_dir = os.path.join(quodlibet.get_user_dir(), "dumps")
+    dump_dir = os.path.join(quodlibet.get_cache_dir(), "dumps")  # TODO: maybe `get_data_dir`?
     dump_to_disk(dump_dir, exc_info)
 
     sentry = get_sentry()

--- a/quodlibet/errorreport/main.py
+++ b/quodlibet/errorreport/main.py
@@ -159,7 +159,8 @@ def errorhook(exc_info=None):
         return
 
     # write error and logs to disk
-    dump_dir = os.path.join(quodlibet.get_cache_dir(), "dumps")  # TODO: maybe `get_data_dir`?
+    # TODO: maybe `get_data_dir`?
+    dump_dir = os.path.join(quodlibet.get_cache_dir(), "dumps")
     dump_to_disk(dump_dir, exc_info)
 
     sentry = get_sentry()

--- a/quodlibet/errorreport/main.py
+++ b/quodlibet/errorreport/main.py
@@ -158,8 +158,7 @@ def errorhook(exc_info=None):
         # Make sure only one of these is active at a time
         return
 
-    # write error and logs to disk
-    # TODO: maybe `get_data_dir`?
+    # write error and logs to disk (cache folder)
     dump_dir = os.path.join(quodlibet.get_cache_dir(), "dumps")
     dump_to_disk(dump_dir, exc_info)
 

--- a/quodlibet/exfalso.py
+++ b/quodlibet/exfalso.py
@@ -24,7 +24,7 @@ def main(argv=None):
 
     import quodlibet
 
-    config_file = os.path.join(quodlibet.get_user_dir(), "config")
+    config_file = os.path.join(quodlibet.get_config_dir(), "config")
     quodlibet.init(config_file=config_file)
 
     from quodlibet.qltk import add_signal_watch

--- a/quodlibet/ext/events/appinfo.py
+++ b/quodlibet/ext/events/appinfo.py
@@ -16,7 +16,8 @@ from quodlibet.qltk import Icons
 from quodlibet.util.path import unexpand
 from quodlibet.plugins.events import EventPlugin
 from quodlibet import formats
-from quodlibet import app, get_user_dir, get_runtime_dir, get_cache_dir
+from quodlibet import app, get_user_dir, get_data_dir, \
+        get_runtime_dir, get_cache_dir
 from quodlibet.util import fver, escape
 from quodlibet.qltk import gtk_version, pygobject_version, get_backend_name, \
     get_font_backend_name
@@ -69,6 +70,13 @@ class AppInformation(EventPlugin):
         grid.insert_row(row)
         l = label_title(_("Configuration Directory"))
         v = label_path(get_user_dir())
+        grid.attach(l, 0, row, 1, 1)
+        grid.attach(v, 1, row, 1, 1)
+        row += 1
+
+        grid.insert_row(row)
+        l = label_title(_("Data Directory"))
+        v = label_path(get_data_dir())
         grid.attach(l, 0, row, 1, 1)
         grid.attach(v, 1, row, 1, 1)
         row += 1

--- a/quodlibet/ext/events/appinfo.py
+++ b/quodlibet/ext/events/appinfo.py
@@ -29,7 +29,7 @@ class AppInformation(EventPlugin):
     PLUGIN_NAME = _("Application Information")
     PLUGIN_DESC = _("Various information about the application and its "
                     "environment.")
-    PLUGIN_CAN_ENABLE = False
+    PLUGIN_CAN_ENABLE = True
     PLUGIN_ICON = Icons.PREFERENCES_SYSTEM
 
     def PluginPreferences(self, *args):

--- a/quodlibet/ext/events/appinfo.py
+++ b/quodlibet/ext/events/appinfo.py
@@ -16,7 +16,7 @@ from quodlibet.qltk import Icons
 from quodlibet.util.path import unexpand
 from quodlibet.plugins.events import EventPlugin
 from quodlibet import formats
-from quodlibet import app, get_user_dir, get_data_dir, \
+from quodlibet import app, get_config_dir, get_data_dir, \
         get_runtime_dir, get_cache_dir
 from quodlibet.util import fver, escape
 from quodlibet.qltk import gtk_version, pygobject_version, get_backend_name, \
@@ -69,7 +69,7 @@ class AppInformation(EventPlugin):
 
         grid.insert_row(row)
         l = label_title(_("Configuration Directory"))
-        v = label_path(get_user_dir())
+        v = label_path(get_config_dir())
         grid.attach(l, 0, row, 1, 1)
         grid.attach(v, 1, row, 1, 1)
         row += 1

--- a/quodlibet/ext/events/appinfo.py
+++ b/quodlibet/ext/events/appinfo.py
@@ -16,7 +16,7 @@ from quodlibet.qltk import Icons
 from quodlibet.util.path import unexpand
 from quodlibet.plugins.events import EventPlugin
 from quodlibet import formats
-from quodlibet import app, get_user_dir, get_cache_dir
+from quodlibet import app, get_user_dir, get_runtime_dir, get_cache_dir
 from quodlibet.util import fver, escape
 from quodlibet.qltk import gtk_version, pygobject_version, get_backend_name, \
     get_font_backend_name
@@ -76,6 +76,13 @@ class AppInformation(EventPlugin):
         grid.insert_row(row)
         l = label_title(_("Cache Directory"))
         v = label_path(get_cache_dir())
+        grid.attach(l, 0, row, 1, 1)
+        grid.attach(v, 1, row, 1, 1)
+        row += 1
+
+        grid.insert_row(row)
+        l = label_title(_("Runtime Directory"))
+        v = label_path(get_runtime_dir())
         grid.attach(l, 0, row, 1, 1)
         grid.attach(v, 1, row, 1, 1)
         row += 1

--- a/quodlibet/ext/events/jep118.py
+++ b/quodlibet/ext/events/jep118.py
@@ -14,7 +14,7 @@ from quodlibet import util
 from quodlibet.qltk import Icons
 from quodlibet.plugins.events import EventPlugin
 
-outfile = os.path.join(quodlibet.get_user_dir(), "jabber")
+outfile = os.path.join(quodlibet.get_cache_dir(), "jabber")
 format = """\
 <tune xmlns='http://jabber.org/protocol/tune'>
  <artist>%s</artist>
@@ -29,7 +29,7 @@ class JEP118(EventPlugin):
     PLUGIN_ID = "JEP-118"
     PLUGIN_NAME = _("JEP-118")
     PLUGIN_DESC_MARKUP = _("Outputs a Jabber User Tunes file to "
-                           "<tt>~/.quodlibet/jabber</tt>.")
+                           "$XDG_CACHE_HOME/jabber")
     PLUGIN_ICON = Icons.DOCUMENT_SAVE
 
     def plugin_on_song_started(self, song):

--- a/quodlibet/ext/events/jep118.py
+++ b/quodlibet/ext/events/jep118.py
@@ -29,7 +29,7 @@ class JEP118(EventPlugin):
     PLUGIN_ID = "JEP-118"
     PLUGIN_NAME = _("JEP-118")
     PLUGIN_DESC_MARKUP = _("Outputs a Jabber User Tunes file to "
-                           "$XDG_CACHE_HOME/jabber")
+                           "<tt>$XDG_CACHE_HOME/jabber</tt>.")
     PLUGIN_ICON = Icons.DOCUMENT_SAVE
 
     def plugin_on_song_started(self, song):

--- a/quodlibet/ext/events/qlscrobbler.py
+++ b/quodlibet/ext/events/qlscrobbler.py
@@ -87,7 +87,7 @@ class QLSubmitQueue:
     CLIENT = "qlb"
     CLIENT_VERSION = const.VERSION
     PROTOCOL_VERSION = "1.2"
-    SCROBBLER_CACHE_FILE = os.path.join(quodlibet.get_user_dir(), "scrobbler_cache_v2")
+    SCROBBLER_CACHE_FILE = os.path.join(quodlibet.get_cache_dir(), "scrobbler_cache_v2")
 
     # These objects are shared across instances, to allow other plugins to
     # queue scrobbles in future versions of QL

--- a/quodlibet/ext/events/synchronize_to_device.py
+++ b/quodlibet/ext/events/synchronize_to_device.py
@@ -18,7 +18,7 @@ from senf import fsn2text
 from quodlibet import _
 from quodlibet import app
 from quodlibet import config
-from quodlibet import get_user_dir
+from quodlibet import get_data_dir
 from quodlibet import ngettext
 from quodlibet import qltk
 from quodlibet import util
@@ -93,8 +93,8 @@ class SyncToDevice(EventPlugin, PluginConfigMixin):
     CONFIG_PATH_KEY = '{}_{}'.format(PLUGIN_CONFIG_SECTION, 'path')
     CONFIG_PATTERN_KEY = '{}_{}'.format(PLUGIN_CONFIG_SECTION, 'pattern')
 
-    path_query = os.path.join(get_user_dir(), 'lists', 'queries.saved')
-    path_pattern = os.path.join(get_user_dir(), 'lists', 'renamepatterns')
+    path_query = os.path.join(get_data_dir(), 'lists', 'queries.saved')
+    path_pattern = os.path.join(get_data_dir(), 'lists', 'renamepatterns')
 
     spacing_main = 20
     spacing_large = 6

--- a/quodlibet/ext/events/write_cover.py
+++ b/quodlibet/ext/events/write_cover.py
@@ -20,8 +20,7 @@ from quodlibet.qltk import Icons
 
 
 def get_path():
-    # TODO: get XDG_RUNTIME_DIR
-    default = os.path.join(quodlibet.get_config_dir(), "current.cover")
+    default = os.path.join(quodlibet.get_runtime_dir(), "current.cover")
     return config.get("plugins", __name__, default=default)
 
 

--- a/quodlibet/ext/events/write_cover.py
+++ b/quodlibet/ext/events/write_cover.py
@@ -21,7 +21,7 @@ from quodlibet.qltk import Icons
 
 def get_path():
     # TODO: get XDG_RUNTIME_DIR
-    default = os.path.join(quodlibet.get_user_dir(), "current.cover")
+    default = os.path.join(quodlibet.get_config_dir(), "current.cover")
     return config.get("plugins", __name__, default=default)
 
 

--- a/quodlibet/ext/events/write_cover.py
+++ b/quodlibet/ext/events/write_cover.py
@@ -20,6 +20,7 @@ from quodlibet.qltk import Icons
 
 
 def get_path():
+    # TODO: get XDG_RUNTIME_DIR
     default = os.path.join(quodlibet.get_user_dir(), "current.cover")
     return config.get("plugins", __name__, default=default)
 

--- a/quodlibet/ext/query/savedsearch.py
+++ b/quodlibet/ext/query/savedsearch.py
@@ -12,7 +12,7 @@ from quodlibet import _, print_w
 from quodlibet.plugins.query import QueryPlugin, QueryPluginError, markup_for_syntax
 from quodlibet.query import Query
 from quodlibet.query._match import Error as QueryError
-from quodlibet import get_user_dir
+from quodlibet import get_data_dir
 
 
 class IncludeSavedSearchQuery(QueryPlugin):
@@ -35,7 +35,7 @@ class IncludeSavedSearchQuery(QueryPlugin):
         if query_path_:
             query_path = query_path_
         else:
-            query_path = os.path.join(get_user_dir(), 'lists', 'queries.saved')
+            query_path = os.path.join(get_data_dir(), 'lists', 'queries.saved')
         try:
             with open(query_path, 'r', encoding="utf-8") as query_file:
                 for query_string in query_file:

--- a/quodlibet/ext/songsmenu/custom_commands.py
+++ b/quodlibet/ext/songsmenu/custom_commands.py
@@ -188,7 +188,7 @@ class CustomCommands(PlaylistPlugin, SongsMenuPlugin, PluginConfigMixin):
     ]
 
     COMS_FILE = os.path.join(
-        quodlibet.get_user_dir(), 'lists', 'customcommands.json')
+        quodlibet.get_data_dir(), 'lists', 'customcommands.json')
 
     _commands = None
     """Commands known to the class"""

--- a/quodlibet/ext/songsmenu/lastfmsync.py
+++ b/quodlibet/ext/songsmenu/lastfmsync.py
@@ -233,7 +233,7 @@ class LastFMSync(SongsMenuPlugin):
                     "Last.fm profile.")
     PLUGIN_ICON = Icons.EMBLEM_SHARED
 
-    CACHE_PATH = os.path.join(quodlibet.get_user_dir(), "lastfmsync.db")
+    CACHE_PATH = os.path.join(quodlibet.get_cache_dir(), "lastfmsync.db")
 
     def runner(self, cache):
         changed = True

--- a/quodlibet/ext/songsmenu/website_search.py
+++ b/quodlibet/ext/songsmenu/website_search.py
@@ -57,7 +57,7 @@ class WebsiteSearch(SongsMenuPlugin):
         ("Go to ~website", "<website>"),
     ]
     PATTERNS_FILE = os.path.join(
-        quodlibet.get_user_dir(), 'lists', 'searchsites')
+        quodlibet.get_data_dir(), 'lists', 'searchsites')
 
     _no_launch = False
 

--- a/quodlibet/library/playlist.py
+++ b/quodlibet/library/playlist.py
@@ -15,7 +15,7 @@ from quodlibet.util.collection import (Playlist, XSPFBackedPlaylist,
                                        FileBackedPlaylist)
 from senf import text2fsn, _fsnative, fsn2text
 
-_DEFAULT_PLAYLIST_DIR = text2fsn(os.path.join(quodlibet.get_user_dir(), "playlists"))
+_DEFAULT_PLAYLIST_DIR = text2fsn(os.path.join(quodlibet.get_data_dir(), "playlists"))
 """Directory for playlist files"""
 
 HIDDEN_RE = re.compile(r'^\.\w[^.]*')

--- a/quodlibet/main.py
+++ b/quodlibet/main.py
@@ -21,7 +21,7 @@ def main(argv=None):
 
     import quodlibet
 
-    config_file = os.path.join(quodlibet.get_user_dir(), "config")
+    config_file = os.path.join(quodlibet.get_config_dir(), "config")
     quodlibet.init_cli(config_file=config_file)
 
     try:
@@ -159,7 +159,7 @@ def main(argv=None):
     mmkeys_handler.start()
 
     # TODO: get XDG_RUNTIME_DIR
-    current_path = os.path.join(quodlibet.get_user_dir(), "current")
+    current_path = os.path.join(quodlibet.get_config_dir(), "current")
     fsiface = FSInterface(current_path, player, library)
     remote = Remote(app, cmd_registry)
     try:

--- a/quodlibet/main.py
+++ b/quodlibet/main.py
@@ -158,8 +158,7 @@ def main(argv=None):
     mmkeys_handler = MMKeysHandler(app)
     mmkeys_handler.start()
 
-    # TODO: get XDG_RUNTIME_DIR
-    current_path = os.path.join(quodlibet.get_config_dir(), "current")
+    current_path = os.path.join(quodlibet.get_runtime_dir(), "current")
     fsiface = FSInterface(current_path, player, library)
     remote = Remote(app, cmd_registry)
     try:

--- a/quodlibet/main.py
+++ b/quodlibet/main.py
@@ -50,7 +50,7 @@ def main(argv=None):
     app.process_name = "quodlibet"
     quodlibet.set_application_info(app)
 
-    library_path = os.path.join(quodlibet.get_user_dir(), "songs")
+    library_path = os.path.join(quodlibet.get_data_dir(), "songs")
 
     print_d("Initializing main library (%s)" % (
             quodlibet.util.path.unexpand(library_path)))
@@ -158,6 +158,7 @@ def main(argv=None):
     mmkeys_handler = MMKeysHandler(app)
     mmkeys_handler.start()
 
+    # TODO: get XDG_RUNTIME_DIR
     current_path = os.path.join(quodlibet.get_user_dir(), "current")
     fsiface = FSInterface(current_path, player, library)
     remote = Remote(app, cmd_registry)

--- a/quodlibet/main.py
+++ b/quodlibet/main.py
@@ -11,6 +11,7 @@ import sys
 import os
 
 from quodlibet import _
+from quodlibet import config
 from quodlibet.cli import process_arguments, exit_
 from quodlibet.util.dprint import print_d, print_, print_exc
 
@@ -21,6 +22,7 @@ def main(argv=None):
 
     import quodlibet
 
+    config.migrate_legacy_data(move=False)  # TODO: When tested, `move=True`?
     config_file = os.path.join(quodlibet.get_config_dir(), "config")
     quodlibet.init_cli(config_file=config_file)
 
@@ -40,7 +42,6 @@ def main(argv=None):
 
     import quodlibet.player
     import quodlibet.library
-    from quodlibet import config
     from quodlibet import browsers
     from quodlibet import util
 

--- a/quodlibet/plugins/listenbrainz/__init__.py
+++ b/quodlibet/plugins/listenbrainz/__init__.py
@@ -87,7 +87,7 @@ class ListenBrainzSubmitQueue():
     plugin being enabled; other plugins may use submit() to queue songs for
     submission.
     """
-    DUMP = os.path.join(quodlibet.get_user_dir(), "listenbrainz_cache")
+    DUMP = os.path.join(quodlibet.get_cache_dir(), "listenbrainz_cache")
 
     # These objects are shared across instances, to allow other plugins to
     # queue listens in future versions of QL.

--- a/quodlibet/qltk/queue.py
+++ b/quodlibet/qltk/queue.py
@@ -36,7 +36,8 @@ from quodlibet.qltk.x import ScrolledWindow, SymbolicIconImage, \
     SmallImageButton, SmallImageToggleButton, MenuItem, RadioMenuItem
 from quodlibet.qltk.songlistcolumns import CurrentColumn
 
-QUEUE = os.path.join(quodlibet.get_user_dir(), "queue")
+# TODO: get XDG_RUNTIME_DIR
+QUEUE = os.path.join(quodlibet.get_data_dir(), "queue")
 
 
 class PlaybackStatusIcon(Gtk.Box):

--- a/quodlibet/qltk/queue.py
+++ b/quodlibet/qltk/queue.py
@@ -36,8 +36,7 @@ from quodlibet.qltk.x import ScrolledWindow, SymbolicIconImage, \
     SmallImageButton, SmallImageToggleButton, MenuItem, RadioMenuItem
 from quodlibet.qltk.songlistcolumns import CurrentColumn
 
-# TODO: get XDG_RUNTIME_DIR
-QUEUE = os.path.join(quodlibet.get_data_dir(), "queue")
+QUEUE = os.path.join(quodlibet.get_runtime_dir(), "queue")
 
 
 class PlaybackStatusIcon(Gtk.Box):

--- a/quodlibet/qltk/quodlibetwindow.py
+++ b/quodlibet/qltk/quodlibetwindow.py
@@ -280,7 +280,6 @@ class TopBar(Gtk.Toolbar):
         self._pattern_box = Gtk.VBox(spacing=3)
 
         # song text
-        # FIXME: this `songinfo` file is not used anywhere?
         info_pattern_path = os.path.join(quodlibet.get_data_dir(), "songinfo")
         text = SongInfo(library.librarian, player, info_pattern_path)
         self._pattern_box.pack_start(text, True, True, 0)

--- a/quodlibet/qltk/quodlibetwindow.py
+++ b/quodlibet/qltk/quodlibetwindow.py
@@ -579,7 +579,7 @@ class QuodLibetWindow(Window, PersistentWindowMixin, AppWindow):
         accel_group.connect(keyval, mod, 0, scroll_and_jump)
 
         # custom accel map
-        accel_fn = os.path.join(quodlibet.get_user_dir(), "accels")
+        accel_fn = os.path.join(quodlibet.get_config_dir(), "accels")
         Gtk.AccelMap.load(accel_fn)
         # save right away so we fill the file with example comments of all
         # accels

--- a/quodlibet/qltk/quodlibetwindow.py
+++ b/quodlibet/qltk/quodlibetwindow.py
@@ -280,7 +280,8 @@ class TopBar(Gtk.Toolbar):
         self._pattern_box = Gtk.VBox(spacing=3)
 
         # song text
-        info_pattern_path = os.path.join(quodlibet.get_user_dir(), "songinfo")
+        # FIXME: this `songinfo` file is not used anywhere?
+        info_pattern_path = os.path.join(quodlibet.get_data_dir(), "songinfo")
         text = SongInfo(library.librarian, player, info_pattern_path)
         self._pattern_box.pack_start(text, True, True, 0)
         box.pack_start(self._pattern_box, True, True, 0)

--- a/quodlibet/qltk/renamefiles.py
+++ b/quodlibet/qltk/renamefiles.py
@@ -36,7 +36,7 @@ from quodlibet.util import connect_obj
 from quodlibet.util.path import strip_win32_incompat_from_path
 from quodlibet.util.dprint import print_d, print_e
 
-NBP = os.path.join(quodlibet.get_user_dir(), "lists", "renamepatterns")
+NBP = os.path.join(quodlibet.get_data_dir(), "lists", "renamepatterns")
 NBP_EXAMPLES = """\
 <tracknumber>. <title>
 <tracknumber|<tracknumber>. ><title>

--- a/quodlibet/qltk/searchbar.py
+++ b/quodlibet/qltk/searchbar.py
@@ -50,7 +50,7 @@ class SearchBarBox(Gtk.Box):
 
         if filename is None:
             filename = os.path.join(
-                quodlibet.get_user_dir(), "lists", "queries")
+                quodlibet.get_data_dir(), "lists", "queries")
 
         historic_entries_count = config.getint("browsers", "searchbar_historic_entries")
 
@@ -281,7 +281,7 @@ class MultiSearchBarBox(LimitSearchBarBox):
         super().__init__(*args, **kwargs)
 
         self.multi_filename = os.path.join(
-            quodlibet.get_user_dir(), "lists", "multiqueries"
+            quodlibet.get_data_dir(), "lists", "multiqueries"
         ) if multi_filename is None else multi_filename
 
         self._old_placeholder = self._entry.get_placeholder_text()

--- a/quodlibet/qltk/tagsfrompath.py
+++ b/quodlibet/qltk/tagsfrompath.py
@@ -34,7 +34,7 @@ from quodlibet.util import connect_obj
 from quodlibet.plugins.editing import TagsFromPathPlugin
 
 
-TBP = os.path.join(quodlibet.get_user_dir(), "lists", "tagpatterns")
+TBP = os.path.join(quodlibet.get_data_dir(), "lists", "tagpatterns")
 TBP_EXAMPLES = """\
 <tracknumber>. <title>
 <tracknumber> - <title>

--- a/quodlibet/remote.py
+++ b/quodlibet/remote.py
@@ -12,7 +12,7 @@ from typing import Type
 from senf import path2fsn, fsn2bytes, bytes2fsn, fsnative
 
 from quodlibet.util import fifo, print_w
-from quodlibet import get_user_dir
+from quodlibet import get_config_dir
 try:
     from quodlibet.util import winpipe
 except ImportError:
@@ -115,7 +115,7 @@ class QuodLibetUnixRemote(RemoteBase):
 
     _FIFO_NAME = "control"
     # TODO: get XDG_RUNTIME_DIR
-    _PATH = os.path.join(get_user_dir(), _FIFO_NAME)
+    _PATH = os.path.join(get_config_dir(), _FIFO_NAME)
 
     def __init__(self, app, cmd_registry):
         self._app = app

--- a/quodlibet/remote.py
+++ b/quodlibet/remote.py
@@ -12,7 +12,7 @@ from typing import Type
 from senf import path2fsn, fsn2bytes, bytes2fsn, fsnative
 
 from quodlibet.util import fifo, print_w
-from quodlibet import get_config_dir
+from quodlibet import get_runtime_dir
 try:
     from quodlibet.util import winpipe
 except ImportError:
@@ -114,8 +114,7 @@ class QuodLibetWinRemote(RemoteBase):
 class QuodLibetUnixRemote(RemoteBase):
 
     _FIFO_NAME = "control"
-    # TODO: get XDG_RUNTIME_DIR
-    _PATH = os.path.join(get_config_dir(), _FIFO_NAME)
+    _PATH = os.path.join(get_runtime_dir(), _FIFO_NAME)
 
     def __init__(self, app, cmd_registry):
         self._app = app

--- a/quodlibet/remote.py
+++ b/quodlibet/remote.py
@@ -114,6 +114,7 @@ class QuodLibetWinRemote(RemoteBase):
 class QuodLibetUnixRemote(RemoteBase):
 
     _FIFO_NAME = "control"
+    # TODO: get XDG_RUNTIME_DIR
     _PATH = os.path.join(get_user_dir(), _FIFO_NAME)
 
     def __init__(self, app, cmd_registry):

--- a/quodlibet/util/path.py
+++ b/quodlibet/util/path.py
@@ -25,7 +25,6 @@ from . import windows
 from . import print_w
 from .environment import is_windows
 from .misc import NamedTemporaryFile
-from .util import print_w
 
 if sys.platform == "darwin":
     from Foundation import NSString
@@ -275,7 +274,7 @@ def xdg_get_config_home():
 def xdg_get_runtime_dir():
     if os.name == "nt":
         from gi.repository import GLib
-        return glib2fsn(GLib.get_user_runtime_dir())
+        return GLib.get_user_runtime_dir()
 
     data_home = os.getenv("XDG_RUNTIME_DIR")
     if data_home:

--- a/quodlibet/util/path.py
+++ b/quodlibet/util/path.py
@@ -22,6 +22,7 @@ from senf import (fsnative, bytes2fsn, fsn2bytes,
                   fsn2text, path2fsn, uri2fsn, _fsnative)
 
 from . import windows
+from . import print_w
 from .environment import is_windows
 from .misc import NamedTemporaryFile
 from .util import print_w

--- a/quodlibet/util/path.py
+++ b/quodlibet/util/path.py
@@ -270,6 +270,21 @@ def xdg_get_config_home():
         return os.path.join(os.path.expanduser("~"), ".config")
 
 
+def xdg_get_runtime_dir():
+    if os.name == "nt":
+        from gi.repository import GLib
+        return glib2fsn(GLib.get_user_runtime_dir())
+
+    data_home = os.getenv("XDG_RUNTIME_DIR")
+    if data_home:
+        return os.path.abspath(data_home)
+    else:
+        # > fall back to a replacement directory with similar capabilities and
+        # > print a warning message
+        # TODO: print a warning message?
+        return xdg_get_cache_home()
+
+
 def parse_xdg_user_dirs(data):
     """Parses xdg-user-dirs and returns a dict of keys and paths.
 

--- a/quodlibet/util/path.py
+++ b/quodlibet/util/path.py
@@ -24,6 +24,7 @@ from senf import (fsnative, bytes2fsn, fsn2bytes,
 from . import windows
 from .environment import is_windows
 from .misc import NamedTemporaryFile
+from .util import print_w
 
 if sys.platform == "darwin":
     from Foundation import NSString
@@ -281,7 +282,7 @@ def xdg_get_runtime_dir():
     else:
         # > fall back to a replacement directory with similar capabilities and
         # > print a warning message
-        # TODO: print a warning message?
+        print_w('Using the cache as runtime directory')
         return xdg_get_cache_home()
 
 

--- a/tests/plugin/test_synchronize_to_device.py
+++ b/tests/plugin/test_synchronize_to_device.py
@@ -15,7 +15,7 @@ from gi.repository import Gtk
 from quodlibet import app
 from quodlibet import config
 from quodlibet import library
-from quodlibet import get_user_dir
+from quodlibet import get_cache_dir
 from quodlibet.formats import AudioFile
 from quodlibet.plugins import PM
 from quodlibet.qltk.ccb import ConfigCheckButton
@@ -97,7 +97,7 @@ class TSyncToDevice(PluginTestCase):
         with open(self.plugin.path_pattern, 'w') as f:
             f.write(self.RENAMEPATTERNS)
 
-        path_dest = Path(get_user_dir(), 'export')
+        path_dest = Path(get_cache_dir(), 'export')
         path_dest.mkdir(parents=True, exist_ok=True)
         self.path_dest = str(path_dest)
 

--- a/tests/test___init__.py
+++ b/tests/test___init__.py
@@ -33,7 +33,7 @@ class TQuodlibet(TestCase):
     def test_dirs(self):
         self.assertTrue(isinstance(quodlibet.get_base_dir(), fsnative))
         self.assertTrue(isinstance(quodlibet.get_image_dir(), fsnative))
-        self.assertTrue(isinstance(quodlibet.get_user_dir(), fsnative))
+        self.assertTrue(isinstance(quodlibet.get_config_dir(), fsnative))
         self.assertTrue(isinstance(quodlibet.get_cache_dir(), fsnative))
         self.assertTrue(isinstance(quodlibet.get_data_dir(), fsnative))
 

--- a/tests/test___init__.py
+++ b/tests/test___init__.py
@@ -35,6 +35,7 @@ class TQuodlibet(TestCase):
         self.assertTrue(isinstance(quodlibet.get_image_dir(), fsnative))
         self.assertTrue(isinstance(quodlibet.get_user_dir(), fsnative))
         self.assertTrue(isinstance(quodlibet.get_cache_dir(), fsnative))
+        self.assertTrue(isinstance(quodlibet.get_data_dir(), fsnative))
 
     def test_get_build_description(self):
         quodlibet.get_build_description()


### PR DESCRIPTION
This is a rebased version of work originally done by @somini. It works for me (caveat to be discussed in comments).

I'm submitting this as a draft PR for discussion and suggestions, before I go too much farther with fixing the remaining issues. It is intended to replace #3275.

TODO:

 * triple-check that the file migration code works correctly
 * album_pattern should be in config dir, not data dir
 * playlist_pattern should be in config dir, not data dir
 * after testing, data migration should only be an "info" level debug item
 * appinfo plugin: check appropriate CAN_ENABLE value
 * regenerate any needed translation items
 * fix documentation mentions of config location (and internal doc strings / comments)
 * where do saved queries belong? what about "renamepatterns", "searchsites"?
 * flip the switch to `migrate_legacy_data`


Fixes #2202.

Check-list
----------

 * [x] There is a linked issue discussing the motivations for this feature or bugfix
 * [x] Unit tests have been added where possible
 * [ ] I've added / updated documentation for any user-facing features.
 * [x] Performance seems to be comparable or better than current `master`