### PR TITLE
Don't insert blank tag when doing column sort magic

### DIFF
--- a/quodlibet/qltk/songlist.py
+++ b/quodlibet/qltk/songlist.py
@@ -163,7 +163,7 @@ def get_sort_tag(tag):
 
     if "<" in tag:
         for key, value in replace_order.items():
-            if value != "":
+            if value:
                 value = "<%s>" % value
             tag = tag.replace("<%s>" % key, value)
         for key, value in TAG_TO_SORT.items():

--- a/quodlibet/qltk/songlist.py
+++ b/quodlibet/qltk/songlist.py
@@ -151,6 +151,8 @@ def get_sort_tag(tag):
     replace_order = {
         "~#track": "",
         "~#disc": "",
+        "~#tracks": "",
+        "~#discs": "",
         "~length": "~#length"
     }
 
@@ -161,7 +163,9 @@ def get_sort_tag(tag):
 
     if "<" in tag:
         for key, value in replace_order.items():
-            tag = tag.replace("<%s>" % key, "<%s>" % value)
+            if value != "":
+                value = "<%s>" % value
+            tag = tag.replace("<%s>" % key, value)
         for key, value in TAG_TO_SORT.items():
             tag = tag.replace("<%s>" % key,
                               "<{1}|<{1}>|<{0}>>".format(key, value))

--- a/quodlibet/qltk/songlist.py
+++ b/quodlibet/qltk/songlist.py
@@ -165,7 +165,7 @@ def get_sort_tag(tag):
         for key, value in replace_order.items():
             if value:
                 value = f"<{value}>"
-            tag = tag.replace("<%s>" % key, value)
+            tag = tag.replace(f"<{key}>", value)
         for key, value in TAG_TO_SORT.items():
             tag = tag.replace("<%s>" % key,
                               "<{1}|<{1}>|<{0}>>".format(key, value))

--- a/quodlibet/qltk/songlist.py
+++ b/quodlibet/qltk/songlist.py
@@ -164,7 +164,7 @@ def get_sort_tag(tag):
     if "<" in tag:
         for key, value in replace_order.items():
             if value:
-                value = "<%s>" % value
+                value = f"<{value}>"
             tag = tag.replace("<%s>" % key, value)
         for key, value in TAG_TO_SORT.items():
             tag = tag.replace("<%s>" % key,


### PR DESCRIPTION
If a user has a column with a tag pattern, and tries to sort by this column, Quod Libet will try to make sorting work intuitively by mangling the pattern and removing or replacing tags.

For example, `~#track` tags in patterns will be removed, on the assumption that the user will prefer the default ordering, which already looks at track numbers.

This commit fixes an issue where this is done incorrectly, and a tag like `<~#track>` is replaced with an empty tag `<>`, producing an exception when sorting by the column.

It also adds several missing tags so that magic sorting will also work for them.

Fixes #4164.

Check-list
----------

 * [x] There is a linked issue discussing the motivations for this feature or bugfix
 * [ ] Unit tests have been added where possible