### PR TITLE
Fix startup on Python 3.12

### DIFF
--- a/quodlibet/_import.py
+++ b/quodlibet/_import.py
@@ -8,6 +8,7 @@
 
 import sys
 import importlib
+import importlib.util
 
 
 class RedirectImportHook:
@@ -30,6 +31,11 @@ class RedirectImportHook:
 
         self._name = name
         self._packages = packages
+
+    def find_spec(self, fullname, path, target=None):
+        loader = self.find_module(fullname, path)
+        if loader is not None:
+            return importlib.util.spec_from_loader(fullname, loader)
 
     def find_module(self, fullname, path=None):
         package = fullname.split(".")[0]

--- a/quodlibet/util/config.py
+++ b/quodlibet/util/config.py
@@ -377,7 +377,7 @@ class Config:
             with open(filename, "rb") as fileobj:
                 fileobj = StringIO(
                     fileobj.read().decode("utf-8", "surrogateescape"))
-                self._config.readfp(fileobj, filename)
+                self._config.read_file(fileobj, filename)
         except (IOError, OSError):
             return
 

--- a/quodlibet/util/importhelper.py
+++ b/quodlibet/util/importhelper.py
@@ -92,8 +92,8 @@ def load_module(name, package, path):
     except KeyError:
         pass
 
-    loader = importlib.find_loader(fullname, [path])
-    if loader is None:
+    spec = importlib.machinery.PathFinder.find_spec(fullname, [path])
+    if spec is None:
         return
 
     # modules need a parent package
@@ -101,7 +101,7 @@ def load_module(name, package, path):
         spec = importlib.machinery.ModuleSpec(package, None, is_package=True)
         sys.modules[package] = importlib.util.module_from_spec(spec)
 
-    mod = loader.load_module(fullname)
+    mod = spec.loader.load_module(fullname)
 
     # make it accessible from the parent, like __import__ does
     vars(sys.modules[package])[name] = mod

--- a/tests/test_browsers_soundcloud.py
+++ b/tests/test_browsers_soundcloud.py
@@ -4,7 +4,8 @@
 # (at your option) any later version.
 
 import time
-from unittest import TestCase
+
+from tests import TestCase
 
 from gi.repository import Gtk
 


### PR DESCRIPTION
Check-list
----------

 * [ ] There is a linked issue discussing the motivations for this feature or bugfix
 * [ ] Unit tests have been added where possible
 * [ ] I've added / updated documentation for any user-facing features.
 * [ ] Performance seems to be comparable or better than current `main`


What this change is adding / fixing
-----------------------------------
<!-- A high-level description of the changes.
Hopefully the commits are atomic and well described, but this is the overall
summary of the change, to other developers / maintainers, plus any TODOs. -->

This makes QuodLibet work with Python 3.12.