### PR TITLE
Re-add newline in Album List sidebar header

### DIFF
--- a/quodlibet/browsers/albums/main.py
+++ b/quodlibet/browsers/albums/main.py
@@ -543,7 +543,7 @@ class AlbumList(Browser, util.InstanceTracker, VisibleUpdate,
             album = model.get_album(iter_)
 
             if album is None:
-                text = util.bold(_("All Albums"))
+                text = util.bold(_("All Albums")) + "\n"
                 text += numeric_phrase("%d album", "%d albums", len(model) - 1)
                 markup = text
             else:


### PR DESCRIPTION
Check-list
----------

 * bug: https://github.com/quodlibet/quodlibet/issues/4232
 * [n/a] Unit tests have been added where possible
 * [n/a ] I've added / updated documentation for any user-facing features.
 * [ x] Performance seems to be comparable or better than current `main`


What this change is adding / fixing
-----------------------------------
The newline was lost with the changes in the last commit. Without the newline the sidebar displays as

All Albums1 album

instead of on two lines

All Albums
1 album


***

I know only enough python to be dangerous. This fixes it for me in my local version on Ubuntu 22.10. But there may be a better way to do this!