### PR TITLE
Fix description of JEP-118 plugin not being translated

### DIFF
--- a/quodlibet/ext/events/jep118.py
+++ b/quodlibet/ext/events/jep118.py
@@ -28,8 +28,10 @@ format = """\
 class JEP118(EventPlugin):
     PLUGIN_ID = "JEP-118"
     PLUGIN_NAME = _("JEP-118")
-    PLUGIN_DESC_MARKUP = _("Outputs a Jabber User Tunes file to %(path)s." %
-                           {"path": util.monospace("~/.quodlibet/jabber")})
+    PLUGIN_DESC_MARKUP = (
+        _("Outputs a Jabber User Tunes file to %(path)s.")
+        % {"path": util.monospace("~/.quodlibet/jabber")}
+    )
     PLUGIN_ICON = Icons.DOCUMENT_SAVE
 
     def plugin_on_song_started(self, song):


### PR DESCRIPTION
What this change is adding / fixing
-----------------------------------
Plugin description appears untranslated even though translation exists.
