### PR TITLE
Add disjunction / fallback tag expression

### DIFF
--- a/docs/guide/tags/patterns.rst
+++ b/docs/guide/tags/patterns.rst
@@ -3,12 +3,28 @@
 Tag Patterns
 ============
 
-Tag patterns allow more complex string representation of tags, with a
-notion of if-null defaulting; whilst this sounds complex (and it can be!)
-it's very useful where libraries have wildly varying tags.
+Tag patterns can be used to change the information displayed in various places
+like the playing song area, columns in the song list and the album list in the
+album browser.
 
-Tag patterns can include strings (e.g. tag names) enclosed in angled
-brackets like this
+They can also be used to group songs in the paned and album collection browsers
+in more complex ways.
+
+The file renaming tool uses tag patterns to determine the file names and folder
+structure to be used for the moved files.
+
+Usage
+-----
+
+A tag pattern is a string (piece of text) in which certain symbols receive
+special meaning. Parts of the string that carry no special meaning will be
+printed as-is when the tag pattern is rendered by Quod Libet.
+
+To indicate that part of a tag pattern is to be given special meaning in Quod
+Libet, it is surrounded by angle brackets, as in ``<artist>``. The portion of
+a tag pattern surrounded by brackets is called a tag *expression*.
+
+Let's consider a simple example:
 
 ``<artist> - <title> (<album>)``
 
@@ -16,66 +32,125 @@ Which might produce:
 
 ``The Beatles - Drive My Car (Rubber Soul)``
 
-Usage
------
+The most basic form of a tag expression is illustrated in this example. In this
+case, each tag expression is simply the name of a tag. In a tag expression, a
+tag name is replaced by the contents of the tag, or nothing (if the tag is
+absent or empty). If the file used in the example did not have the album tag
+set, the tag pattern would produce:
 
-Tag patterns in QL can be used to change the information displayed in various
-places, like the playing song area, columns in the song list and the album list
-in the album browser.
+``The Beatles - Drive My Car ()``
 
-They can be used to group songs in the paned and the album collection
-browser in more complex ways.
+Tag expressions are not arbitrary strings like tag patterns. If you write a tag
+expression with incorrect syntax, it is likely that Quod Libet will not print
+anything at all, so it is important to be careful.
 
-And, of course, tag renaming based on tags uses tag patterns to create
-the file names and folder structure.
+Let's consider some more sophisticated tag expressions.
+
+Fallback Tags
+-------------
+
+It's useful to be able to print the contents of a tag only if it exists, as
+shown above. However, frequently you want to print a tag if it exists, and fall
+back to some other tag if it does not. The fallback tag expression allows you
+to do this with a convenient piece of syntax, the double pipe (``||``).
+
+The syntax for this expression is as follows:
+
+ * ``<tag-pattern||tag-pattern>``
+
+This tag expression will print the result of the tag pattern on the left, if it
+is non-empty, and otherwise print the tag pattern on the right (even if it is
+empty).
+
+Notice that since this tag expression can contain arbitrary tag patterns, it is
+extremely flexible. These tag patterns can be a piece of text or a valid tag
+expression. Both of the following are valid uses of the fallback tag
+expression:
+
+ * ``<<albumartist>||<artist>>``
+ * ``<<albumartist>||no album artist>``
+
+The former will fallback to printing the contents of the artist tag, if the
+albumartist tag does not exist. The latter will instead print the text "no
+album artist".
+
+The fallback expression is also chainable - you can have an arbitrary number of
+tag patterns and only the first one will be printed. For instance:
+
+ * ``<<composer>||<albumartist>||<artist>>``
 
 Conditional Tags
 ----------------
 
-A simple if-then-else concept can be used in tag patterns, testing if a tag
-is non-empty. The syntax uses the pipe (``|``) character as a delimiter, in
-either of these formats:
+Sometimes you want to print something if a tag exists, but you don't want to
+print the content of the tag. In this case the conditional tag expression
+syntax comes in handy.
 
- * ``<tag-expression|non-empty-value>`` or
- * ``<tag-expression|non-empty-value|empty-value>``
+This is a simple if-then-else concept, which tests if a tag is non-empty and
+prints one of two patterns based on the result of the test. The syntax for this
+expression uses the pipe (``|``) character as a delimiter, in either of these
+formats:
 
-So using the full (second) form, a Pattern of:
+ * ``<tag-expression|tag-pattern-if-non-empty>`` or
+ * ``<tag-expression|tag-pattern-if-non-empty|tag-pattern-if-empty>``
+
+Using the second form, a pattern of:
 
     ``<album|Has An Album|No Album>``
 
-produces *Has An Album* for any song with at least one ``album`` tag value,
-else *No Album*.
+produces ``Has An Album`` for any song with at least one ``album`` tag value,
+else producing ``No Album``.
 
-Note that these can be recursive, i.e. both `non-empty-value` and
-`empty-value` are themselves tag patterns, which could contain a
-conditional. A more useful example now:
+Boolean Tag Expressions
+-----------------------
 
-    ``<albumartist|<albumartist>|<artist>>``
+The conditional tag expression is not limited to just testing for the existence
+of a tag. Quod Libet supports more complicated tag expressions that test for
+other conditions. These expressions do not print anything; instead they produce
+a true or false condition that is interpreted by the conditional tag
+expression.
 
-This will look for the ``albumartist`` tag and display that if available,
-else use ``artist`` (nearly always available).
+The syntax for these expressions is, conveniently, the same as that used for
+search queries and described in :ref:`Searching`. For example, to check that
+the content of a tag matches a particular search string, one could do this:
 
+    ``<sometag=test|the tag contained test|it was something different>``
 
-Examples:
-
-  * ``<~year|<~year>. <album>|<album>>``: *2011. This is an album title*
-  * ``<title>, by <albumartist|<albumartist>|<composer|<composer>|<artist>>>``:
-    *Liebstraum no. 3, (by Franz Liszt)*
-
-
-Conditional Tags With Comparisons
----------------------------------
-
-In addition to checking if a tag value is empty, the "if" expression can also
-contain a value comparison using the same syntax as the :ref:`search
-<Searching>`:
-
-    ``<sometag=test|the value was test|it was something different>``
-
-or more complex ones (note the needed escaping):
+Or to take a more complicated example:
 
     ``<artist=\|(Townshend, Who)|foo|bar>``
 
+In this case, notice that any piece of syntax that would normally be
+interpreted as a piece of tag expression syntax needs to be escaped for it to
+be interpreted as search query syntax. This is done by preceding it with a
+``\\`` character.
+
+Nested Tag Expressions
+-------------------------
+
+The syntax for both fallback and conditional tag expressions allows for the
+use of arbitrary tag patterns as possible outputs of the expression. In both
+cases, this means that tag expressions can contain other tag expressions.
+
+For example, suppose you wanted to print the composer tag for classical music,
+and print the artist tag for anything else. You could do it like this:
+
+    ``<genre=classical|<composer>|<artist>``
+
+If you wanted to print the composer tag for classical music only if it exists,
+you could do this:
+
+    ``<<genre=classical|<composer>>||<artist>``
+
+As you can see, this makes use of a conditional expression and a fallback
+expression at once. Their syntax allows them to be nested arbitrarily.
+
+Additional Examples
+-------------------
+
+  * ``<~year|<~year>. <album>|<album>>``: *2011. This is an album title*
+  * ``<title>, by <<albumartist>||<composer>||<artist>>``:
+    *Liebstraum no. 3, (by Franz Liszt)*
 
 .. _TextMarkup:
 

--- a/docs/guide/tags/patterns.rst
+++ b/docs/guide/tags/patterns.rst
@@ -4,7 +4,7 @@ Tag Patterns
 ============
 
 Tag patterns can be used to change the information displayed in various places
-like the playing song area, columns in the song list and the album list in the
+like the playing song area, columns in the song list, and the album list in the
 album browser.
 
 They can also be used to group songs in the paned and album collection browsers
@@ -17,12 +17,15 @@ Usage
 -----
 
 A tag pattern is a string (piece of text) in which certain symbols receive
-special meaning. Parts of the string that carry no special meaning will be
-printed as-is when the tag pattern is rendered by Quod Libet.
+special meaning.
+Parts of the string that carry no special meaning will be printed as-is when
+the tag pattern is rendered by Quod Libet.
 
 To indicate that part of a tag pattern is to be given special meaning in Quod
-Libet, it is surrounded by angle brackets, as in ``<artist>``. The portion of
-a tag pattern surrounded by brackets is called a tag *expression*.
+Libet, it is surrounded by angle brackets,
+as in ``<artist>``.
+The portion of a tag pattern surrounded by brackets is called a tag
+*expression*.
 
 Let's consider a simple example:
 
@@ -32,66 +35,74 @@ Which might produce:
 
 ``The Beatles - Drive My Car (Rubber Soul)``
 
-The most basic form of a tag expression is illustrated in this example. In this
-case, each tag expression is simply the name of a tag. In a tag expression, a
-tag name is replaced by the contents of the tag, or nothing (if the tag is
-absent or empty). If the file used in the example did not have the album tag
-set, the tag pattern would produce:
+This example illustrates the most basic form of a tag expression.
+In this case, each tag expression is simply the name of a tag.
+In a tag expression, a tag name signifies the *contents* of the tag,
+or nothing (if the tag is absent or empty).
+If the file used in the example did not have the album tag set, the tag pattern
+would produce:
 
 ``The Beatles - Drive My Car ()``
 
-Tag expressions are not arbitrary strings like tag patterns. If you write a tag
-expression with incorrect syntax, it is likely that Quod Libet will not print
-anything at all, so it is important to be careful.
+Tag expressions are not arbitrary strings like tag patterns.
+If you write a tag expression with incorrect syntax,
+it is likely that Quod Libet will not print anything at all,
+so it is important to be careful.
 
 Let's consider some more sophisticated tag expressions.
 
 Fallback Tags
 -------------
 
-It's useful to be able to print the contents of a tag only if it exists, as
-shown above. However, frequently you want to print a tag if it exists, and fall
-back to some other tag if it does not. The fallback tag expression allows you
-to do this with a convenient piece of syntax, the double pipe (``||``).
+It's useful to be able to print the contents of a tag only if it exists,
+as shown above.
+However, you might want to print a tag if it exists,
+and fall back to printing some other tag if it does not.
+The fallback tag expression allows you to do this with a convenient piece of
+syntax,
+the double pipe (``||``).
 
 The syntax for this expression is as follows:
 
  * ``<tag-pattern||tag-pattern>``
 
-This tag expression will print the result of the tag pattern on the left, if it
-is non-empty, and otherwise print the tag pattern on the right (even if it is
-empty).
+This tag expression will print the result of the tag pattern on the left,
+if it is non-empty,
+and otherwise print the tag pattern on the right (even if it is empty).
 
-Notice that since this tag expression can contain arbitrary tag patterns, it is
-extremely flexible. These tag patterns can be a piece of text or a valid tag
-expression. Both of the following are valid uses of the fallback tag
-expression:
+Because fallback tag expressions can contain arbitrary tag patterns,
+they are extremely flexible.
+Since tag patterns can contain a piece of text *or* a valid tag expression,
+both of the following are valid examples of fallback tag expressions:
 
  * ``<<albumartist>||<artist>>``
  * ``<<albumartist>||no album artist>``
 
-The former will fallback to printing the contents of the artist tag, if the
-albumartist tag does not exist. The latter will instead print the text "no
-album artist".
+The former will fall back to printing the contents of the ``artist``
+tag, if the ``albumartist`` tag does not exist.
+The latter will instead print the text "no album artist".
 
-The fallback expression is also chainable - you can have an arbitrary number of
-tag patterns and only the first one will be printed. For instance:
+Fallback tag expressions are also chainable:
+you can use an arbitrary number of tag patterns
+and only the first non-empty pattern will be printed.
+For instance:
 
  * ``<<composer>||<albumartist>||<artist>>``
 
 Conditional Tags
 ----------------
 
-Sometimes you want to print something if a tag exists, but you don't want to
-print the content of the tag. In this case the conditional tag expression
-syntax comes in handy.
+Sometimes you want to print something if a tag exists,
+but you don't want to print the content of the tag.
+In this case the conditional tag expression syntax comes in handy.
 
-This is a simple if-then-else concept, which tests if a tag is non-empty and
-prints one of two patterns based on the result of the test. The syntax for this
-expression uses the pipe (``|``) character as a delimiter, in either of these
-formats:
+This is a simple if-then-else concept,
+which tests if a tag is non-empty,
+and prints one of two patterns based on the result of the test.
+The syntax for this expression uses the pipe (``|``) character as a delimiter,
+in either of these formats:
 
- * ``<tag-expression|tag-pattern-if-non-empty>`` or
+ * ``<tag-expression|tag-pattern-if-non-empty>``
  * ``<tag-expression|tag-pattern-if-non-empty|tag-pattern-if-empty>``
 
 Using the second form, a pattern of:
@@ -104,15 +115,18 @@ else producing ``No Album``.
 Boolean Tag Expressions
 -----------------------
 
-The conditional tag expression is not limited to just testing for the existence
-of a tag. Quod Libet supports more complicated tag expressions that test for
-other conditions. These expressions do not print anything; instead they produce
-a true or false condition that is interpreted by the conditional tag
-expression.
+The conditional tag expression is not limited to testing for the existence of a
+tag.
+Quod Libet supports more complicated tag expressions that test for other
+conditions.
+These expressions do not print anything.
+Instead, they produce a true or false condition that is interpreted by the
+conditional tag expression.
 
-The syntax for these expressions is, conveniently, the same as that used for
-search queries and described in :ref:`Searching`. For example, to check that
-the content of a tag matches a particular search string, one could do this:
+Conveniently, these expressions reuse the same syntax as search queries,
+which is described in :ref:`Searching`.
+For example, to check that the contents of a tag match a particular search
+string, one could do this:
 
     ``<sometag=test|the tag contained test|it was something different>``
 
@@ -122,45 +136,51 @@ Or to take a more complicated example:
 
 In this case, notice that any piece of syntax that would normally be
 interpreted as a piece of tag expression syntax needs to be escaped for it to
-be interpreted as search query syntax. This is done by preceding it with a
-``\\`` character.
+be interpreted as search query syntax.
+This is done by preceding it with a ``\\`` character.
 
 Nested Tag Expressions
 -------------------------
 
 The syntax for both fallback and conditional tag expressions allows for the
-use of arbitrary tag patterns as possible outputs of the expression. In both
-cases, this means that tag expressions can contain other tag expressions.
+use of arbitrary tag patterns as possible outputs of the expression.
+In both cases, this means that tag expressions can contain other tag
+expressions.
 
-For example, suppose you wanted to print the composer tag for classical music,
-and print the artist tag for anything else. You could do it like this:
+For example,
+suppose you wanted to print the ``composer`` tag for classical music,
+and print the ``artist`` tag for anything else.
+You could do it like this:
 
     ``<genre=classical|<composer>|<artist>``
 
-If you wanted to print the composer tag for classical music only if it exists,
-you could do this:
+If you wanted to print the ``composer`` tag for classical music only if it
+exists, and print the ``artist`` in all other cases, you could do this:
 
     ``<<genre=classical|<composer>>||<artist>``
 
 As you can see, this makes use of a conditional expression and a fallback
-expression at once. Their syntax allows them to be nested arbitrarily.
+expression at once.
+Their syntax allows them to be nested arbitrarily.
 
 Additional Examples
 -------------------
 
   * ``<~year|<~year>. <album>|<album>>``: *2011. This is an album title*
   * ``<title>, by <<albumartist>||<composer>||<artist>>``:
-    *Liebstraum no. 3, (by Franz Liszt)*
+    *Liebstraum no. 3, by Franz Liszt*
 
 .. _TextMarkup:
 
 Text Markup
 -----------
 
-In some situations the resulting text will be displayed in the user
-interface like for example the album list or the area which displays
-information about the currently playing song. To style the resulting text
-you can use the following tags in combination with the tag patterns.
+In some situations the text generated by a tag pattern will be displayed in the
+user interface ---
+for example, the currently playing song information is an editable tag pattern,
+as is the list of albums.
+To style this text,
+you can use the following markup in combination with the tag patterns.
 
 ===================== ==========
 Tag                   Result
@@ -175,8 +195,9 @@ Tag                   Result
 ===================== ==========
 
 The ``span`` tag can define many more text attributes like size and color:
-``[span size='small' color='blue']..[/span]``. See the `Pango Markup
-Language`_ page for a complete list of available attributes and values.
+``[span size='small' color='blue']..[/span]``.
+See the `Pango Markup Language`_ page for a complete list of available
+attributes and values.
 
 A complete example might look like this:
 

--- a/tests/test_pattern.py
+++ b/tests/test_pattern.py
@@ -123,6 +123,31 @@ class TPattern(_TPattern):
         pat = Pattern(u'<artist=un élève français|matched|not matched>')
         s.assertEquals(pat.format(s.g), 'matched')
 
+    def test_disjunction(s):
+        pat = Pattern('<<composer>||<albumartist>>')
+        s.assertEquals(pat.format(s.a), '')
+        pat = Pattern('<<composer>||<artist>>')
+        s.assertEquals(pat.format(s.a), 'Artist')
+        pat = Pattern('<<artist>||<albumartist>>')
+        s.assertEquals(pat.format(s.a), 'Artist')
+
+    def test_disjunction_chain(s):
+        pat = Pattern('<<composer>||<albumartist>||<artist>>')
+        s.assertEquals(pat.format(s.a), 'Artist')
+        pat = Pattern('<<composer>||<albumartist>||no tag>')
+        s.assertEquals(pat.format(s.a), 'no tag')
+
+    def test_disjunction_conjunction_nested(s):
+        pat = Pattern('<<album|<albumartist>>||<artist>>')
+        s.assertEquals(pat.format(s.a), 'Artist')
+        s.assertEquals(pat.format(s.f), 'foo.bar')
+        pat = Pattern('<<album|<composer>>||<artist>>')
+        s.assertEquals(pat.format(s.f), 'Foo')
+        pat = Pattern('<<album|<albumartist>|text>||<artist>>')
+        s.assertEquals(pat.format(s.a), 'text')
+        pat = Pattern('<<album>||<artist=x|<artist>|<title>>>')
+        s.assertEquals(pat.format(s.a), 'Title5')
+
     def test_duplicate_query(self):
         pat = Pattern('<u=yes|<u=yes|x|y>|<u=yes|q|z>>')
         self.assertEqual(pat.format(AudioFile({"u": u"yes"})), "x")


### PR DESCRIPTION
Check-list
----------

 * [x] There is a linked issue discussing the motivations for this feature or bugfix
 * [x] Unit tests have been added where possible
 * [x] I've added / updated documentation for any user-facing features.
 * [x] Performance seems to be comparable or better than current `main`


What this change is adding / fixing
-----------------------------------

Add a new piece of tag pattern syntax, with the operator `||`. This operator returns the tag pattern on the left side, if it is not empty, and otherwise returns the tag pattern on the right side.

It is implemented so as to be chainable, e.g. one can do

    <<composer>||<albumartist>||<artist>>

And the first non-empty expression will be used.

In documentation, this syntax will be called the "fallback" tag expression, for greater clarity.

Fixes https://github.com/quodlibet/quodlibet/issues/4152.

This PR also documents the new feature and improves the documentation for tag patterns to make it more accessible to new users. Tests have been added.