### PR TITLE
Fix xgettext warning about 'Invalid tag' plural

### DIFF
--- a/quodlibet/qltk/edittags.py
+++ b/quodlibet/qltk/edittags.py
@@ -796,8 +796,8 @@ class EditTags(Gtk.VBox):
             assert isinstance(value, str)
             if not self._group_info.can_change(tag):
                 title = ngettext("Invalid tag", "Invalid tags", 1)
-                msg = ngettext("Invalid tag %s\n\nThe files currently"
-                        " selected do not support editing this tag.",
+                msg = ngettext("Invalid tag %s\n\nThe files currently "
+                        "selected do not support editing this tag.",
                         "Invalid tags %s\n\nThe files currently "
                         "selected do not support editing these tags.", 1
                         ) % util.bold(tag)
@@ -979,8 +979,8 @@ class EditTags(Gtk.VBox):
         elif not self._group_info.can_change(new_tag):
             # Can't add the new tag.
             title = ngettext("Invalid tag", "Invalid tags", 1)
-            msg = ngettext("Invalid tag %s\n\nThe files currently"
-                    " selected do not support editing this tag.",
+            msg = ngettext("Invalid tag %s\n\nThe files currently "
+                    "selected do not support editing this tag.",
                     "Invalid tags %s\n\nThe files currently "
                     "selected do not support editing these tags.", 1
                     ) % util.bold(new_tag)

--- a/quodlibet/qltk/edittags.py
+++ b/quodlibet/qltk/edittags.py
@@ -11,7 +11,7 @@ from typing import Optional, Type, Sequence
 
 from gi.repository import Gtk, Pango, Gdk
 
-from quodlibet import C_, _, print_e, print_d
+from quodlibet import C_, _, ngettext, print_e, print_d
 from quodlibet import app
 from quodlibet import config
 from quodlibet import qltk
@@ -795,9 +795,11 @@ class EditTags(Gtk.VBox):
             value = massagers.validate(tag, value)
             assert isinstance(value, str)
             if not self._group_info.can_change(tag):
-                title = _("Invalid tag")
-                msg = _("Invalid tag %s\n\nThe files currently"
-                        " selected do not support editing this tag."
+                title = ngettext("Invalid tag", "Invalid tags", 1)
+                msg = ngettext("Invalid tag %s\n\nThe files currently"
+                        " selected do not support editing this tag.",
+                        "Invalid tags %s\n\nThe files currently "
+                        "selected do not support editing these tags.", 1
                         ) % util.bold(tag)
                 qltk.ErrorMessage(self, title, msg).run()
             else:
@@ -976,9 +978,11 @@ class EditTags(Gtk.VBox):
             return
         elif not self._group_info.can_change(new_tag):
             # Can't add the new tag.
-            title = _("Invalid tag")
-            msg = _("Invalid tag %s\n\nThe files currently"
-                    " selected do not support editing this tag."
+            title = ngettext("Invalid tag", "Invalid tags", 1)
+            msg = ngettext("Invalid tag %s\n\nThe files currently"
+                    " selected do not support editing this tag.",
+                    "Invalid tags %s\n\nThe files currently "
+                    "selected do not support editing these tags.", 1
                     ) % util.bold(new_tag)
             qltk.ErrorMessage(self, title, msg, escape_desc=False).run()
         else:

--- a/quodlibet/util/__init__.py
+++ b/quodlibet/util/__init__.py
@@ -36,7 +36,7 @@ from .misc import cached_func, get_module_dir, get_ca_file, \
 from .environment import is_plasma, is_unity, is_enlightenment, \
     is_linux, is_windows, is_wine, is_osx, is_flatpak, matches_flatpak_runtime
 from .enum import enum
-from .i18n import _, C_
+from .i18n import _, ngettext, C_
 
 
 # flake8
@@ -508,7 +508,7 @@ def tag(name, cap=True):
     # Strips ~ and ~# from the start and runs it through a map (which
     # the user can configure).
     if not name:
-        return _("Invalid tag")
+        return ngettext("Invalid tag", "Invalid tags", 1)
     else:
         from quodlibet.util.tags import readable
         parts = map(readable, tagsplit(name))

--- a/quodlibet/util/tags.py
+++ b/quodlibet/util/tags.py
@@ -7,7 +7,7 @@
 # the Free Software Foundation; either version 2 of the License, or
 # (at your option) any later version.
 
-from quodlibet import _
+from quodlibet import _, ngettext
 
 """Database of all known tags, their translations and how they are used"""
 
@@ -241,7 +241,7 @@ def readable(tag, plural=False):
             else:
                 tag = tag[1:]
     except IndexError:
-        return _("Invalid tag")
+        return ngettext("Invalid tag", "Invalid tags", 1)
 
     def desc(tag):
         if plural:


### PR DESCRIPTION
Check-list
----------

 * [x] Performance seems to be comparable or better than current `main`


What this change is adding / fixing
-----------------------------------
During build I get this warning:
```
/home/user/src/quodlibet/gdist/gettextutil.py:164: GettextWarning: xgettext: WARNING : msgid 'Invalid tag' is used without plural and with plural.
                          quodlibet/qltk/edittags.py:798: Here is the occurrence without plural.
                          quodlibet/qltk/tagsfrompath.py:211: Here is the occurrence with plural.
                          Workaround: If the msgid is a sentence, change the wording of the sentence; otherwise, use contexts for disambiguation.
xgettext: WARNING : msgid 'Invalid tag %s
                          
                          The files currently selected do not support editing this tag.' is used without plural and with plural.
                          quodlibet/qltk/edittags.py:799: Here is the occurrence without plural.
                          quodlibet/qltk/tagsfrompath.py:212: Here is the occurrence with plural.
                          Workaround: If the msgid is a sentence, change the wording of the sentence; otherwise, use contexts for disambiguation.
xgettext: WARNING : msgid 'Invalid tag' is used without plural and with plural.
                          quodlibet/util/__init__.py:511: Here is the occurrence without plural.
                          quodlibet/qltk/edittags.py:798: Here is the occurrence with plural.
                          Workaround: If the msgid is a sentence, change the wording of the sentence; otherwise, use contexts for disambiguation.
xgettext: WARNING : msgid 'Invalid tag' is used without plural and with plural.
                          quodlibet/util/tags.py:244: Here is the occurrence without plural.
                          quodlibet/qltk/edittags.py:798: Here is the occurrence with plural.
                          Workaround: If the msgid is a sentence, change the wording of the sentence; otherwise, use contexts for disambiguation.

  warnings.warn(stderr, GettextWarning)
```

This patch fixes it with a pluralized string forced to 1 element (maybe not on the cleanest way, check it...)
