### PR TITLE
Repeat should pass set_explicit and set_implicit instead of set

### DIFF
--- a/quodlibet/order/repeat.py
+++ b/quodlibet/order/repeat.py
@@ -21,8 +21,11 @@ class Repeat(Order):
     def next(self, playlist, iter):
         raise NotImplementedError
 
-    def set(self, playlist, iter):
-        return self.wrapped.set(playlist, iter)
+    def set_explicit(self, playlist, iter):
+        return self.wrapped.set_explicit(playlist, iter)
+
+    def set_implicit(self, playlist, iter):
+        return self.wrapped.set_implicit(playlist, iter)
 
     def previous(self, playlist, iter):
         return self.wrapped.previous(playlist, iter)


### PR DESCRIPTION
Check-list
----------

 * [ ] There is a linked issue discussing the motivations for this feature or bugfix
 * [ ] Unit tests have been added where possible
 * [ ] I've added / updated documentation for any user-facing features.
 * [ ] Performance seems to be comparable or better than current `main`


What this change is adding / fixing
-----------------------------------
If only set is defined, both set_explicit and set_implicit are calling set on wrapped object as defined by Order, so it is not possible to distinguish in the wrapped. So this change is needed if I want to distinguish set_explicit/set_implicit in some shuffle plugin and have also repeat enabled.