### PR TITLE
Don't make the WaitLoadWindow modal

### DIFF
--- a/quodlibet/qltk/wlw.py
+++ b/quodlibet/qltk/wlw.py
@@ -143,7 +143,8 @@ class WaitLoadWindow(WaitLoadBase, Gtk.Window):
             window = parent.get_window()
             if window:
                 window.set_cursor(Gdk.Cursor.new(Gdk.CursorType.WATCH))
-        self.set_modal(True)
+        # Note that this should not be modal as popups occuring during
+        # progress will not be clickable
         self.add(Gtk.Frame())
         self.get_child().set_shadow_type(Gtk.ShadowType.OUT)
         vbox = Gtk.VBox(spacing=12)


### PR DESCRIPTION
If a callback pops up another window (eg confirming a save operation) then that popup blocks the progress until it is clicked. If the WLW has the focus then the popup cannot be clicked and deadlock results. Add a comment to explain.
Fixes #1736

Check-list
----------

 * [x] There is a linked issue discussing the motivations for this feature or bugfix
 * [ ] Unit tests have been added where possible
 * [ ] I've added / updated documentation for any user-facing features.
 * [ ] Performance seems to be comparable or better than current `master`


What this change is adding / fixing


