### PR TITLE
Add human time tags

### DIFF
--- a/quodlibet/ext/events/advanced_preferences.py
+++ b/quodlibet/ext/events/advanced_preferences.py
@@ -178,8 +178,8 @@ class AdvancedPreferences(EventPlugin):
                  "(restart required)")),
             text_config(
                 "settings", "datecolumn_timestamp_format",
-                "DateColumn timestamp format:",
-                "A timestamp format, e.g. %Y%m%d %X"),
+                "Timestamp date format:",
+                "A timestamp format for dates, e.g. %Y%m%d %X (restart required)"),
             boolean_config(
                 "settings", "scrollbar_always_visible",
                 "Scrollbars always visible:",

--- a/quodlibet/formats/_audio.py
+++ b/quodlibet/formats/_audio.py
@@ -55,6 +55,8 @@ PEOPLE = ["artist", "albumartist", "author", "composer", "~performers",
 TIME_TAGS = {"~#lastplayed", "~#laststarted", "~#added", "~#mtime"}
 """Time in seconds since epoch, defaults to 0"""
 
+HUMAN_TO_NUMERIC_TIME_TAGS = {t.replace("~#", "~"): t for t in TIME_TAGS}
+
 DURATION_TAGS = {"~#length"}
 """Duration in seconds"""
 
@@ -148,6 +150,9 @@ class AudioFile(dict, ImageContainer, HasKey):
 
     mimes: List[str] = []
     """MIME types this class can represent"""
+
+    # Faster than per-call
+    date_format = config.gettext("settings", "datecolumn_timestamp_format")
 
     def __init__(self, default=tuple(), **kwargs):
         for key, value in dict(default).items():
@@ -500,6 +505,9 @@ class AudioFile(dict, ImageContainer, HasKey):
                     return round(float(val.split(" ")[0]), 2)
                 except (ValueError, TypeError, AttributeError):
                     return default
+            elif real_key in HUMAN_TO_NUMERIC_TIME_TAGS:
+                time_value = self.get(HUMAN_TO_NUMERIC_TIME_TAGS[real_key], 0)
+                return format_date(time_value, self.date_format)
             elif key[:1] == "#":
                 key = "~" + key
                 if key in self:
@@ -621,7 +629,7 @@ class AudioFile(dict, ImageContainer, HasKey):
             return expanded
 
         def sanitise(sep, parts):
-            """Return a santisied version of a path's parts"""
+            """Return a sanitised version of a path's parts"""
             return sep.join(part.replace(os.path.sep, u'')[:128] for part in parts)
 
         # setup defaults (user-defined take precedence)

--- a/quodlibet/util/string/date.py
+++ b/quodlibet/util/string/date.py
@@ -14,7 +14,7 @@ def format_date(seconds: float, format_setting: Optional[Text] = None) -> Text:
     try:
         date = datetime.fromtimestamp(seconds).date()
     except (OverflowError, ValueError, OSError):
-        text = u""
+        text = ""
     else:
         if format_setting:
             format_ = format_setting

--- a/quodlibet/util/string/date.py
+++ b/quodlibet/util/string/date.py
@@ -14,7 +14,7 @@ def format_date(seconds: float, format_setting: Optional[Text] = None) -> Text:
     try:
         date = datetime.fromtimestamp(seconds).date()
     except (OverflowError, ValueError, OSError):
-        text = ""
+        text = u""
     else:
         if format_setting:
             format_ = format_setting

--- a/tests/test_formats__audio.py
+++ b/tests/test_formats__audio.py
@@ -7,16 +7,18 @@
 import io
 import os
 import shutil
+import time
 from contextlib import contextmanager
 from tempfile import mkstemp, mkdtemp
 
 from quodlibet import config, app
 from quodlibet.formats import AudioFile, types as format_types, AudioFileError
 from quodlibet.formats import decode_value, MusicFile, FILESYSTEM_TAGS
-from quodlibet.formats._audio import NUMERIC_ZERO_DEFAULT
+from quodlibet.formats._audio import NUMERIC_ZERO_DEFAULT, TIME_TAGS
 from quodlibet.util.environment import is_windows
 from quodlibet.util.path import (normalize_path, mkdir, get_home_dir, unquote,
                                  escape_filename, RootPathFile)
+from quodlibet.util.string.date import format_date
 from quodlibet.util.tags import _TAGS as TAGS
 from senf import fsnative, fsn2text, bytes2fsn
 from tests import TestCase, get_data_path, init_fake_app, destroy_fake_app
@@ -1167,3 +1169,12 @@ class Treplay_gain(TestCase):
             self.failUnlessAlmostEqual(
                 val, exp, places=5,
                 msg="%s should be %s not %s" % (key, exp, val))
+
+    def test_human_time_tags(self):
+        now = int(time.time())
+        tags = {t: now for t in TIME_TAGS}
+        tags["~filename"] = "/dev/null"
+        af = AudioFile(tags)
+        for t in TIME_TAGS:
+            assert af(t) == now, "Numeric dates broken"
+            assert af(t.replace("~#", "~")) == format_date(now), "Human date broken"


### PR DESCRIPTION
 * e.g. `~lastplayed` and `~added`
 * These use a human formatter (as configured for columns) to display a human-friendly version of the numeric tags.
 * Also use a variable for the full key, rather than reconstructing it in many places

 Fixes #4263
