### PR TITLE
Fix escaping issues & improve Pango markup helpers

### DIFF
--- a/quodlibet/browsers/albums/main.py
+++ b/quodlibet/browsers/albums/main.py
@@ -543,7 +543,7 @@ class AlbumList(Browser, util.InstanceTracker, VisibleUpdate,
             album = model.get_album(iter_)
 
             if album is None:
-                text = "<b>%s</b>\n" % _("All Albums")
+                text = util.bold(_("All Albums"))
                 text += numeric_phrase("%d album", "%d albums", len(model) - 1)
                 markup = text
             else:

--- a/quodlibet/browsers/collection/models.py
+++ b/quodlibet/browsers/collection/models.py
@@ -1,5 +1,5 @@
 # Copyright 2010, 2012-2014 Christoph Reiter
-#                      2020 Nick Boultbee
+#                   2020-22 Nick Boultbee
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -21,8 +21,8 @@ ALBUM_PATTERN = r"""
 ALBUM_PATTERN = ALBUM_PATTERN.lstrip()
 PAT = XMLFromPattern(ALBUM_PATTERN)
 
-UNKNOWN_PATTERN = "<b><i>%s</i></b>" % _("Unknown %s")
-MULTI_PATTERN = "<b><i>%s</i></b>" % _("Multiple %s Values")
+UNKNOWN_PATTERN = util.bold_italic(_("Unknown %s"))
+MULTI_PATTERN = util.bold_italic(_("Multiple %s Values"))
 COUNT_PATTERN = " <span size='small' color='#777'>(%s)</span>"
 
 

--- a/quodlibet/browsers/covergrid/models.py
+++ b/quodlibet/browsers/covergrid/models.py
@@ -1,4 +1,5 @@
 # Copyright 2022 Thomas Leberbauer
+#           2022 Nick Boultbee
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -74,7 +75,7 @@ class AlbumListCountItem(AlbumListItem):
 
     def format_label(self, pattern=None):
         n = self.__n_albums
-        title = '<b>%s</b>\n' % util.escape(_('All Albums'))
+        title = util.bold(_('All Albums'))
         self._label = title + numeric_phrase('%d album', '%d albums', n)
         self.notify('label')
 

--- a/quodlibet/browsers/covergrid/models.py
+++ b/quodlibet/browsers/covergrid/models.py
@@ -76,7 +76,8 @@ class AlbumListCountItem(AlbumListItem):
     def format_label(self, pattern=None):
         n = self.__n_albums
         title = util.bold(_('All Albums'))
-        self._label = title + numeric_phrase('%d album', '%d albums', n)
+        number_phrase = numeric_phrase('%d album', '%d albums', n)
+        self._label = f"{title}\n{number_phrase}"
         self.notify('label')
 
     @GObject.Property

--- a/quodlibet/browsers/paned/models.py
+++ b/quodlibet/browsers/paned/models.py
@@ -85,7 +85,7 @@ class UnknownEntry(SongsEntry):
         super().__init__("", tuple(), songs)
 
     def get_text(self, config):
-        return True, "<b>%s</b>" % _("Unknown")
+        return True, util.bold(_("Unknown"))
 
     def contains_text(self, text):
         return False
@@ -103,7 +103,7 @@ class AllEntry(BaseEntry):
         return u""
 
     def get_text(self, config):
-        return True, "<b>%s</b>" % _("All")
+        return True, util.bold(_("All"))
 
     def contains_text(self, text):
         return False

--- a/quodlibet/browsers/paned/prefs.py
+++ b/quodlibet/browsers/paned/prefs.py
@@ -19,7 +19,7 @@ from quodlibet.qltk.x import SymbolicIconImage, MenuItem, Button
 from quodlibet.qltk import Icons
 from quodlibet.qltk.menubutton import MenuButton
 from quodlibet.qltk.ccb import ConfigCheckButton
-from quodlibet.util import connect_obj, escape
+from quodlibet.util import connect_obj
 from .util import get_headers, save_headers
 
 
@@ -106,9 +106,8 @@ class PatternEditor(Gtk.VBox):
 
         self.pack_start(radio_box, False, True, 0)
 
-        tooltip = _("Tag pattern with optional markup "
-                    "e.g. <tt>composer</tt> or\n<tt>%s</tt>"
-                    % escape(self._COMPLEX_PATTERN_EXAMPLE))
+        tooltip = _("Tag pattern with optional markup e.g. <tt>composer</tt> or\n%s"
+                    % util.monospace(self._COMPLEX_PATTERN_EXAMPLE))
         cb = TagsComboBoxEntry(self.COMPLETION, tooltip_markup=tooltip)
 
         view = BaseView(model=model)

--- a/quodlibet/browsers/podcasts.py
+++ b/quodlibet/browsers/podcasts.py
@@ -325,7 +325,7 @@ class Podcasts(Browser):
     @staticmethod
     def cell_data(col, render, model, iter, data):
         if model[iter][0].changed:
-            render.markup = "<b>%s</b>" % util.escape(model[iter][0].name)
+            render.markup = util.bold(model[iter][0].name)
         else:
             render.markup = util.escape(model[iter][0].name)
         render.set_property('markup', render.markup)

--- a/quodlibet/ext/events/jep118.py
+++ b/quodlibet/ext/events/jep118.py
@@ -28,8 +28,8 @@ format = """\
 class JEP118(EventPlugin):
     PLUGIN_ID = "JEP-118"
     PLUGIN_NAME = _("JEP-118")
-    PLUGIN_DESC_MARKUP = _("Outputs a Jabber User Tunes file to "
-                           "<tt>~/.quodlibet/jabber</tt>.")
+    PLUGIN_DESC_MARKUP = _("Outputs a Jabber User Tunes file to %(path)s." %
+                           {"path": util.monospace("~/.quodlibet/jabber")})
     PLUGIN_ICON = Icons.DOCUMENT_SAVE
 
     def plugin_on_song_started(self, song):

--- a/quodlibet/ext/events/mqtt.py
+++ b/quodlibet/ext/events/mqtt.py
@@ -1,4 +1,4 @@
-# Copyright 2016 - 2020 Nick Boultbee
+# Copyright 2016 - 2022 Nick Boultbee
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@ if os.name == "nt" or sys.platform == "darwin":
 
 from quodlibet import _
 from quodlibet.formats import AudioFile
-from quodlibet.util import monospace, escape
+from quodlibet.util import monospace
 from quodlibet.util.tags import _TAGS
 
 _TOTAL_MQTT_ITEMS = 5
@@ -54,7 +54,7 @@ class Config:
 
 
 _ACCEPTS_PATTERNS = (_("Accepts QL Patterns e.g. %s") %
-                     monospace(escape('<~artist~title>')))
+                     monospace('<~artist~title>'))
 
 
 class MqttPublisherPlugin(EventPlugin, PluginConfigMixin):

--- a/quodlibet/ext/events/randomalbum.py
+++ b/quodlibet/ext/events/randomalbum.py
@@ -99,7 +99,7 @@ class RandomAlbum(EventPlugin):
         less_lbl = Gtk.Label()
         arr = Gtk.Arrow(arrow_type=Gtk.ArrowType.LEFT,
                         shadow_type=Gtk.ShadowType.OUT)
-        less_lbl.set_markup("<i>%s</i>" % util.escape(_("avoid")))
+        less_lbl.set_markup(util.italic(_("avoid")))
         less_lbl.set_alignment(0, 0)
         hb = Gtk.HBox(spacing=0)
         hb.pack_start(arr, False, True, 0)
@@ -110,7 +110,7 @@ class RandomAlbum(EventPlugin):
         more_lbl = Gtk.Label()
         arr = Gtk.Arrow(arrow_type=Gtk.ArrowType.RIGHT,
                         shadow_type=Gtk.ShadowType.OUT)
-        more_lbl.set_markup("<i>%s</i>" % util.escape(_("prefer")))
+        more_lbl.set_markup(util.italic(_("prefer")))
         more_lbl.set_alignment(1, 0)
         hb = Gtk.HBox(spacing=0)
         hb.pack_end(arr, False, True, 0)

--- a/quodlibet/ext/events/randomalbum.py
+++ b/quodlibet/ext/events/randomalbum.py
@@ -213,8 +213,7 @@ class RandomAlbum(EventPlugin):
             srcid = GLib.timeout_add(1000 * self.delay,
                                      self.change_album, album)
             task = notif.Task(_("Random Album"),
-                              _("Waiting to start %s") %
-                                    util.bold(util.escape(album("album"))),
+                              _("Waiting to start %s") % util.bold(album("album")),
                               stop=lambda: GLib.source_remove(srcid))
 
             def countdown():

--- a/quodlibet/ext/events/synchronize_to_device.py
+++ b/quodlibet/ext/events/synchronize_to_device.py
@@ -849,10 +849,10 @@ class SyncToDevice(EventPlugin, PluginConfigMixin):
         except ValueError:
             self._show_sync_error(
                 _('Export path is not absolute'),
-                _('The pattern\n\n<b>{}</b>\n\ncontains "/" but does not start '
+                _('The pattern\n\n{}\n\ncontains "/" but does not start '
                   'from root. Please provide an absolute destination path by '
                   'making sure it starts with / or ~/.')
-                .format(util.escape(full_export_path)))
+                .format(util.bold(full_export_path)))
             return None, None
 
         return destination_path, pattern

--- a/quodlibet/ext/events/synchronizedlyrics.py
+++ b/quodlibet/ext/events/synchronizedlyrics.py
@@ -1,6 +1,6 @@
 # Synchronized Lyrics: a Quod Libet plugin for showing synchronized lyrics.
 # Copyright (C) 2015 elfalem
-#            2016-20 Nick Boultbee
+#            2016-22 Nick Boultbee
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@ from typing import List, Tuple, Optional
 
 from gi.repository import Gtk, Gdk, GLib
 
-from quodlibet import _
+from quodlibet import _, util
 from quodlibet import app
 from quodlibet import qltk
 from quodlibet.formats import AudioFile
@@ -62,7 +62,7 @@ class SynchronizedLyrics(EventPlugin, PluginConfigMixin):
         t.set_row_spacings(3)
 
         clr_section = Gtk.Label()
-        clr_section.set_markup("<b>" + _("Colors") + "</b>")
+        clr_section.set_markup(util.bold(_("Colors")))
         t.attach(clr_section, 0, 2, 0, 1)
 
         l = Gtk.Label(label=_("Text:"))
@@ -86,7 +86,7 @@ class SynchronizedLyrics(EventPlugin, PluginConfigMixin):
         b.connect('color-set', cls._set_background_color)
 
         font_section = Gtk.Label()
-        font_section.set_markup("<b>" + _("Font") + "</b>")
+        font_section.set_markup(util.bold(_("Font")))
         t.attach(font_section, 0, 2, 3, 4)
 
         l = Gtk.Label(label=_("Size (px):"))

--- a/quodlibet/ext/events/telepathy_status.py
+++ b/quodlibet/ext/events/telepathy_status.py
@@ -128,8 +128,7 @@ class TelepathyStatusPlugin(EventPlugin, PluginConfigMixin):
         lbl = Gtk.Label(label=_("Playing:"))
         entry.set_tooltip_markup(_("Status text when a song is started. "
                                  "Accepts QL Patterns e.g. %s")
-                                 % util.monospace(
-                                        util.escape("<~artist~title>")))
+                                 % util.monospace("<~artist~title>"))
         lbl.set_mnemonic_widget(entry)
         hb.pack_start(lbl, False, True, 0)
         hb.pack_start(entry, True, True, 0)
@@ -145,8 +144,7 @@ class TelepathyStatusPlugin(EventPlugin, PluginConfigMixin):
         lbl = Gtk.Label(label=_("Paused:"))
         entry.set_tooltip_markup(_("Status text when a song is paused. "
                                    "Accepts QL Patterns e.g. %s")
-                                   % util.monospace(
-                                        util.escape("<~artist~title>")))
+                                   % util.monospace("<~artist~title>"))
         lbl.set_mnemonic_widget(entry)
         hb.pack_start(lbl, False, True, 0)
         hb.pack_start(entry, True, True, 0)

--- a/quodlibet/ext/events/thumbrating.py
+++ b/quodlibet/ext/events/thumbrating.py
@@ -6,7 +6,7 @@
 # (at your option) any later version.
 
 from gi.repository import Gtk
-from quodlibet import _
+from quodlibet import _, util
 from quodlibet.plugins.events import EventPlugin
 from quodlibet.qltk import Icons, ToggleButton
 from quodlibet.plugins.gui import UserInterfacePlugin
@@ -59,9 +59,7 @@ class RatingBox(Gtk.VBox):
     def __set_pending_score_value(self, score):
         existing_score = self.thumb_ups - self.thumb_downs
         if score == existing_score:
-            self.score_label.set_markup("<b>"
-                                        + str(int(score))
-                                        + "</b>")
+            self.score_label.set_markup(util.bold(str(int(score))))
         elif score > existing_score:
             self.score_label.set_markup("<b><span foreground=\"green\">"
                                         + str(int(score))

--- a/quodlibet/ext/songsmenu/albumart.py
+++ b/quodlibet/ext/songsmenu/albumart.py
@@ -569,7 +569,7 @@ class AlbumArtWindow(qltk.Window, PersistentWindowMixin, PluginConfigMixin):
 
             esc = escape_data
 
-            txt = '<b><i>%s</i></b>' % esc(cover['name'])
+            txt = util.bold_italic(cover['name'], escaper=esc)
             txt += "\n<small>%s</small>" % (
                 _('from %(source)s') % {
                     "source": util.italic(cover['source'], escaper=esc)})
@@ -700,7 +700,7 @@ class AlbumArtWindow(qltk.Window, PersistentWindowMixin, PluginConfigMixin):
     def __searchfieldchanged(self, *data):
         search = data[0].get_text()
         clean = cleanup_query(search, ' ')
-        self.search_fieldclean.set_text(f"<i>{clean}</i>")
+        self.search_fieldclean.set_text(util.italic(clean))
         self.search_fieldclean.set_use_markup(True)
 
     def __searchtypetoggled(self, *data):

--- a/quodlibet/ext/songsmenu/albumart.py
+++ b/quodlibet/ext/songsmenu/albumart.py
@@ -572,12 +572,12 @@ class AlbumArtWindow(qltk.Window, PersistentWindowMixin, PluginConfigMixin):
             txt = '<b><i>%s</i></b>' % esc(cover['name'])
             txt += "\n<small>%s</small>" % (
                 _('from %(source)s') % {
-                    "source": util.italic(esc(cover['source']))})
+                    "source": util.italic(cover['source'], escaper=esc)})
             if 'resolution' in cover:
                 txt += "\n" + _('Resolution: %s') % util.italic(
-                    esc(cover['resolution']))
+                    cover['resolution'], escaper=esc)
             if 'size' in cover:
-                txt += "\n" + _('Size: %s') % util.italic(esc(cover['size']))
+                txt += "\n" + _('Size: %s') % util.italic(cover['size'], escaper=esc)
 
             cell.markup = txt
             cell.set_property('markup', cell.markup)

--- a/quodlibet/ext/songsmenu/brainz/widgets.py
+++ b/quodlibet/ext/songsmenu/brainz/widgets.py
@@ -97,8 +97,8 @@ class ResultComboBox(Gtk.ComboBox):
             discs_text = numeric_phrase("%d disc", "%d discs", disc_count)
             tracks_text = numeric_phrase("%d track", "%d tracks", track_count)
 
-            markup = "<b>%s</b>\n%s - %s, %s (%s)" % (
-                    util.escape(release.title),
+            markup = "%s\n%s - %s, %s (%s)" % (
+                    util.bold(release.title),
                     util.escape(", ".join(artist_names)),
                     util.escape(discs_text),
                     util.escape(tracks_text),
@@ -445,12 +445,11 @@ class SearchWindow(Dialog):
         query = self.search_query.get_text()
 
         if not query:
-            self.result_label.set_markup(
-                "<b>%s</b>" % _("Please enter a query."))
+            self.result_label.set_markup(util.bold(_("Please enter a query.")))
             self.search_button.set_sensitive(True)
             return
 
-        self.result_label.set_markup("<i>%s</i>" % _(u"Searching…"))
+        self.result_label.set_markup(util.italic(_("Searching…")))
 
         self._qthread.add(self._process_results, search_releases, query)
 
@@ -471,7 +470,7 @@ class SearchWindow(Dialog):
         self._resultlist.append_many(results)
 
         if len(results) > 0:
-            self.result_label.set_markup("<i>%s</i>" % _(u"Loading result…"))
+            self.result_label.set_markup(util.italic(_("Loading result…")))
             self.result_combo.set_active(0)
         else:
             self.result_label.set_markup(_("No results found."))
@@ -487,7 +486,7 @@ class SearchWindow(Dialog):
         if release.id in self._releasecache:
             self._update_result(self._releasecache[release.id])
         else:
-            self.result_label.set_markup("<i>%s</i>" % _(u"Loading result…"))
+            self.result_label.set_markup(util.italic(_("Loading result…")))
             self.result_treeview.update_release(None)
             self._qthread.add(self._update_result, release.fetch_full)
 

--- a/quodlibet/ext/songsmenu/cover_download.py
+++ b/quodlibet/ext/songsmenu/cover_download.py
@@ -13,7 +13,7 @@ from typing import Iterable, List
 
 from gi.repository import GObject, Gtk, Gdk, Gio, GLib, Soup, GdkPixbuf
 
-from quodlibet import _, app, print_d, print_w
+from quodlibet import _, app, print_d, print_w, util
 from quodlibet import qltk
 from quodlibet.formats import AudioFile
 from senf import path2fsn
@@ -225,7 +225,7 @@ class CoverArtWindow(qltk.Dialog, PersistentWindowMixin):
             source = escape(item.source)
             text = (f"{source} - {format}, "
                     f"{props.width} x {props.height}, "
-                    f"<b>{format_size(size)}</b>")
+                    f"{util.bold(format_size(size))}")
             frame.get_label_widget().set_markup(text)
             frame.get_child().set_reveal_child(True)
 
@@ -292,9 +292,9 @@ class CoverArtWindow(qltk.Dialog, PersistentWindowMixin):
                  reduce(operator.concat, group_songs, [])}
         albums = "\n".join(texts)
         providers = ", ".join({manager.name for manager in results.keys()})
-        data = {'albums': escape(albums), 'providers': escape(providers)}
-        markup = _("Nothing found for albums:\n<i>%(albums)s</i>.\n\n"
-                   "Providers used:\n<tt>%(providers)s</tt>") % data
+        data = {'albums': util.italic(albums), 'providers': util.monospace(providers)}
+        markup = _("Nothing found for albums:\n%(albums)s.\n\n"
+                   "Providers used:\n%(providers)s") % data
         dialog = qltk.Message(Gtk.MessageType.INFO, parent=self,
                               title=_("No covers found"), description=markup,
                               escape_desc=False)
@@ -355,7 +355,7 @@ class CoverArtWindow(qltk.Dialog, PersistentWindowMixin):
                 pat_text = model[it][0]
                 ext = "jpg" if self.config.re_encode else "*"
                 text = list(self._filenames(pat_text, ext))[0]
-                cell.set_property("markup", f"<tt>{escape(text)}</tt>")
+                cell.set_property("markup", util.monospace(text))
 
             save_filename.set_cell_data_func(cell, draw_save_type, None)
 

--- a/quodlibet/ext/songsmenu/editplaycount.py
+++ b/quodlibet/ext/songsmenu/editplaycount.py
@@ -1,5 +1,5 @@
 # Copyright 2012-2015 Ryan "ZDBioHazard" Turner <zdbiohazard2@gmail.com>
-#                2016 Nick Boultbee
+#             2016-22 Nick Boultbee
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -8,7 +8,7 @@
 
 from gi.repository import Gtk
 
-from quodlibet import _
+from quodlibet import _, util
 from quodlibet.plugins.songshelpers import each_song, is_writable
 from quodlibet.plugins.songsmenu import SongsMenuPlugin
 from quodlibet.qltk import Icons
@@ -82,8 +82,8 @@ class EditPlaycount(SongsMenuPlugin):
         else:
             note = Gtk.Label()
             note.set_justify(Gtk.Justification.CENTER)
-            note.set_markup("<b>Multiple files selected.</b>\n"
-                            "Counts will be incremented.")
+            note.set_markup(util.bold(_("Multiple files selected."))
+                            + "\n" + _("Counts will be incremented."))
             dlg.vbox.add(note)
 
         dlg.show_all()
@@ -105,8 +105,7 @@ class EditPlaycount(SongsMenuPlugin):
                 # itself and the last played/started time. We don't
                 # want unused or impossible data floating around.
                 if song.get('~#playcount', 0) == 0:
-                    for tag in ['~#playcount', '~#lastplayed',
-                                '~#laststarted']:
+                    for tag in ['~#playcount', '~#lastplayed', '~#laststarted']:
                         song.pop(tag, None)
 
                 # Also delete the skip count if it's zero.

--- a/quodlibet/ext/songsmenu/fingerprint/submit.py
+++ b/quodlibet/ext/songsmenu/fingerprint/submit.py
@@ -1,5 +1,5 @@
 # Copyright 2011,2013 Christoph Reiter
-#                2016 Nick Boultbee
+#             2016-22 Nick Boultbee
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -8,7 +8,7 @@
 
 from gi.repository import Gtk, Pango, GLib
 
-from quodlibet import _
+from quodlibet import _, util
 from quodlibet.qltk import Button, Window
 from quodlibet.util import connect_obj, print_w
 
@@ -45,7 +45,7 @@ class FingerprintDialog(Window):
         box = Gtk.VBox(spacing=6)
 
         self.__label = label = Gtk.Label()
-        label.set_markup("<b>%s</b>" % _("Generating fingerprints:"))
+        label.set_markup(util.bold(_("Generating fingerprints:")))
         label.set_alignment(0, 0.5)
         box.pack_start(label, False, True, 0)
 
@@ -115,15 +115,15 @@ class FingerprintDialog(Window):
         got_mbid, got_meta = get_stats(results)
 
         text = _("Songs either need a <i><b>musicbrainz_trackid</b></i>, "
-            "or <i><b>artist</b></i> / "
-            "<i><b>title</b></i> / <i><b>album</b></i> tags to get submitted.")
-        text += "\n\n" + "<i>%s</i>" % _("Fingerprints:")
+                 "or <i><b>artist</b></i> / "
+                 "<i><b>title</b></i> / <i><b>album</b></i> tags to get submitted.")
+        text += "\n\n" + util.italic(_("Fingerprints:"))
         text += " %d/%d" % (valid_fp, all_)
-        text += "\n" + "<i>%s</i>" % _("Songs with MBIDs:")
+        text += "\n" + util.italic(_("Songs with MBIDs:"))
         text += " %d/%d" % (got_mbid, all_)
-        text += "\n" + "<i>%s</i>" % _("Songs with sufficient tags:")
+        text += "\n" + util.italic(_("Songs with sufficient tags:"))
         text += " %d/%d" % (got_meta, all_)
-        text += "\n" + "<i>%s</i>" % _("Songs to submit:")
+        text += "\n" + util.italic(_("Songs to submit:"))
         text += " %d/%d" % (to_send, all_)
         self.__stats.set_markup(text)
 
@@ -177,7 +177,7 @@ class FingerprintDialog(Window):
 
     def __submit_cb(self, *args):
         self.__submit.set_sensitive(False)
-        self.__label.set_markup("<b>%s</b>" % _("Submitting fingerprints:"))
+        self.__label.set_markup(util.bold(_("Submitting fingerprints:")))
         self.__set_fraction(0)
         self.__acoustid_thread = AcoustidSubmissionThread(
             list(filter(can_submit, self.__fp_results.values())),
@@ -185,7 +185,7 @@ class FingerprintDialog(Window):
 
     def __acoustid_update(self, progress):
         self.__set_fraction(progress)
-        self.__label_song.set_text(_(u"Submitting…"))
+        self.__label_song.set_text(_("Submitting…"))
 
     def __acoustid_done(self):
         self.__acoustid_thread.join()

--- a/quodlibet/ext/songsmenu/ifp.py
+++ b/quodlibet/ext/songsmenu/ifp.py
@@ -58,9 +58,8 @@ class IFPUpload(SongsMenuPlugin):
             os.system("ifp mkdir %r> /dev/null 2>/dev/null" % dirname)
             self.__madedir.append(dirname)
         if os.system("ifp upload %r %r > /dev/null" % (filename, target)):
-            qltk.ErrorMessage(
-                None, _("Error uploading"),
-                _("Unable to upload <b>%s</b>. The device may be "
-                  "out of space, or turned off.") % (
-                util.escape(filename))).run()
+            tmpl = _("Unable to upload <b>%s</b>."
+                     "The device may be out of space, or turned off.")
+            qltk.ErrorMessage(None, _("Error uploading"), tmpl % util.escape(filename),
+                              escape_desc=False).run()
             return True

--- a/quodlibet/ext/songsmenu/ifp.py
+++ b/quodlibet/ext/songsmenu/ifp.py
@@ -58,8 +58,8 @@ class IFPUpload(SongsMenuPlugin):
             os.system("ifp mkdir %r> /dev/null 2>/dev/null" % dirname)
             self.__madedir.append(dirname)
         if os.system("ifp upload %r %r > /dev/null" % (filename, target)):
-            tmpl = _("Unable to upload <b>%s</b>."
+            tmpl = _("Unable to upload %s."
                      "The device may be out of space, or turned off.")
-            qltk.ErrorMessage(None, _("Error uploading"), tmpl % util.escape(filename),
+            qltk.ErrorMessage(None, _("Error uploading"), tmpl % util.bold(filename),
                               escape_desc=False).run()
             return True

--- a/quodlibet/ext/songsmenu/import_export_tags_and_track_user_data.py
+++ b/quodlibet/ext/songsmenu/import_export_tags_and_track_user_data.py
@@ -33,7 +33,7 @@ from quodlibet.util.path import join_path_with_escaped_name_of_legal_length, \
 
 from quodlibet.util.songwrapper import SongWrapper, check_wrapper_changed
 
-from quodlibet import _, app, print_e, print_d, qltk
+from quodlibet import _, app, print_e, print_d, qltk, util
 
 from quodlibet.plugins.songshelpers import each_song, is_writable, is_finite
 from quodlibet.qltk.msg import ErrorMessage, WarningMessage
@@ -192,8 +192,9 @@ class ImportExportTagsAndTrackUserDataPlugin(SongsMenuPlugin):
         info_frame = qltk.Frame(_("Further information"), child=info_box)
         vbox.pack_start(info_frame, False, True, 0)
 
+        meta_markup = util.monospace(", ".join(MIGRATE))
         info_text = _("The term 'track user data' includes the playlists in which the "
-                      "selected tracks are and the following metadata:\n\n<tt>%s</tt>\n"
+                      "selected tracks are and the following metadata:\n\n%s\n"
                       "\nBe aware that whatever you chose to export will be imported. "
                       "If you exported the file stems (file names without extension), "
                       "then, on import, the selected files will be renamed.\n\nAfter "
@@ -202,7 +203,7 @@ class ImportExportTagsAndTrackUserDataPlugin(SongsMenuPlugin):
                       "The plugin matches the exported data to the new tracks, even if "
                       "the names of the tracks are slightly different. The automatic "
                       "matching is not always correct, so it is better to not reduce "
-                      "the following similarity values too much.") % ", ".join(MIGRATE)
+                      "the following similarity values too much.") % meta_markup
 
         info_lbl = Gtk.Label(label=info_text, use_markup=True, wrap=True)
         info_box.pack_start(info_lbl, True, True, 0)

--- a/quodlibet/ext/songsmenu/playlist.py
+++ b/quodlibet/ext/songsmenu/playlist.py
@@ -130,7 +130,7 @@ class PlaylistExport(PlaylistPlugin, SongsMenuPlugin):
         dialog = qltk.ErrorMessage(
             None,
             _("Unable to export playlist"),
-            _("Writing to <b>%s</b> failed.") % util.escape(file_path),
+            _("Writing to %s failed.") % util.bold(file_path),
             escape_desc=False)
         dialog.run()
 

--- a/quodlibet/ext/songsmenu/playlist.py
+++ b/quodlibet/ext/songsmenu/playlist.py
@@ -127,10 +127,12 @@ class PlaylistExport(PlaylistPlugin, SongsMenuPlugin):
         return files
 
     def __file_error(self, file_path):
-        qltk.ErrorMessage(
+        dialog = qltk.ErrorMessage(
             None,
             _("Unable to export playlist"),
-            _("Writing to <b>%s</b> failed.") % util.escape(file_path)).run()
+            _("Writing to <b>%s</b> failed.") % util.escape(file_path),
+            escape_desc=False)
+        dialog.run()
 
     def __m3u_export(self, file_path, files):
         try:

--- a/quodlibet/ext/songsmenu/replaygain.py
+++ b/quodlibet/ext/songsmenu/replaygain.py
@@ -14,7 +14,7 @@ from gi.repository import Pango
 from gi.repository import Gst
 from gi.repository import GLib
 
-from quodlibet import print_d, ngettext, C_, _
+from quodlibet import print_d, ngettext, C_, _, util
 from quodlibet.plugins import PluginConfigMixin
 
 from quodlibet.browsers.collection.models import EMPTY
@@ -450,12 +450,12 @@ class RGDialog(Dialog):
         self.__fill_view(view, albums)
         num_to_process = sum(int(rga.should_process) for rga in self._todo)
         template = ngettext(
-            "There is <b>%(to-process)s</b> album to update (of %(all)s)",
-            "There are <b>%(to-process)s</b> albums to update (of %(all)s)",
+            "There is %(to-process)s album to update (of %(all)s)",
+            "There are %(to-process)s albums to update (of %(all)s)",
             num_to_process)
         info.set_markup(template % {
-            "to-process": format_int_locale(num_to_process),
-            "all": format_int_locale(len(self._todo)),
+            "to-process": util.bold(format_int_locale(num_to_process)),
+            "all": util.bold(format_int_locale(len(self._todo))),
         })
         self.connect("destroy", self.__destroy)
         self.connect('response', self.__response)
@@ -607,7 +607,7 @@ class ReplayGain(SongsMenuPlugin, PluginConfigMixin):
 
         def create_model():
             model = Gtk.ListStore(str, str)
-            model.append(["<b>%s</b>" % _("always"), UpdateMode.ALWAYS])
+            model.append([util.bold(_("always")), UpdateMode.ALWAYS])
             model.append([_("if <b>any</b> RG tags are missing"),
                           UpdateMode.ANY_MISSING])
             model.append([_("if <b>album</b> RG tags are missing"),

--- a/quodlibet/ext/songsmenu/website_search.py
+++ b/quodlibet/ext/songsmenu/website_search.py
@@ -11,7 +11,7 @@ from urllib.parse import quote_plus
 from gi.repository import Gtk
 
 import quodlibet
-from quodlibet import _
+from quodlibet import _, util
 from quodlibet import qltk
 from quodlibet.formats import AudioFile
 from quodlibet.pattern import Pattern
@@ -36,8 +36,8 @@ class WebsiteSearch(SongsMenuPlugin):
     PLUGIN_NAME = _("Website Search")
     PLUGIN_DESC_MARKUP = (_(
         "Searches your choice of website using any song tags.\n"
-        "Supports patterns e.g. <tt>%(pattern-example)s</tt>.")
-         % {"pattern-example": "https://duckduckgo.com?q=&lt;~artist~title&gt;"}
+        "Supports patterns e.g. %(pattern)s.")
+         % {"pattern": util.monospace("https://duckduckgo.com?q=&lt;~artist~title&gt;")}
     )
 
     # Here are some starters...

--- a/quodlibet/qltk/_editutils.py
+++ b/quodlibet/qltk/_editutils.py
@@ -30,7 +30,7 @@ class OverwriteWarning(WarningMessage):
     def __init__(self, parent, song):
         title = _("Tag may not be accurate")
 
-        fn_format = "<b>%s</b>" % util.escape(fsn2text(song("~basename")))
+        fn_format = util.bold(fsn2text(song("~basename")))
         description = _("%(file-name)s changed while the program was running. "
             "Saving without refreshing your library may "
             "overwrite other changes to the song.") % {"file-name": fn_format}
@@ -49,7 +49,7 @@ class WriteFailedError(ErrorMessage):
     def __init__(self, parent, song):
         title = _("Unable to save song")
 
-        fn_format = "<b>%s</b>" % util.escape(fsn2text(song("~basename")))
+        fn_format = util.bold(fsn2text(song("~basename")))
         description = _("Saving %(file-name)s failed."
                         "The file may be read-only, corrupted, or you do not have "
                         "permission to edit it.") % {"file-name": fn_format}

--- a/quodlibet/qltk/_editutils.py
+++ b/quodlibet/qltk/_editutils.py
@@ -50,12 +50,10 @@ class WriteFailedError(ErrorMessage):
         title = _("Unable to save song")
 
         fn_format = "<b>%s</b>" % util.escape(fsn2text(song("~basename")))
-        description = _("Saving %(file-name)s failed. The file may be "
-            "read-only, corrupted, or you do not have "
-            "permission to edit it.") % {"file-name": fn_format}
-
-        super().__init__(
-            parent, title, description)
+        description = _("Saving %(file-name)s failed."
+                        "The file may be read-only, corrupted, or you do not have "
+                        "permission to edit it.") % {"file-name": fn_format}
+        super().__init__(parent, title, description, escape_desc=False)
 
 
 class EditingPluginHandler(GObject.GObject, PluginHandler):

--- a/quodlibet/qltk/cbes.py
+++ b/quodlibet/qltk/cbes.py
@@ -11,7 +11,7 @@ from typing import Dict
 
 from gi.repository import Gtk, Pango, GObject, GLib
 
-from quodlibet import _, config
+from quodlibet import _, config, util
 from quodlibet import qltk
 from quodlibet.qltk.views import RCMHintedTreeView
 from quodlibet.qltk.util import GSignals
@@ -141,8 +141,8 @@ class _KeyValueEditor(qltk.Window):
         row = model[iter]
         content, name = row
         cell.set_property("markup",
-                          f"<b>{escape(name)}</b>\n"
-                          f"<tt>{escape(content)}</tt>")
+                          util.bold(name) + "\n",
+                          util.monospace(content))
 
     def __changed(self, entry, buttons):
         for b in buttons:

--- a/quodlibet/qltk/data_editors.py
+++ b/quodlibet/qltk/data_editors.py
@@ -17,7 +17,7 @@ from quodlibet.qltk.x import MenuItem, Button, Align
 from quodlibet.qltk import Icons
 from quodlibet.query import Query
 from quodlibet.util.json_data import JSONObjectDict
-from quodlibet.util import connect_obj, escape
+from quodlibet.util import connect_obj
 from quodlibet.qltk.getstring import GetStringDialog
 
 
@@ -249,7 +249,7 @@ class JSONBasedEditor(qltk.UniqueWindow):
         obj = row[0]
         obj_name = util.escape(obj.name)
         obj_description = util.escape(str(obj))
-        markup = '<b>%s</b>\n%s' % (obj_name, obj_description)
+        markup = f"{util.bold(obj_name)}\n{obj_description}"
         cell.markup = markup
         cell.set_property('markup', markup)
 
@@ -353,8 +353,7 @@ class TagListEditor(qltk.Window):
         def desc_cdf(column, cell, model, iter, data):
             row = model[iter]
             if row:
-                escaped = escape(util.tag(row[0]))
-                cell.set_property('markup', f"<i>{escaped}</i>")
+                cell.set_property('markup', util.italic(util.tag(row[0])))
 
         def __create_cell_renderer():
             r = Gtk.CellRendererText()

--- a/quodlibet/qltk/edittags.py
+++ b/quodlibet/qltk/edittags.py
@@ -772,7 +772,7 @@ class EditTags(Gtk.VBox):
             msg += _("The files currently"
                      " selected do not support multiple values for <b>%s</b>."
                      ) % util.escape(tag)
-            qltk.ErrorMessage(self, title, msg).run()
+            qltk.ErrorMessage(self, title, msg, escape_desc=False).run()
             return
 
         entry = ListEntry(tag, Comment(value))
@@ -981,7 +981,7 @@ class EditTags(Gtk.VBox):
             msg = _("Invalid tag <b>%s</b>\n\nThe files currently"
                     " selected do not support editing this tag."
                     ) % util.escape(new_tag)
-            qltk.ErrorMessage(self, title, msg).run()
+            qltk.ErrorMessage(self, title, msg, escape_desc=False).run()
         else:
             # FIXME: In case this is a special one we only
             # validate one value and never write it back..

--- a/quodlibet/qltk/edittags.py
+++ b/quodlibet/qltk/edittags.py
@@ -93,11 +93,10 @@ class Comment:
             return util.escape(self.text)
         elif self.shared:
             return "\n".join(
-                ['%s<i> (%s)</i>' % (util.escape(s),
-                                     util.escape(self._paren()))
+                [f"{util.escape(s)}{util.italic(' ' + self._paren())}"
                  for s in self.text.split("\n")])
         else:
-            return '<i>(%s)</i>' % util.escape(self._paren())
+            return util.italic(self._paren())
 
 
 def get_default_tags():
@@ -767,11 +766,11 @@ class EditTags(Gtk.VBox):
         iters = [i for (i, v) in model.iterrows() if v.tag == tag]
         if iters and not self._group_info.can_multiple_values(tag):
             title = _("Unable to add tag")
-            msg = _("Unable to add <b>%s</b>") % util.escape(tag)
+            msg = _("Unable to add %s") % util.bold(tag)
             msg += "\n\n"
             msg += _("The files currently"
-                     " selected do not support multiple values for <b>%s</b>."
-                     ) % util.escape(tag)
+                     " selected do not support multiple values for %s."
+                     ) % util.bold(tag)
             qltk.ErrorMessage(self, title, msg, escape_desc=False).run()
             return
 
@@ -797,9 +796,9 @@ class EditTags(Gtk.VBox):
             assert isinstance(value, str)
             if not self._group_info.can_change(tag):
                 title = _("Invalid tag")
-                msg = _("Invalid tag <b>%s</b>\n\nThe files currently"
+                msg = _("Invalid tag %s\n\nThe files currently"
                         " selected do not support editing this tag."
-                        ) % util.escape(tag)
+                        ) % util.bold(tag)
                 qltk.ErrorMessage(self, title, msg).run()
             else:
                 self.__add_new_tag(model, tag, value)
@@ -949,8 +948,8 @@ class EditTags(Gtk.VBox):
         if not massagers.is_valid(entry.tag, new_value):
             error_dialog = qltk.WarningMessage(
                 self, _("Invalid value"),
-                _("Invalid value: <b>%(value)s</b>\n\n%(error)s") % {
-                "value": new_value,
+                _("Invalid value: %(value)s\n\n%(error)s") % {
+                "value": util.bold(new_value),
                 "error": massagers.error_message(entry.tag, new_value)})
         else:
             new_value = massagers.validate(entry.tag, new_value)
@@ -978,9 +977,9 @@ class EditTags(Gtk.VBox):
         elif not self._group_info.can_change(new_tag):
             # Can't add the new tag.
             title = _("Invalid tag")
-            msg = _("Invalid tag <b>%s</b>\n\nThe files currently"
+            msg = _("Invalid tag %s\n\nThe files currently"
                     " selected do not support editing this tag."
-                    ) % util.escape(new_tag)
+                    ) % util.bold(new_tag)
             qltk.ErrorMessage(self, title, msg, escape_desc=False).run()
         else:
             # FIXME: In case this is a special one we only
@@ -990,8 +989,8 @@ class EditTags(Gtk.VBox):
             if not massagers.is_valid(new_tag, text):
                 qltk.WarningMessage(
                     self, _("Invalid value"),
-                    _("Invalid value: <b>%(value)s</b>\n\n%(error)s") % {
-                      "value": text,
+                    _("Invalid value: %(value)s\n\n%(error)s") % {
+                      "value": util.bold(text),
                       "error": massagers.error_message(new_tag, text)}).run()
                 return
             text = massagers.validate(new_tag, text)

--- a/quodlibet/qltk/filesel.py
+++ b/quodlibet/qltk/filesel.py
@@ -397,7 +397,7 @@ class DirectoryTree(RCMHintedTreeView, MultiDragTreeView):
             try:
                 os.rmdir(directory)
             except EnvironmentError as err:
-                error = "<b>%s</b>: %s" % (err.filename, err.strerror)
+                error = f"{util.bold(err.filename)}: {err.strerror}"
                 qltk.ErrorMessage(
                     None, _("Unable to delete folder"), error, escape_desc=False).run()
                 return

--- a/quodlibet/qltk/filesel.py
+++ b/quodlibet/qltk/filesel.py
@@ -12,7 +12,7 @@ from urllib.parse import urlsplit
 from gi.repository import Gtk, GObject, Gdk, Gio, Pango
 from senf import uri2fsn, fsnative, fsn2text, bytes2fsn
 
-from quodlibet import formats, print_d
+from quodlibet import formats, print_d, util
 from quodlibet import qltk
 from quodlibet import _
 
@@ -380,9 +380,9 @@ class DirectoryTree(RCMHintedTreeView, MultiDragTreeView):
         try:
             os.makedirs(fullpath)
         except EnvironmentError as err:
-            error = "<b>%s</b>: %s" % (err.filename, err.strerror)
+            error = f"{util.bold(err.filename)}: {util.escape(err.strerror)}"
             qltk.ErrorMessage(
-                None, _("Unable to create folder"), error).run()
+                None, _("Unable to create folder"), error, escape_desc=False).run()
             return
 
         self.emit('test-expand-row', model.get_iter(path), path)
@@ -399,7 +399,7 @@ class DirectoryTree(RCMHintedTreeView, MultiDragTreeView):
             except EnvironmentError as err:
                 error = "<b>%s</b>: %s" % (err.filename, err.strerror)
                 qltk.ErrorMessage(
-                    None, _("Unable to delete folder"), error).run()
+                    None, _("Unable to delete folder"), error, escape_desc=False).run()
                 return
 
         ppath = Gtk.TreePath(paths[0][:-1])

--- a/quodlibet/qltk/information.py
+++ b/quodlibet/qltk/information.py
@@ -1,5 +1,5 @@
 # Copyright 2004-2005 Joe Wreschnig, Michael Urman, Iñigo Serna
-#           2016-2018 Nick Boultbee
+#           2016-2022 Nick Boultbee
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -48,7 +48,7 @@ class TitleLabel(Gtk.Label):
     def __init__(self, text, is_markup=False):
         super().__init__()
         self.set_ellipsize(Pango.EllipsizeMode.END)
-        markup = text if is_markup else ("<i>%s</i>" % util.escape(text))
+        markup = text if is_markup else (util.italic(text))
         markup = "<span size='xx-large'>%s</span>" % markup
         self.set_markup(markup)
         self.set_selectable(True)
@@ -164,14 +164,12 @@ class OneSong(qltk.Notebook):
     def _album(self, song, box):
         if "album" not in song:
             return
-        text = ["<span size='x-large'><i>%s</i></span>"
-                % util.escape(song.comma("album"))]
+        text = [f"<span size='x-large'>{util.italic(song.comma('album'))}</span>"]
         secondary = []
         if "discnumber" in song:
             secondary.append(_("Disc %s") % song["discnumber"])
         if "discsubtitle" in song:
-            secondary.append("<i>%s</i>" %
-                             util.escape(song.comma("discsubtitle")))
+            secondary.append(util.italic(song.comma("discsubtitle")))
         if "tracknumber" in song:
             secondary.append(_("Track %s") % song["tracknumber"])
         if secondary:
@@ -315,7 +313,7 @@ class OneSong(qltk.Notebook):
 
         if "comment" in song:
             comments = song.list("comment")
-            markups = ["<i>%s</i>" % util.escape(c) for c in comments]
+            markups = [util.italic(c) for c in comments]
             markup_data.append(("comment", markups))
 
         if "website" in song:
@@ -354,7 +352,7 @@ class OneAlbum(qltk.Notebook):
     def _title(self, songs, box):
         song = songs[0]
         self.title = text = song["album"]
-        markup = "<i>%s</i>" % util.escape(text)
+        markup = util.italic(text)
         if "date" in song:
             markup += " <small>(%s)</small>" % util.escape(song("~year"))
         box.pack_start(TitleLabel(markup, is_markup=True), False, False, 0)
@@ -461,9 +459,8 @@ class OneAlbum(qltk.Notebook):
                 text.append("{ts}{cur: >2}. {text}".format(
                     ts=ts, cur=cur_track, text=_("Track unavailable")))
                 cur_track += 1
-            markup = util.escape(song.comma("~title~version"))
-            text.append("{ts}{cur: >2}. <i>{text}</i>".format(
-                    ts=ts, cur=track, text=markup))
+            title = util.italic(song.comma("~title~version"))
+            text.append(f"{ts}{track: >2}. {title}")
         l = Label(markup="\n".join(text), ellipsize=True)
         box.pack_start(Frame(_("Track List"), l), False, False, 0)
 
@@ -490,7 +487,7 @@ class OneArtist(qltk.Notebook):
 
         def format(args):
             date, song, album = args
-            markup = "<big><i>%s</i></big>" % util.escape(album)
+            markup = f"<big>{util.italic(album)}</big>"
             return "%s (%s)" % (markup, date[:4]) if date else markup
 
         get_cover = app.cover_manager.get_cover
@@ -498,7 +495,7 @@ class OneArtist(qltk.Notebook):
         albums = [format(a) for a in albums]
         if noalbum:
             albums.append(ngettext("%d song with no album",
-                "%d songs with no album", noalbum) % noalbum)
+                                   "%d songs with no album", noalbum) % noalbum)
         l = Label(markup="\n".join(albums), ellipsize=True)
         box.pack_start(Frame(_("Selected Discography"), l), False, False, 0)
 
@@ -585,18 +582,17 @@ class ManySongs(qltk.Notebook):
         albums = sorted(albums)
         num_albums = len(albums)
 
-        markup = "\n".join("<i>%s</i>" % util.escape(a) for a in albums)
+        markup = "\n".join(util.italic(a) for a in albums)
         if none:
             text = ngettext("%d song with no album",
                             "%d songs with no album",
                             none) % none
-            markup += "\n%s" % util.escape(text)
+            markup += f"\n{util.escape(text)}"
 
         label = Label()
         label.set_markup(markup)
-        box.pack_start(Frame(
-            "%s (%d)" % (util.capitalize(_("albums")), num_albums),
-            label), False, False, 0)
+        albums = util.capitalize(_('albums'))
+        box.pack_start(Frame(f"{albums} ({num_albums})", label), False, False, 0)
 
     def _file(self, songs, box):
         length = 0
@@ -656,7 +652,7 @@ class Information(Window, PersistentWindowMixin):
         elif len(songs) == 1:
             self.add(OneSong(library, songs[0]))
         else:
-            tags = [(s.get("artist", u""), s.get("album", u"")) for s in songs]
+            tags = [(s.get("artist", ""), s.get("album", "")) for s in songs]
             artists, albums = zip(*tags)
             if min(albums) == max(albums) and albums[0]:
                 self.add(OneAlbum(songs))

--- a/quodlibet/qltk/msg.py
+++ b/quodlibet/qltk/msg.py
@@ -106,7 +106,7 @@ class ConfirmFileReplace(WarningMessage):
 
     def __init__(self, parent, path):
         title = _("File exists")
-        fn_format = "<b>%s</b>" % util.escape(fsn2text(path2fsn(path)))
+        fn_format = util.bold(fsn2text(path2fsn(path)))
         description = _("Replace %(file-name)s?") % {"file-name": fn_format}
 
         super().__init__(

--- a/quodlibet/qltk/notif.py
+++ b/quodlibet/qltk/notif.py
@@ -30,7 +30,7 @@ Of course, right now it does none of these things.
 
 from gi.repository import Gtk, GLib, Pango
 
-from quodlibet import _
+from quodlibet import _, util
 from quodlibet.util import copool
 from quodlibet.qltk.x import SmallImageToggleButton, SmallImageButton, Align
 from quodlibet.qltk import Icons, add_css
@@ -268,7 +268,7 @@ class TaskWidget(Gtk.HBox):
             self.task.stop()
 
     def update(self):
-        formatted_label = f"<b>{self.task.source}</b> – {self.task.desc}"
+        formatted_label = f"{util.bold(self.task.source)} – {self.task.desc}"
         self.label.set_markup(formatted_label)
         if self.task.frac is not None:
             self.progress.set_fraction(self.task.frac)

--- a/quodlibet/qltk/pluginwin.py
+++ b/quodlibet/qltk/pluginwin.py
@@ -78,7 +78,7 @@ class PluginErrorWindow(UniqueWindow):
         keys = failures.keys()
         show_expanded = len(keys) <= 3
         for key in sorted(keys):
-            expander = Gtk.Expander(label="<b>%s</b>" % util.escape(key))
+            expander = Gtk.Expander(label=util.bold(key))
             expander.set_use_markup(True)
             if show_expanded:
                 expander.set_expanded(True)

--- a/quodlibet/qltk/quodlibetwindow.py
+++ b/quodlibet/qltk/quodlibetwindow.py
@@ -856,7 +856,8 @@ class QuodLibetWindow(Window, PersistentWindowMixin, AppWindow):
         if error:
             ErrorMessage(
                 self, _("Unable to add songs"),
-                _("%s uses an unsupported protocol.") % util.bold(uri)).run()
+                _("%s uses an unsupported protocol.") % util.bold(uri),
+                escape_desc=False).run()
         else:
             if dirs:
                 copool.add(
@@ -1291,13 +1292,12 @@ class QuodLibetWindow(Window, PersistentWindowMixin, AppWindow):
             if not uri_is_valid(name):
                 ErrorMessage(
                     self, _("Unable to add location"),
-                    _("%s is not a valid location.") % (
-                    util.bold(util.escape(name)))).run()
+                    _("%s is not a valid location.") % util.bold(name)).run()
             elif not app.player.can_play_uri(name):
                 ErrorMessage(
                     self, _("Unable to add location"),
-                    _("%s uses an unsupported protocol.") % (
-                    util.bold(util.escape(name)))).run()
+                    _("%s uses an unsupported protocol.") % (util.bold(name)),
+                    escape_desc=False).run()
             else:
                 if name not in self.__library:
                     self.__library.add([RemoteFile(name)])

--- a/quodlibet/qltk/renamefiles.py
+++ b/quodlibet/qltk/renamefiles.py
@@ -335,12 +335,12 @@ class RenameFiles(Gtk.VBox):
                 RESPONSE_SKIP_ALL = 1
                 msg = qltk.Message(
                     Gtk.MessageType.ERROR, win, _("Unable to rename file"),
-                    _("Renaming <b>%(old-name)s</b> to <b>%(new-name)s</b> "
-                      "failed. Possibly the target file already exists, "
+                    _("Renaming %(old-name)s to %(new-name)s failed. "
+                      "Possibly the target file already exists, "
                       "or you do not have permission to make the "
                       "new file or remove the old one.") % {
-                        "old-name": util.escape(old_name),
-                        "new-name": util.escape(new_name),
+                        "old-name": util.bold(old_name),
+                        "new-name": util.bold(new_name),
                     },
                     buttons=Gtk.ButtonsType.NONE)
                 msg.add_button(_("Ignore _All Errors"), RESPONSE_SKIP_ALL)
@@ -461,11 +461,10 @@ class RenameFiles(Gtk.VBox):
         except ValueError:
             qltk.ErrorMessage(
                 self, _("Path is not absolute"),
-                _("The pattern\n\t<b>%s</b>\ncontains / but "
-                  "does not start from root. To avoid misnamed "
-                  "folders, root your pattern by starting "
-                  "it with / or ~/.") % (
-                    util.escape(pattern_text))).run()
+                _("The pattern\n\t%s\ncontains / but does not start from root. "
+                  "To avoid misnamed folders, "
+                  "root your pattern by starting it with / or ~/.") % (
+                    util.bold(pattern_text))).run()
             return
         else:
             if pattern:

--- a/quodlibet/qltk/songsmenu.py
+++ b/quodlibet/qltk/songsmenu.py
@@ -15,7 +15,7 @@ from quodlibet.qltk.chooser import choose_folders
 from quodlibet.qltk.download import DownloadProgress
 from quodlibet.qltk.pluginwin import PluginWindow
 
-from quodlibet import ngettext, _, print_d, app
+from quodlibet import ngettext, _, print_d, app, util
 from quodlibet import qltk
 from quodlibet.errorreport import errorhook
 from quodlibet.qltk.showfiles import show_songs
@@ -440,8 +440,8 @@ class SongsMenu(Gtk.Menu):
                             and len(relevant) < MenuItemPlugin.MAX_INVOCATIONS)
 
             def _finished(p, successes, failures):
-                msg = (f"<b>{successes}</b> " + _("successful") +
-                       f"\n<b>{failures}</b> " + _("failed"))
+                msg = (f"{util.bold(successes)} " + _("successful") +
+                       f"\n{util.bold(failures)} " + _("failed"))
                 print_d(msg.replace("\n", "; "))
                 warning = Message(Gtk.MessageType.INFO, app.window,
                                   _("Downloads complete"), msg, escape_desc=False)

--- a/quodlibet/qltk/tagsfrompath.py
+++ b/quodlibet/qltk/tagsfrompath.py
@@ -13,7 +13,7 @@ from senf import fsn2text
 
 import quodlibet
 
-from quodlibet import _
+from quodlibet import _, ngettext
 from quodlibet import config
 from quodlibet import qltk
 from quodlibet import util
@@ -191,10 +191,10 @@ class TagsFromPath(Gtk.VBox):
         except re.error:
             qltk.ErrorMessage(
                 self, _("Invalid pattern"),
-                _("The pattern\n\t<b>%s</b>\nis invalid. "
+                _("The pattern\n\t%s\nis invalid. "
                   "Possibly it contains the same tag twice or "
                   "it has unbalanced brackets (&lt; / &gt;).") % (
-                util.escape(pattern_text)), escape_desc=False).run()
+                util.bold(pattern_text)), escape_desc=False).run()
             return
         else:
             if pattern_text:
@@ -206,17 +206,15 @@ class TagsFromPath(Gtk.VBox):
         for header in pattern.headers:
             if not min([song.can_change(header) for song in songs]):
                 invalid.append(header)
-        if len(invalid) and songs:
-            if len(invalid) == 1:
-                title = _("Invalid tag")
-                msg = _("Invalid tag <b>%s</b>\n\nThe files currently"
-                        " selected do not support editing this tag.")
-            else:
-                title = _("Invalid tags")
-                msg = _("Invalid tags <b>%s</b>\n\nThe files currently"
-                        " selected do not support editing these tags.")
-            qltk.ErrorMessage(
-                self, title, msg % ", ".join(invalid)).run()
+        total = len(invalid)
+        if total and songs:
+            title = ngettext("Invalid tag", "Invalid tags", total)
+            msg = ngettext("Invalid tag %s\n\nThe files currently "
+                           "selected do not support editing this tag.",
+                           "Invalid tags %s\n\nThe files currently "
+                           "selected do not support editing these tags.", total)
+            tags_str = util.bold(", ".join(invalid))
+            qltk.ErrorMessage(self, title, msg % tags_str, escape_desc=False).run()
             pattern = TagsFromPattern("")
 
         self.view.set_model(None)

--- a/quodlibet/qltk/tagsfrompath.py
+++ b/quodlibet/qltk/tagsfrompath.py
@@ -194,7 +194,7 @@ class TagsFromPath(Gtk.VBox):
                 _("The pattern\n\t<b>%s</b>\nis invalid. "
                   "Possibly it contains the same tag twice or "
                   "it has unbalanced brackets (&lt; / &gt;).") % (
-                util.escape(pattern_text))).run()
+                util.escape(pattern_text)), escape_desc=False).run()
             return
         else:
             if pattern_text:

--- a/quodlibet/qltk/views.py
+++ b/quodlibet/qltk/views.py
@@ -14,7 +14,7 @@ import os
 from gi.repository import Gtk, Gdk, GObject, Pango, GLib
 import cairo
 
-from quodlibet import _, print_e
+from quodlibet import _, print_e, util
 from quodlibet import config
 from quodlibet.qltk import get_top_parent, is_accel, is_wayland, gtk_version, \
     menu_popup, get_primary_accel_mod
@@ -933,7 +933,7 @@ class DragIconTreeView(BaseView):
         layout = None
         if len(paths) > max_rows:
             more = _(u"and %d more…") % (len(paths) - max_rows)
-            more = "<i>%s</i>" % more
+            more = util.italic(more)
             layout = self.create_pango_layout("")
             layout.set_markup(more)
             layout.set_alignment(Pango.Alignment.CENTER)

--- a/quodlibet/qltk/x.py
+++ b/quodlibet/qltk/x.py
@@ -231,7 +231,7 @@ def Frame(label, child=None):
     """A Gtk.Frame with no shadow, 12px left padding, and 6px top padding."""
     frame = Gtk.Frame()
     label_w = Gtk.Label()
-    label_w.set_markup("<b>%s</b>" % util.escape(label))
+    label_w.set_markup(util.bold(label))
     align = Align(left=12, top=6)
     frame.add(align)
     frame.set_shadow_type(Gtk.ShadowType.NONE)

--- a/quodlibet/update.py
+++ b/quodlibet/update.py
@@ -22,7 +22,7 @@ from gi.repository import Gtk
 import feedparser
 
 import quodlibet
-from quodlibet import _
+from quodlibet import _, util
 from quodlibet.build import BUILD_TYPE
 from quodlibet.qltk.window import Dialog
 from quodlibet.util.dprint import print_exc
@@ -128,7 +128,7 @@ class UpdateDialog(Dialog):
             version = quodlibet.get_build_version()
 
             def f(v):
-                return "<b>%s</b>" % escape(format_version(v))
+                return util.bold(format_version(v))
 
             if version >= versions[-1]:
                 text = (_("You are already using the newest version "

--- a/quodlibet/util/__init__.py
+++ b/quodlibet/util/__init__.py
@@ -222,6 +222,10 @@ def italic(string: str, escaper: Callable[[str], str] = escape) -> str:
     return "<i>%s</i>" % escaper(string)
 
 
+def bold_italic(string: str, escaper: Callable[[str], str] = escape) -> str:
+    return "<b><i>%s</i></b>" % escaper(string)
+
+
 def parse_time(timestr, err=object()):
     """Parse a time string in hh:mm:ss, mm:ss, or ss format."""
 

--- a/quodlibet/util/__init__.py
+++ b/quodlibet/util/__init__.py
@@ -1,5 +1,5 @@
 # Copyright 2004-2009 Joe Wreschnig, Michael Urman, Steven Robertson
-#           2011-2020 Nick Boultbee
+#           2011-2022 Nick Boultbee
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -15,7 +15,7 @@ import sys
 import unicodedata
 import threading
 import locale
-from typing import Dict, List
+from typing import Dict, List, Callable
 from functools import reduce
 
 # Windows doesn't have fcntl, just don't lock for now
@@ -200,26 +200,26 @@ class OptionParser:
             return transopts, args
 
 
-def escape(str):
+def escape(string: str) -> str:
     """Escape a string in a manner suitable for XML/Pango."""
-    return str.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+    return string.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
 
 
-def unescape(str):
+def unescape(string: str) -> str:
     """Unescape a string in a manner suitable for XML/Pango."""
-    return str.replace("&lt;", "<").replace("&gt;", ">").replace("&amp;", "&")
+    return string.replace("&lt;", "<").replace("&gt;", ">").replace("&amp;", "&")
 
 
-def bold(string):
-    return "<b>%s</b>" % string
+def bold(string: str, escaper: Callable[[str], str] = escape) -> str:
+    return "<b>%s</b>" % escaper(string)
 
 
-def monospace(string):
-    return "<tt>%s</tt>" % string
+def monospace(string: str, escaper: Callable[[str], str] = escape) -> str:
+    return "<tt>%s</tt>" % escaper(string)
 
 
-def italic(string):
-    return "<i>%s</i>" % string
+def italic(string: str, escaper: Callable[[str], str] = escape) -> str:
+    return "<i>%s</i>" % escaper(string)
 
 
 def parse_time(timestr, err=object()):

--- a/quodlibet/util/songwrapper.py
+++ b/quodlibet/util/songwrapper.py
@@ -119,10 +119,10 @@ def check_wrapper_changed(library, songs):
                         dialog = qltk.ErrorMessage(
                             None,
                             _("Unable to edit song"),
-                            _("Saving <b>%s</b> failed. "
+                            _("Saving %s failed. "
                               "The file may be read-only, corrupted, or you "
                               "do not have permission to edit it.") %
-                            util.escape(song('~basename')), escape_desc=False)
+                            util.bold(song('~basename')), escape_desc=False)
                         dialog.run()
                         print_w("Couldn't save song %s (%s)" % (song("~filename"), e))
                     else:

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -199,6 +199,11 @@ class Tpango(TestCase):
         self.assertEqual(util.italic("foo"), "<i>foo</i>")
         self.assertEqual(util.monospace("foo"), "<tt>foo</tt>")
 
+    def test_format_escape(self):
+        assert util.bold("foo & bar") == "<b>foo &amp; bar</b>"
+        assert util.italic("foo & bar") == "<i>foo &amp; bar</i>"
+        assert util.monospace("foo & bar") == "<tt>foo &amp; bar</tt>"
+
 
 class Tre_esc(TestCase):
     def test_empty(self):

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -203,6 +203,7 @@ class Tpango(TestCase):
         assert util.bold("foo & bar") == "<b>foo &amp; bar</b>"
         assert util.italic("foo & bar") == "<i>foo &amp; bar</i>"
         assert util.monospace("foo & bar") == "<tt>foo &amp; bar</tt>"
+        assert util.bold_italic("foo & bar") == "<b><i>foo &amp; bar</i></b>"
 
 
 class Tre_esc(TestCase):


### PR DESCRIPTION
This ended up a lot bigger than expected, but here goes:

* Quite a lot of un-escaped things were happening in Pango contexts, so this now fixes them
* Where they were, `<b>%s</b> % util.escape(foo)` -> `util.bold(foo)` which is much more readable
* Improve usability of the markup helpers (custom escapers can be passed)
* Add a bold + italic helper, even though this maybe isn't theme / HIG / design best choice (TBC). At least it's clearer where it is now...
* Also moves a lot of markup _out_ of translations 
* Fix a couple more over-escaping problems
* Use more f-strings for readability
