### PR TITLE
Add Stop command to Control menu

### DIFF
--- a/quodlibet/qltk/quodlibetwindow.py
+++ b/quodlibet/qltk/quodlibetwindow.py
@@ -424,6 +424,7 @@ MENU = """
       <menuitem action='Previous' always-show-image='true'/>
       <menuitem action='PlayPause' always-show-image='true'/>
       <menuitem action='Next' always-show-image='true'/>
+      <menuitem action='Stop' always-show-image='true'/>
       <menuitem action='StopAfter' always-show-image='true'/>
     </menu>
 
@@ -957,6 +958,11 @@ class QuodLibetWindow(Window, PersistentWindowMixin, AppWindow):
         act.connect('activate', self.__next_song)
         ag.add_action_with_accel(act, "<Primary>period")
 
+        act = Action(name="Stop", label=_("Stop"),
+                     icon_name=Icons.MEDIA_PLAYBACK_STOP)
+        act.connect('activate', self.__stop)
+        ag.add_action(act)
+
         act = ToggleAction(name="StopAfter", label=_("Stop After This Song"))
         ag.add_action_with_accel(act, "<shift>space")
 
@@ -1211,6 +1217,9 @@ class QuodLibetWindow(Window, PersistentWindowMixin, AppWindow):
 
     def __play_pause(self, *args):
         app.player.playpause()
+
+    def __stop(self, *args):
+        app.player.stop()
 
     def __jump_to_current(self, explicit, songlist=None, force_scroll=False):
         """Select/scroll to the current playing song in the playlist.


### PR DESCRIPTION
Check-list
----------

 * [x] There is a linked issue discussing the motivations for this feature or bugfix
   * Might address https://github.com/quodlibet/quodlibet/issues/3969, not sure if a button in the main UI is really needed.
 * [-] Unit tests have been added where possible
   * `tests/test_qltk_quodlibetwindow.py` is currently very barebones, so I figured I'll skip this :wink: 
   * Tested manually, seems to work fine.
 * [-] I've added / updated documentation for any user-facing features.
   * Did a quick search but couldn't find any description of the Control menu.
 * [x] Performance seems to be comparable or better than current `main`


What this change is adding / fixing
-----------------------------------
<!-- A high-level description of the changes.
Hopefully the commits are atomic and well described, but this is the overall
summary of the change, to other developers / maintainers, plus any TODOs. -->

This adds a menu item to fully stop playback, which is currently only available through the CLI, and some other integrations like MPRIS.

**Screenshot:**

![image](https://user-images.githubusercontent.com/6501/204650509-ddd3424a-502b-40e3-94ba-a2eeece20d70.png)