### PR TITLE
Stop query date regex from matching > 4 digit year

### DIFF
--- a/quodlibet/query/_parser.py
+++ b/quodlibet/query/_parser.py
@@ -27,7 +27,7 @@ SINGLE_STRING = re.compile(r"([^'\\]|\\.)*")
 DOUBLE_STRING = re.compile(r'([^"\\]|\\.)*')
 MODIFIERS = re.compile(r'[cisld]*')
 TEXT = re.compile(r'[^,)]+')
-DATE = re.compile(r'\d{4}(-\d{1,2}(-\d{1,2})?)?')
+DATE = re.compile(r'\d{4}(?!\d)(-\d{1,2}(-\d{1,2})?)?')
 
 
 class QueryParser:

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -194,7 +194,7 @@ class TQuery(TestCase):
              "version": u"cake mix",
              "~filename": fsnative(u"/dir1/foobar.ogg"),
              "~#length": 224, "~#skipcount": 13, "~#playcount": 24,
-             "date": u"2007-05-24"})
+             "date": u"2007-05-24", "~#samplerate": 44100})
         self.s2 = AudioFile(
             {"album": u"Foo the Bar", "artist": u"mu", "title": u"Rockin' Out",
              "~filename": fsnative(u"/dir2/something.mp3"),
@@ -521,6 +521,10 @@ class TQuery(TestCase):
         assert Query("#(date > 4)").search(self.s1)
         assert Query("#(date > 0004)").search(self.s1)
         assert Query("#(date > 0000)").search(self.s1)
+
+    def test_large_numbers(self):
+        assert Query("#(playcount = 00024)").search(self.s1)
+        assert Query("#(samplerate = 44100)").search(self.s1)
 
     def test_ignore_characters(self):
         try:


### PR DESCRIPTION
Some queries are ambiguous between dates and numbers, e.g. "2002" could be a year or a number. In order to simplify quering parsing, Quod Libet stores these ambiguous subqueries as the "NumexprNumberOrDate" type.

When parsing a query, Quod Libet will use this type if the string matches a regex for parsing dates. However, before this commit, the regex will match the first four digits of any four or more digit number. This results in a parsing error for large numbers because of the remaining digits after the four that get matched and parsed.

Instead, use a negative lookahead to limit the year part of the date to four digits. Quod Libet will fall back to using an unambiguous number representation for large numbers.

As an alternative, I tried to allow >4 digit years for future-proofing, but a 4 digit year assumption is baked in too deeply, e.g. in Python's `strptime` function.

Fixes #4161.

Check-list
----------

 * [x] There is a linked issue discussing the motivations for this feature or bugfix
 * [x] Unit tests have been added where possible
 * [x] I've added / updated documentation for any user-facing features.
 * [x] Performance seems to be comparable or better than current `master`