### PR TITLE
Remove leftover `util.path.expanduser`

### DIFF
--- a/quodlibet/cli.py
+++ b/quodlibet/cli.py
@@ -251,14 +251,14 @@ def process_arguments(argv):
                     filename = uri2fsn(arg)
                 except ValueError:
                     filename = arg
-                filename = os.path.abspath(util.path.expanduser(arg))
+                filename = os.path.abspath(os.path.expanduser(arg))
                 queue("play-file", filename)
         elif command == 'add-location':
             try:
                 path = uri2fsn(arg)
             except ValueError:
                 path = arg
-            path = os.path.abspath(util.path.expanduser(arg))
+            path = os.path.abspath(os.path.expanduser(arg))
             queue("add-location", path)
         elif command == "print-playing":
             try:


### PR DESCRIPTION
The helpers were removed in 0cd37f779b0a8c9caf1f7d42041c7715e2a63fd6 in favor of Python 3 stdlib.

Fixes #4240

Check-list
----------

 * [x] There is a linked issue discussing the motivations for this feature or bugfix
 * [ ] Unit tests have been added where possible
 * [ ] I've added / updated documentation for any user-facing features.
 * [ ] Performance seems to be comparable or better than current `main`


What this change is adding / fixing
-----------------------------------
<!-- A high-level description of the changes.
Hopefully the commits are atomic and well described, but this is the overall
summary of the change, to other developers / maintainers, plus any TODOs. -->

This changes to use `os.path.expanduser` in favor of `expanduser` helper from `senf` as it was removed in 0cd37f779b0a8c9caf1f7d42041c7715e2a63fd6. These two cases were leftover.