### PR TITLE
CI: install test dependencies in a venv in flatpak

### DIFF
--- a/.ci/flatpak-test.sh
+++ b/.ci/flatpak-test.sh
@@ -5,8 +5,10 @@ set -e
 DIR="$( cd "$( dirname "$0" )" && pwd )"
 
 if [[ $1 == "inflatpak" ]]; then
-    python3 -m pip install --user pytest flake8==5.0.4 flaky
-    python3 setup.py test
+    tmp="$(mktemp -d)"
+    python3 -m venv --system-site-packages "$tmp"
+    "$tmp"/bin/python3 -m pip install pytest flake8==5.0.4 flaky
+    "$tmp"/bin/python3 setup.py test
 else
     xvfb-run -a flatpak run --devel --user --command="bash" io.github.quodlibet.QuodLibet "${DIR}"/flatpak-test.sh inflatpak
 fi


### PR DESCRIPTION
pip install in newer GNOME runtimes is broken and doesn't install packages in a location where python looks for then. So use a venv with system-site-packages instead.

That's less hacky anyway.