### PR TITLE
Allow disabling of songlist sorting

### DIFF
--- a/quodlibet/config.py
+++ b/quodlibet/config.py
@@ -112,6 +112,9 @@ INITIAL: Dict[str, Dict[str, str]] = {
     "song_list": {
         # Automatically re-sort song list when tags are modified
         "auto_sort": "true",
+
+        # Make all browsers sortable even
+        "always_allow_sorting": "true"
     },
 
     "browsers": {

--- a/quodlibet/qltk/browser.py
+++ b/quodlibet/qltk/browser.py
@@ -1,5 +1,5 @@
 # Copyright 2005 Joe Wreschnig, Michael Urman
-#           2016 Nick Boultbee
+#        2016-23 Nick Boultbee
 #           2018 Peter Strulo
 #
 # This program is free software; you can redistribute it and/or modify
@@ -317,6 +317,7 @@ class LibraryBrowser(Window, util.InstanceTracker, PersistentWindowMixin):
                 songs = list(filter(bg, songs))
         print_d(f"Setting {len(songs)} songs...")
         self.songlist.set_songs(songs, sorted)
+        self.songlist.sortable = browser.can_reorder
 
     def __enqueue(self, view, path, column, player):
         app.window.playlist.enqueue([view.get_model()[path][0]])

--- a/quodlibet/qltk/prefs.py
+++ b/quodlibet/qltk/prefs.py
@@ -69,11 +69,20 @@ class PreferencesWindow(UniqueWindow):
                                  'settings', 'jump', populate=True,
                                  tooltip=_("When the playing song changes, "
                                            "scroll to it in the song list"))
-                autosort_button = CS(_("Sort songs when tags are modified"),
+                autosort_button = CS(_("_Sort songs when tags are modified"),
                                      'song_list', 'auto_sort', populate=True,
                                      tooltip=_("Automatically re-sort songs in "
                                                "the song list when tags are modified"))
+                always_sortable = CS(_("Always allow sorting"),
+                                     'song_list', 'always_allow_sorting', populate=True,
+                                     tooltip=_("Allow sorting by column headers, "
+                                               "even for playlists etc"))
+
+                def refresh_browser(*args):
+                    app.window.set_sortability()
+                always_sortable.connect("notify::active", refresh_browser)
                 vbox.pack_start(jump_button, False, True, 0)
+                vbox.pack_start(always_sortable, False, True, 0)
                 vbox.pack_start(autosort_button, False, True, 0)
                 return qltk.Frame(_("Behavior"), child=vbox)
 

--- a/quodlibet/qltk/queue.py
+++ b/quodlibet/qltk/queue.py
@@ -1,5 +1,5 @@
 # Copyright 2004-2005 Joe Wreschnig, Michael Urman, Iñigo Serna
-#           2016-2021 Nick Boultbee
+#           2016-2023 Nick Boultbee
 #                2017 Fredrik Strupe
 #
 # This program is free software; you can redistribute it and/or modify
@@ -378,14 +378,13 @@ class QueueModel(PlaylistModel):
 
 class PlayQueue(SongList):
 
-    sortable = False
     _activated = False
     _MAX_PENDING = 5
     """Maximum number of queue items to leave unpersisted (batching)"""
 
     def __init__(self, library: Library, player: BasePlayer,
                  autosave_interval_secs: Optional[int] = None):
-        super().__init__(library, player, model_cls=QueueModel)
+        super().__init__(library, player, model_cls=QueueModel, sortable=False)
         self._updated_time = time.time()
         self.autosave_interval = autosave_interval_secs
         self._pending = 0

--- a/quodlibet/qltk/quodlibetwindow.py
+++ b/quodlibet/qltk/quodlibetwindow.py
@@ -1,6 +1,6 @@
 # Copyright 2004-2005 Joe Wreschnig, Michael Urman, Iñigo Serna
 #           2012 Christoph Reiter
-#           2012-2022 Nick Boultbee
+#           2012-2023 Nick Boultbee
 #           2017 Uriel Zajaczkovski
 #
 # This program is free software; you can redistribute it and/or modify
@@ -1134,7 +1134,7 @@ class QuodLibetWindow(Window, PersistentWindowMixin, AppWindow):
             self.songlist.disable_drop()
         if self.browser.accelerators:
             self.add_accel_group(self.browser.accelerators)
-
+        self.set_sortability()
         container = self.browser.__container = self.browser.pack(self.songpane)
 
         # Reset the cursor when done loading the browser
@@ -1147,6 +1147,11 @@ class QuodLibetWindow(Window, PersistentWindowMixin, AppWindow):
         container.show()
         self._filter_menu.set_browser(self.browser)
         self.__hide_headers()
+
+    def set_sortability(self):
+        # It's either sortable or clickable columns, both ends in a buggy UI (see #4099)
+        always_sortable = config.getboolean("song_list", "always_allow_sorting")
+        self.songlist.sortable = not self.browser.can_reorder or always_sortable
 
     def __update_paused(self, player, paused):
         menu = self.ui.get_widget("/Menu/Control/PlayPause")

--- a/quodlibet/qltk/songlist.py
+++ b/quodlibet/qltk/songlist.py
@@ -419,7 +419,7 @@ class SongList(AllTreeView, SongListDnDMixin, DragScroll, util.InstanceTracker):
         self._first_column = None
         # A priority list of how to apply the sort keys.
         # might contain column header names not present...
-        self._sort_sequence = []
+        self._sort_sequence: List[str] = []
         self.set_column_headers(self.headers)
         librarian = library.librarian or library
 

--- a/quodlibet/qltk/songlist.py
+++ b/quodlibet/qltk/songlist.py
@@ -1,7 +1,7 @@
 # Copyright 2005 Joe Wreschnig
 #           2012 Christoph Reiter
 #           2014 Jan Path
-#      2011-2022 Nick Boultbee
+#      2011-2023 Nick Boultbee
 #           2018 David Morris
 #
 # This program is free software; you can redistribute it and/or modify
@@ -376,7 +376,6 @@ class SongList(AllTreeView, SongListDnDMixin, DragScroll, util.InstanceTracker):
     """The list of current headers."""
 
     star = list(Query.STAR)
-    sortable = True
 
     def Menu(self, header, browser, library):
         songs = self.get_selected_songs()
@@ -405,8 +404,10 @@ class SongList(AllTreeView, SongListDnDMixin, DragScroll, util.InstanceTracker):
         menu.show_all()
         return menu
 
-    def __init__(self, library, player=None, update=False, model_cls=PlaylistModel):
+    def __init__(self, library, player=None, update=False, model_cls=PlaylistModel,
+                 sortable: bool = True):
         super().__init__()
+        self._sortable = sortable
         self._register_instance(SongList)
         self.set_model(model_cls())
         self.info = SongSelectionInfo(self)
@@ -442,6 +443,16 @@ class SongList(AllTreeView, SongListDnDMixin, DragScroll, util.InstanceTracker):
         self.set_search_equal_func(self.__search_func, None)
 
         self.connect('destroy', self.__destroy)
+
+    @property
+    def sortable(self) -> bool:
+        """Whether the columns clicked to enable sorting of songs"""
+        return self._sortable
+
+    @sortable.setter
+    def sortable(self, value: bool):
+        self._sortable = value
+        self.set_headers_clickable(value)
 
     @property
     def model(self) -> Gtk.TreeModel:


### PR DESCRIPTION
* Primarily for playlist use-case
* When false, the new config setting will disallow clicking on songlists in browsers that aren't `can_reorder`
* Add a prefs config switch to control this
* Defaults to current behaviour

This fixes #4099
