### PR TITLE
Fix the link to cli.py in interacting.rst

### DIFF
--- a/docs/guide/interacting.rst
+++ b/docs/guide/interacting.rst
@@ -55,7 +55,7 @@ Quod Libet can also be controlled via a `FIFO
 <https://en.wikipedia.org/wiki/Named_pipe>`_ , ``~/.quodlibet/control``. To see 
 how the command-line arguments map to FIFO commands, refer to 
 ``process_arguments()`` in 
-https://github.com/quodlibet/quodlibet/blob/main/quodlibet/quodlibet/cli.py; 
+https://github.com/quodlibet/quodlibet/blob/main/quodlibet/cli.py; 
 as a simple example::
 
     # Sets volume to 50%


### PR DESCRIPTION
Check-list
----------

 * [ ] There is a linked issue discussing the motivations for this feature or bugfix
 * [ ] Unit tests have been added where possible
 * [ ] I've added / updated documentation for any user-facing features.
 * [ ] Performance seems to be comparable or better than current `main`


What this change is adding / fixing
-----------------------------------
Fix the link to cli.py in documentation