### PR TITLE
libsoup 3 also needs gir1.2-soup-3.0

### DIFF
--- a/docs/packaging.rst
+++ b/docs/packaging.rst
@@ -34,6 +34,7 @@ The following software is needed to start Ex Falso or Quod Libet.
 * **mutagen** (>= 1.34)
 * **GTK+** (>= 3.18)
 * **libsoup** (>= 3.0)
+* **gir1.2-soup-3.0**
 * On OS X only: **PyObjC**
 * **feedparser**
 


### PR DESCRIPTION
This is not provided by any non-dev packages on debian 12

I see it has been mentioned in the distant past:
https://debian-bugs-dist.debian.narkive.com/dkv2jhqf/bug-820443-quodlibet-quodlibet-won-t-start-valueerror-namespace-soup-not-available

What this change is adding / fixing
-----------------------------------
Fixes:
ValueError: Namespace Soup not available for version 3.0

