### PR TITLE
OSX: Fix unknown variable problem in bundle script clean

### DIFF
--- a/dev-utils/osx_bundle/bundle.sh
+++ b/dev-utils/osx_bundle/bundle.sh
@@ -39,9 +39,9 @@ function main {
     find "$APP_PREFIX"/lib/"$PYTHONID" -name '*.whl' -delete
     rm -Rf "$APP_PREFIX"/lib/"$PYTHONID"/*/test
     rm -Rf "${APP_PREFIX}"/lib/"${PYTHONID}"/test
-    find "${APP_PREFIX}"/lib/"${PYTHON_ID}" -type d -name "test*" \
+    find "${APP_PREFIX}"/lib/"${PYTHONID}" -type d -name "test*" \
         -prune -exec rm -rf {} \;
-    find "${APP_PREFIX}"/lib/"${PYTHON_ID}" -type d -name "*_test*" \
+    find "${APP_PREFIX}"/lib/"${PYTHONID}" -type d -name "*_test*" \
         -prune -exec rm -rf {} \;
 
     # remove some larger icon theme files


### PR DESCRIPTION
At least, it *seems* like an unknown variable...

Extracted from #4304, as it seems more like a genuine bug
