### PR TITLE
docs: correct formatting

### DIFF
--- a/docs/guide/tags/tags.rst
+++ b/docs/guide/tags/tags.rst
@@ -34,10 +34,10 @@ Programmatic Tags
 -----------------
 
 A programmatic tag is one typically added by either Quod Libet / Ex Falso or
- another program and not designed for human consumption. Examples are
- ``replaygain_track_gain`` or ``musicbrainz_albumid``. Note that to see
- these, you must turn on "Show programmatic tags" in the relevant
- preferences window.
+another program and not designed for human consumption. Examples are
+``replaygain_track_gain`` or ``musicbrainz_albumid``. Note that to see
+these, you must turn on "Show programmatic tags" in the relevant
+preferences window.
 
 
 Internal Tags


### PR DESCRIPTION
Some extraneous whitespace had made it into the "Programmatic Tags" section and was causing the formatting to go slightly wrong.  Remove the whitespace, get better formatting.

Check-list
----------

 * [ ] There is a linked issue discussing the motivations for this feature or bugfix
 * [x] Unit tests have been added where possible
 * [x] I've added / updated documentation for any user-facing features.
 * [x] Performance seems to be comparable or better than current `main`


What this change is adding / fixing
-----------------------------------

This is a very minor doc formatting fix. I've not created a separate issue, as it doesn't seem worthwhile for what's hopefully a very obviously correct change, but let me know if that's not the case :)
