### PR TITLE
Update _id3.py

### DIFF
--- a/quodlibet/formats/_id3.py
+++ b/quodlibet/formats/_id3.py
@@ -58,6 +58,7 @@ class ID3File(AudioFile):
            "TBPM": "bpm",
            "TDRC": "date",
            "TDOR": "originaldate",
+           "TDRL": "releasedate",
            "TOAL": "originalalbum",
            "TOPE": "originalartist",
            "WOAR": "website",


### PR DESCRIPTION
What this change is adding / fixing
-----------------------------------
Tiny change: missing `TDRL` frame in the id3 tag mapping. See: https://github.com/quodlibet/mutagen/blob/2115107ee5d4a1480ecb139723f88ee3b84ed521/mutagen/id3/_frames.py#L690