### PR TITLE
Make --rating-up work when song has no previous rating

### DIFF
--- a/quodlibet/commands.py
+++ b/quodlibet/commands.py
@@ -323,7 +323,7 @@ def _rating(app, value):
             change = (1 / RATINGS.number)
         if value[0] == '-':
             change = -change
-        rating = song["~#rating"] + change
+        rating = song("~#rating") + change
     else:
         try:
             rating = float(value)

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -87,9 +87,6 @@ class TCommands(TestCase):
         self.__send("random album")
         self.__send("refresh")
         self.__send("repeat 0")
-        self.__send("rating 0.5")
-        self.__send("rating +0.01")
-        self.__send("rating -10")
         self.__send("show-window")
         self.__send("song-list 1")
         self.__send("stop-after 1")
@@ -109,3 +106,15 @@ class TCommands(TestCase):
         self.__send("enqueue-files "
                     "one,two\\, please,slash\\\\.mp3,four")
         self.assertEquals(app.window.playlist.q.get(), songs)
+
+    def test_rating(self):
+        app.player.song = AudioFile(
+            {"album": "foo", "~filename": fsnative("/dev/null")})
+        self.__send("rating +")
+        self.assertAlmostEqual(app.player.song['~#rating'], 0.75)
+        self.__send("rating 0.4")
+        self.assertAlmostEqual(app.player.song['~#rating'], 0.4)
+        self.__send("rating +0.01")
+        self.assertAlmostEqual(app.player.song['~#rating'], 0.41)
+        self.__send("rating -10")
+        self.assertEquals(app.player.song['~#rating'], 0)


### PR DESCRIPTION
Now assume songs with no ratings have the default rating.  (Also fix other relative rating changes.)

Check-list
----------

 * [ ] There is a linked issue discussing the motivations for this feature or bugfix
 * [x] Unit tests have been added where possible
 * [x] I've added / updated documentation for any user-facing features.
 * [x] Performance seems to be comparable or better than current `master`


What this change is adding / fixing
-----------------------------------
<!-- A high-level description of the changes.
Hopefully the commits are atomic and well described, but this is the overall
summary of the change, to other developers / maintainers, plus any TODOs. -->

`QL --rating-up` fails to change the rating of a song if the song does not currently have a rating.  Unfortunately, I once again forgot to create a bug report first, but the fix is very straightforward.  Thanks.
