### PR TITLE
Fix shuffle by grouping

### DIFF
--- a/quodlibet/ext/playorder/shufflebygrouping.py
+++ b/quodlibet/ext/playorder/shufflebygrouping.py
@@ -43,6 +43,12 @@ class ShuffleByGrouping(ShufflePlugin, OrderRemembered):
     def next(self, playlist, current_song):
         return self._next(playlist, current_song)
 
+    def next_explicit(self, playlist, current_song):
+        return self._next(playlist, current_song, delay_on=False)
+
+    def previous(self, playlist, current_song):
+        return OrderRemembered.previous(self, playlist, current_song)
+
     def _next(self, playlist, current_song, delay_on=True):
         grouping = str(pconfig.gettext("grouping")).strip()
         grouping_filter = str(pconfig.gettext("grouping_filter")).strip()
@@ -110,12 +116,6 @@ class ShuffleByGrouping(ShufflePlugin, OrderRemembered):
             return True
         tag_value = song(tag_name)
         return bool(tag_value.strip())
-
-    def next_explicit(self, playlist, current_song):
-        return self._next(playlist, current_song, delay_on=False)
-
-    def previous(self, playlist, current_song):
-        return OrderRemembered.previous(self, playlist, current_song)
 
     @classmethod
     def PluginPreferences(cls, window):


### PR DESCRIPTION
Check-list
----------

 * [ ] There is a linked issue discussing the motivations for this feature or bugfix
 * [ ] Unit tests have been added where possible
 * [ ] I've added / updated documentation for any user-facing features.
 * [x] Performance seems to be comparable or better than current `main`


What this change is adding / fixing
-----------------------------------
This PR is caused by unexpected behaviour when going back'n'forth between groupings. Fox example if there are albums A, B and C (and grouping is done by album), if complete album A plays out and shuffle selects album B, and I press previous and last track of A starts playing, but next track afterwards will be randomly B or C, while I would still expect it to be B.
