### PR TITLE
Fix Poetry lock and check in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -162,6 +162,11 @@ jobs:
         pipx install poetry
         pipx ensurepath
 
+    - name: Check Poetry project
+      run: |
+        poetry check
+        poetry lock --check
+
     - name: Install project virtualenv
       run: poetry install -E plugins
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -287,7 +287,7 @@ name = "paho-mqtt"
 version = "1.6.1"
 description = "MQTT version 5.0/3.1.1 client class"
 category = "main"
-optional = false
+optional = true
 python-versions = "*"
 
 [package.extras]
@@ -714,12 +714,12 @@ docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "rst.linker
 testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more-itertools", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)"]
 
 [extras]
-plugins = ["musicbrainzngs", "dbus-python", "soco", "pypresence"]
+plugins = ["musicbrainzngs", "dbus-python", "paho-mqtt", "soco", "pypresence"]
 
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8.1"
-content-hash = "25372349afab86695ff859705a0701706136bf7811a6d35ad9e5d9a5564961b2"
+content-hash = "37dd23590db029200c52cc86ff7b45269a1ee0c9c3c0d2da531d298ce5cc1dc6"
 
 [metadata.files]
 alabaster = [

--- a/poetry.lock
+++ b/poetry.lock
@@ -283,6 +283,17 @@ optional = false
 python-versions = ">=3.7"
 
 [[package]]
+name = "paho-mqtt"
+version = "1.6.1"
+description = "MQTT version 5.0/3.1.1 client class"
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.extras]
+proxy = ["PySocks"]
+
+[[package]]
 name = "pluggy"
 version = "1.0.0"
 description = "plugin and hook calling mechanisms for python"
@@ -708,7 +719,7 @@ plugins = ["musicbrainzngs", "dbus-python", "soco", "pypresence"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8.1"
-content-hash = "4379f26be79380abc94a19092dc5b81090af8f91d36bdb3a28d820a117b4dbd1"
+content-hash = "25372349afab86695ff859705a0701706136bf7811a6d35ad9e5d9a5564961b2"
 
 [metadata.files]
 alabaster = [
@@ -1015,6 +1026,9 @@ mypy-extensions = [
 packaging = [
     {file = "packaging-23.0-py3-none-any.whl", hash = "sha256:714ac14496c3e68c99c29b00845f7a2b85f3bb6f1078fd9f72fd20f0570002b2"},
     {file = "packaging-23.0.tar.gz", hash = "sha256:b6ad297f8907de0fa2fe1ccbd26fdaf387f5f47c7275fedf8cce89f99446cf97"},
+]
+paho-mqtt = [
+    {file = "paho-mqtt-1.6.1.tar.gz", hash = "sha256:2a8291c81623aec00372b5a85558a372c747cbca8e9934dfe218638b8eefc26f"},
 ]
 pluggy = [
     {file = "pluggy-1.0.0-py2.py3-none-any.whl", hash = "sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -708,7 +708,7 @@ plugins = ["musicbrainzngs", "dbus-python", "soco", "pypresence"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8.1"
-content-hash = "dc066a48a88bb57b407576b48554dc73cf59e1f60cee127fefaf3a4595ad946b"
+content-hash = "4379f26be79380abc94a19092dc5b81090af8f91d36bdb3a28d820a117b4dbd1"
 
 [metadata.files]
 alabaster = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dbus-python = { version = "*", platform="linux", optional = true }
 # 0.28 switched to lxml which is proving tricky on Windows
 soco = { version = ">=0.27, <0.28", optional = true }
 pypresence = { version = "^4.2.1", optional = true }
+paho-mqtt = { version = "^1.6.1", optional = true }
 
 [tool.poetry.extras]
 # Use with poetry install -E plugins


### PR DESCRIPTION
 * It had become outdated again and was warning in CI / locally:
  ![image](https://github.com/quodlibet/quodlibet/assets/3322808/a431ec07-3d8b-4bf4-938a-8648815b2676)

 * Add a CI job to check this to stop it happening again
 * Also fix missing `paho-mqtt` dependency for plugins that the (other) check job found 