### PR TITLE
Connect TreeViewHints->view leave-notify-event to __undisplay

### DIFF
--- a/quodlibet/qltk/views.py
+++ b/quodlibet/qltk/views.py
@@ -124,7 +124,7 @@ class TreeViewHints(Gtk.Window):
 
         self.__handlers[view] = [
             view.connect('motion-notify-event', self.__motion),
-            view.connect('leave-notify-event', self.__motion),
+            view.connect('leave-notify-event', self.__undisplay),
             view.connect('scroll-event', self.__undisplay),
             view.connect('key-press-event', self.__undisplay),
             view.connect('unmap', self.__undisplay),


### PR DESCRIPTION
Check-list
----------

 * [x] There is a linked issue discussing the motivations for this feature or bugfix
 * [ ] Unit tests have been added where possible
 * [ ] I've added / updated documentation for any user-facing features.
 * [ ] Performance seems to be comparable or better than current `main`


What this change is adding / fixing
-----------------------------------
<!-- A high-level description of the changes.
Hopefully the commits are atomic and well described, but this is the overall
summary of the change, to other developers / maintainers, plus any TODOs. -->

This fixes stuck tooltips when leaving the window.

See: https://www.youtube.com/watch?v=x7Ey-y0TPIs
Closes: #4259