### PR TITLE
scrollbar_always_visible as boolean

### DIFF
--- a/quodlibet/ext/events/advanced_preferences.py
+++ b/quodlibet/ext/events/advanced_preferences.py
@@ -180,7 +180,7 @@ class AdvancedPreferences(EventPlugin):
                 "settings", "datecolumn_timestamp_format",
                 "DateColumn timestamp format:",
                 "A timestamp format, e.g. %Y%m%d %X"),
-            text_config(
+            boolean_config(
                 "settings", "scrollbar_always_visible",
                 "Scrollbars always visible:",
                 ("Toggles whether the scrollbars on the bottom and side of "


### PR DESCRIPTION
Check-list
----------

 * [ ] There is a linked issue discussing the motivations for this feature or bugfix
 * [ ] Unit tests have been added where possible
 * [ ] I've added / updated documentation for any user-facing features.
 * [X] Performance seems to be comparable or better than current `main`


What this change is adding / fixing
-----------------------------------
Turn `scrollbar_always_visible` parameter to boolean checkbox, as it's a boolean config parameter. Currently it's a text field containing true/false.

![screenshot_20230124-140214](https://user-images.githubusercontent.com/33821/214298672-69f4d3a2-bb82-408a-b873-bcb4755a8cf4.png)

