### PR TITLE
Fix regression when calling "Edit saved searches" window

### DIFF
--- a/quodlibet/qltk/cbes.py
+++ b/quodlibet/qltk/cbes.py
@@ -141,7 +141,7 @@ class _KeyValueEditor(qltk.Window):
         row = model[iter]
         content, name = row
         cell.set_property("markup",
-                          util.bold(name) + "\n",
+                          util.bold(name) + "\n" +
                           util.monospace(content))
 
     def __changed(self, entry, buttons):


### PR DESCRIPTION
Check-list
----------

 * [x] Performance seems to be comparable or better than current `main`


What this change is adding / fixing
-----------------------------------
Fix a regression bug introduced in #4188

To reproduce:
- open QL
- in searchbar: "Edit saved searches..."

Returns:
```
TypeError: GObject.set_property() takes exactly 2 arguments (3 given)
------
Traceback (most recent call last):

  File "/usr/local/lib/python3.9/dist-packages/quodlibet/qltk/cbes.py", line 143, in __cdf
    cell.set_property("markup",

TypeError: GObject.set_property() takes exactly 2 arguments (3 given)
```
