### PR TITLE
Merge advanced prefs

### DIFF
--- a/docs/guide/stats_rating.rst
+++ b/docs/guide/stats_rating.rst
@@ -9,7 +9,7 @@ Play Count
 The internal ``~#playcount`` tag is incremented when a song ends
 or is forced to end by the user, and the playback time has exceeded
 a certain proportion of the song's duration. This proportion is
-configurable in the config file or with the *Advanced Preferences* plugin.
+configurable in the config file or in the advanced preferences pane.
 
 In case of radio streams, which don't have a defined duration, the play
 count gets incremented whenever the stream is played.

--- a/quodlibet/qltk/advanced_prefs.py
+++ b/quodlibet/qltk/advanced_prefs.py
@@ -35,6 +35,7 @@ def _config(section, option, label, tooltip=None, getter=None):
     revert.add(Gtk.Image.new_from_icon_name(
         Icons.DOCUMENT_REVERT, Gtk.IconSize.BUTTON))
     revert.connect("clicked", on_reverted)
+    revert.set_tooltip_text(_("Revert to default"))
 
     lbl = Gtk.Label(label=label, use_underline=True)
     lbl.set_mnemonic_widget(entry)

--- a/quodlibet/qltk/advanced_prefs.py
+++ b/quodlibet/qltk/advanced_prefs.py
@@ -255,8 +255,8 @@ class AdvancedPreferencesPane():
         help_text.set_text(_("Allow editing of advanced config settings."))
         button = Gtk.Button(label=_("I know what I'm doing"), use_underline=True)
         button.connect("clicked", on_click)
-        vb.pack_start(help_text, True, True, 12)
-        vb.pack_start(button, True, True, 0)
+        vb.pack_start(help_text, False, True, 12)
+        vb.pack_start(button, False, True, 0)
         vb.pack_start(table, True, True, 0)
         table.set_no_show_all(True)
 

--- a/quodlibet/qltk/advanced_prefs.py
+++ b/quodlibet/qltk/advanced_prefs.py
@@ -1,7 +1,7 @@
 # Copyright 2015    Christoph Reiter
 #           2016-22 Nick Boultbee
 #           2019    Peter Strulo
-#           2022    Jej@github
+#           2022-23 Jej@github
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -15,7 +15,6 @@ from quodlibet import config
 from quodlibet.qltk.entry import UndoEntry
 from quodlibet.qltk import Icons
 from quodlibet.util.string import decode
-from quodlibet.plugins.events import EventPlugin
 
 
 def _config(section, option, label, tooltip=None, getter=None):
@@ -114,17 +113,9 @@ def slider_config(section, option, label, tooltip, lower=0, upper=1,
     return lbl, scale, revert
 
 
-class AdvancedPreferences(EventPlugin):
-    PLUGIN_ID = "Advanced Preferences"
-    PLUGIN_NAME = _("Advanced Preferences")
-    PLUGIN_DESC = _("Allow editing of advanced config settings.")
-    PLUGIN_CAN_ENABLE = False
-    PLUGIN_ICON = Icons.PREFERENCES_SYSTEM
+class AdvancedPreferencesPane():
 
-    def __init_defaults(self):
-        self.__enabled = False
-
-    def PluginPreferences(self, *args):
+    def create_display_frame(self, *args):
         def changed(entry, name, section="settings"):
             config.set(section, name, entry.get_text())
 
@@ -259,8 +250,11 @@ class AdvancedPreferences(EventPlugin):
             table.set_no_show_all(False)
             table.show_all()
 
+        help_text = Gtk.Label()
+        help_text.set_text(_("Allow editing of advanced config settings."))
         button = Gtk.Button(label=_("I know what I'm doing"), use_underline=True)
         button.connect("clicked", on_click)
+        vb.pack_start(help_text, True, True, 12)
         vb.pack_start(button, True, True, 0)
         vb.pack_start(table, True, True, 0)
         table.set_no_show_all(True)

--- a/quodlibet/qltk/prefs.py
+++ b/quodlibet/qltk/prefs.py
@@ -3,6 +3,7 @@
 #           2011-2022 Nick Boultbee
 #           2013      Christoph Reiter
 #           2014      Jan Path
+#           2023      Jej@github
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -27,6 +28,7 @@ from quodlibet.qltk.maskedbox import MaskedBox
 from quodlibet.qltk.songlist import SongList, get_columns
 from quodlibet.qltk.window import UniqueWindow
 from quodlibet.qltk.x import Button, Align
+from quodlibet.qltk.advanced_prefs import AdvancedPreferencesPane
 from quodlibet.qltk import Icons, add_css
 from quodlibet.util import copool, format_time_preferred
 from quodlibet.util.dprint import print_d
@@ -733,6 +735,18 @@ class PreferencesWindow(UniqueWindow):
             f = qltk.Frame(_("Scan Directories"), child=vb)
             return f
 
+    class Advanced(Gtk.VBox):
+        name = "advanced"
+
+        def __init__(self):
+            super().__init__(spacing=MARGIN)
+            self.set_border_width(12)
+            self.title = _("Advanced")
+
+            advanced_pane = AdvancedPreferencesPane()
+            vb = advanced_pane.create_display_frame()
+            self.pack_start(vb, False, True, MARGIN)
+
     def __init__(self, parent, open_page=None, all_pages=True):
         if self.is_not_unique():
             return
@@ -746,7 +760,8 @@ class PreferencesWindow(UniqueWindow):
         add_css(notebook, "tab { padding: 6px 24px } ")
         pages = [self.Tagging]
         if all_pages:
-            pages = [self.SongList, self.Browsers, self.Player, self.Library] + pages
+            pages = [self.SongList, self.Browsers, self.Player,
+                        self.Library] + pages + [self.Advanced]
         for Page in pages:
             page = Page()
             page.show()

--- a/quodlibet/qltk/prefs.py
+++ b/quodlibet/qltk/prefs.py
@@ -744,8 +744,14 @@ class PreferencesWindow(UniqueWindow):
             self.title = _("Advanced")
 
             advanced_pane = AdvancedPreferencesPane()
-            vb = advanced_pane.create_display_frame()
-            self.pack_start(vb, False, True, MARGIN)
+            vbox = advanced_pane.create_display_frame()
+
+            scrolledwin = Gtk.ScrolledWindow()
+            scrolledwin.set_policy(Gtk.PolicyType.AUTOMATIC,
+                                Gtk.PolicyType.AUTOMATIC)
+            scrolledwin.add_with_viewport(vbox)
+
+            self.pack_start(scrolledwin, True, True, MARGIN)
 
     def __init__(self, parent, open_page=None, all_pages=True):
         if self.is_not_unique():


### PR DESCRIPTION
Check-list
----------

 * [X] I've added / updated documentation for any user-facing features.
 * [X] Performance seems to be comparable or better than current `main`


What this change is adding / fixing
-----------------------------------
I am always confused about the advanced preferences being in a separate plugin settings pane. It's a lot of clicks to access it. I expect advanced preferences are in the preferences, like most of software. Maybe at the early beginning of QL development it had a sens, but now I think it's better to have these preferences in the core.

This pull request merge the advanced prefs plugin in the prefs pane. It adds also a tooltip on the revert button.

![screenshot_20230124-152703](https://user-images.githubusercontent.com/33821/214322734-175d6f14-f7b3-4b7b-8c8d-2e95a2f3583a.png)

![screenshot_20230124-160325](https://user-images.githubusercontent.com/33821/214329977-68bed20e-509c-46f9-ac5d-d23bf6234d76.png)

I renamed `advanced_preferences.py` (plugin file) to `advanced_prefs.py`, to have a better filename consistency regarding the current `prefs.py` filename.

Hope you like this big change!

