### PR TITLE
Add missing network mark to test_click_add_station()

### DIFF
--- a/tests/test_browsers_iradio.py
+++ b/tests/test_browsers_iradio.py
@@ -94,6 +94,7 @@ class TInternetRadio(TestCase):
         self.assertEqual(self.bar.status_text(1), "1 station")
         self.assertEqual(self.bar.status_text(101, 123), "101 stations")
 
+    @pytest.mark.network
     @skipIf(is_windows() or is_osx(), "Don't need to test downloads all the time")
     def test_click_add_station(self):
         self.bar._update_button.emit('clicked')


### PR DESCRIPTION
Check-list
----------

 * [ ] There is a linked issue discussing the motivations for this feature or bugfix
 * [ ] Unit tests have been added where possible
 * [ ] I've added / updated documentation for any user-facing features.
 * [ ] Performance seems to be comparable or better than current `main`


What this change is adding / fixing
-----------------------------------
<!-- A high-level description of the changes.
Hopefully the commits are atomic and well described, but this is the overall
summary of the change, to other developers / maintainers, plus any TODOs. -->
This makes tests pass when running `pytest -m "not network"` in an environment without internet connection.
