### PR TITLE
Allow songlist editing of simple text tags in-place 🆙

### DIFF
--- a/docs/guide/editing_tags.rst
+++ b/docs/guide/editing_tags.rst
@@ -16,6 +16,13 @@ path* tab to populate these tags automatically. Please see
 process for several songs (the process is the same).
 
 
+Editing tags in-place
+---------------------
+As of QL 4.6, for plain, textual tags (not internal, and not *tag expressions*)
+you can edit these in-place in the songlist, by navigating to the column within
+the song's row, and pressing F2. Changes are immediate.
+
+
 Editing tags for several songs at once
 --------------------------------------
 

--- a/quodlibet/qltk/songlist.py
+++ b/quodlibet/qltk/songlist.py
@@ -440,7 +440,7 @@ class SongList(AllTreeView, SongListDnDMixin, DragScroll, util.InstanceTracker):
         self.connect('destroy', self.__destroy)
 
     @property
-    def model(self):
+    def model(self) -> Gtk.TreeModel:
         return self.get_model()
 
     @property

--- a/quodlibet/qltk/songlistcolumns.py
+++ b/quodlibet/qltk/songlistcolumns.py
@@ -24,7 +24,7 @@ from quodlibet.formats._audio import FILESYSTEM_TAGS
 from quodlibet.qltk.x import CellRendererPixbuf
 
 
-def create_songlist_column(model, t):
+def create_songlist_column(model: Gtk.TreeModel, t):
     """Returns a SongListColumn instance for the given tag"""
 
     if t in ["~#added", "~#mtime", "~#lastplayed", "~#laststarted"]:

--- a/quodlibet/qltk/songlistcolumns.py
+++ b/quodlibet/qltk/songlistcolumns.py
@@ -286,7 +286,6 @@ class NonSynthTextColumn(WideTextColumn):
     can_edit = True
 
     def __row_edited(self, render, path, new: str, model: Gtk.TreeModel) -> None:
-        tree_path = Gtk.TreePath.new_from_string(path)
         print_d(f"Trying to edit {self.header_name} to {new!r}")
         model[path][0][self.header_name] = new
         model.path_changed(path)

--- a/tests/test_qltk_songlistcolumns.py
+++ b/tests/test_qltk_songlistcolumns.py
@@ -17,13 +17,20 @@ import quodlibet.config
 import datetime
 import time
 
+A_DATETIME = datetime.datetime(year=1999, month=5, day=1, hour=23, minute=11,
+                               second=59)
+
 
 class TSongListColumns(TestCase):
     def setUp(self):
         quodlibet.config.init()
+        self.model = object()
 
     def tearDown(self):
         quodlibet.config.quit()
+
+    def _create_col(self, t):
+        return create_songlist_column(self.model, t)
 
     def _render_column(self, column, **kwargs):
         view = Gtk.TreeView()
@@ -44,57 +51,57 @@ class TSongListColumns(TestCase):
         return text
 
     def test_date(self):
-        column = create_songlist_column("~#added")
+        column = self._create_col("~#added")
         self._render_column(column)
 
         # column reuse triggers warning somwhow
-        column = create_songlist_column("~#added")
+        column = self._create_col("~#added")
         self._render_column(column, **{"~#added": 100})
 
     def test_length(self):
-        column = create_songlist_column("~length")
+        column = self._create_col("~length")
         self._render_column(column)
 
     def test_filesize(self):
-        column = create_songlist_column("~#filesize")
+        column = self._create_col("~#filesize")
         self._render_column(column)
 
     def test_rating(self):
-        column = create_songlist_column("~rating")
+        column = self._create_col("~rating")
         text = self._render_column(column)
         self.assertNotEqual(text, "0.67")
 
-        column = create_songlist_column("~#rating")
+        column = self._create_col("~#rating")
         text = self._render_column(column)
         self.assertEqual(text, "0.67")
 
     def test_bitrate(self):
-        column = create_songlist_column("~#bitrate")
+        column = self._create_col("~#bitrate")
         self._render_column(column)
 
     def test_basename(self):
-        column = create_songlist_column("~basename")
+        column = self._create_col("~basename")
         self._render_column(column)
 
     def test_pattern(self):
-        column = create_songlist_column("<artist>-<album>")
+        column = self._create_col("<artist>-<album>")
         self._render_column(column)
 
     def test_artist(self):
-        column = create_songlist_column("artist")
+        column = self._create_col("artist")
         self._render_column(column)
 
     def test_people(self):
-        column = create_songlist_column("~people")
+        column = self._create_col("~people")
         self._render_column(column)
 
     def test_bpm(self):
-        column = create_songlist_column("bpm")
+        column = self._create_col("bpm")
         text = self._render_column(column, **{"bpm": "123"})
         self.assertEqual(text, "123")
 
     def test_initialkey(self):
-        column = create_songlist_column("initialkey")
+        column = self._create_col("initialkey")
         text = self._render_column(column, **{"initialkey": "F"})
         self.assertEqual(text, "F")
 
@@ -103,10 +110,8 @@ class TSongListColumns(TestCase):
         quodlibet.config.settext("settings", "datecolumn_timestamp_format",
                                  format)
 
-        d = datetime.datetime(year=1999, month=5, day=1,
-                              hour=23, minute=11, second=59)
-        stamp = int(time.mktime(d.timetuple()))
-        column = create_songlist_column("~#added")
+        stamp = int(time.mktime(A_DATETIME.timetuple()))
+        column = self._create_col("~#added")
         text = self._render_column(column, **{"~#added": stamp})
         self.assertEqual(text, "19990501 23:11:59 PLAINTEXT")
 
@@ -118,9 +123,7 @@ class TSongListColumns(TestCase):
 
         # make sure unset config option does not result in the
         # behaviour for testcase for set option above
-        d = datetime.datetime(year=1999, month=5, day=1,
-                              hour=23, minute=11, second=59)
-        stamp = int(time.mktime(d.timetuple()))
-        column = create_songlist_column("~#added")
+        stamp = int(time.mktime(A_DATETIME.timetuple()))
+        column = self._create_col("~#added")
         text = self._render_column(column, **{"~#added": stamp})
         self.assertNotEqual(text, "19990501 23:11:59 PLAINTEXT")


### PR DESCRIPTION
* F2 activates the column with focus
* Only works for text tags, and not tied tags, tag expressions, etc
* It's not perfect but seems to work well here.

Closes #2236 