### PR TITLE
Fix songlist sortability

### DIFF
--- a/quodlibet/qltk/browser.py
+++ b/quodlibet/qltk/browser.py
@@ -256,6 +256,7 @@ class LibraryBrowser(Window, util.InstanceTracker, PersistentWindowMixin):
         view = SongList(library, update=True)
         view.info.connect("changed", self.__set_totals)
         self.songlist = view
+        self.songlist.sortable = not Kind.can_reorder
 
         sw = ScrolledWindow()
         sw.set_shadow_type(Gtk.ShadowType.IN)
@@ -317,7 +318,6 @@ class LibraryBrowser(Window, util.InstanceTracker, PersistentWindowMixin):
                 songs = list(filter(bg, songs))
         print_d(f"Setting {len(songs)} songs...")
         self.songlist.set_songs(songs, sorted)
-        self.songlist.sortable = browser.can_reorder
 
     def __enqueue(self, view, path, column, player):
         app.window.playlist.enqueue([view.get_model()[path][0]])

--- a/quodlibet/qltk/quodlibetwindow.py
+++ b/quodlibet/qltk/quodlibetwindow.py
@@ -1155,9 +1155,7 @@ class QuodLibetWindow(Window, PersistentWindowMixin, AppWindow):
         self.__hide_headers()
 
     def set_sortability(self):
-        # It's either sortable or clickable columns, both ends in a buggy UI (see #4099)
-        always_sortable = config.getboolean("song_list", "always_allow_sorting")
-        self.songlist.sortable = not self.browser.can_reorder or always_sortable
+        self.songlist.sortable = not self.browser.can_reorder
 
     def __update_paused(self, player, paused):
         menu = self.ui.get_widget("/Menu/Control/PlayPause")

--- a/quodlibet/qltk/songlist.py
+++ b/quodlibet/qltk/songlist.py
@@ -451,7 +451,9 @@ class SongList(AllTreeView, SongListDnDMixin, DragScroll, util.InstanceTracker):
 
     @sortable.setter
     def sortable(self, value: bool):
-        self._sortable = value
+        # It's either sortable or clickable columns, both ends in a buggy UI (see #4099)
+        always_sortable = config.getboolean("song_list", "always_allow_sorting")
+        self._sortable = value or always_sortable
         self.set_headers_clickable(value)
 
     @property

--- a/tests/test_qltk_songlist.py
+++ b/tests/test_qltk_songlist.py
@@ -103,12 +103,22 @@ class TSongList(TestCase):
         self.assertFalse(s.get_sort_orders())
 
     def test_not_sortable(self):
+        config.set("song_list", "always_allow_sorting", False)
         s = self.songlist
         s.sortable = False
         s.set_column_headers(["foo"])
         s.toggle_column_sort(s.get_columns()[0])
-        self.assertEqual(self.orders_changed, 0)
-        self.assertFalse(s.get_sort_orders())
+        assert self.orders_changed == 0
+        assert not s.get_sort_orders()
+
+    def test_sortable_if_config_overrides(self):
+        config.set("song_list", "always_allow_sorting", True)
+        s = self.songlist
+        s.sortable = False
+        assert s.sortable
+        s.set_column_headers(["foo"])
+        s.toggle_column_sort(s.get_columns()[0])
+        assert s.get_sort_orders()
 
     def test_find_default_sort_column(self):
         s = self.songlist


### PR DESCRIPTION
* Bug introduced (by me) in #4273
* Remove the hard-resetting of clickability in the browser callback
* Instead centralise the overriding-by-config logic to songlist itself
* Adjust test

Hopefully
This fixes #4323
