### PR TITLE
🆙 Add Nix flake for dev

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,3 +11,6 @@ indent_size = 2
 [*.py]
 # See Flake8 config
 max_line_length = 88
+
+[*.nix]
+indent_size = 2

--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,0 +1,25 @@
+name: "test-nix"
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test-nix-shell:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Nix
+        uses: cachix/install-nix-action@v18
+        with:
+          extra_nix_config: |
+            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
+      - uses: workflow/nix-shell-action@v3
+        with:
+          flakes: .#
+          script: |
+            nix run poetry --version
+            nix flake check

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -13,13 +13,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install Nix
-        uses: cachix/install-nix-action@v18
+        uses: cachix/install-nix-action@v22
         with:
-          extra_nix_config: |
-            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
-      - uses: workflow/nix-shell-action@v3
-        with:
-          flakes: .#
-          script: |
-            nix run poetry --version
-            nix flake check
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+      - run: nix run .#poetry -- --version
+      - run: nix flake check

--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@ Pipfile.lock
 # Common virtualenvs
 .venv/
 venv/
+
+# Direnv
+.direnv

--- a/docs/development/devenv.rst
+++ b/docs/development/devenv.rst
@@ -10,6 +10,41 @@ your machine and allow you to change it as you wish. The main task here is to
 install all the software which Quod Libet uses and depends on.
 
 
+Nix Flake
+---------
+
+To help with consistent tooling across machines and platforms,
+we now include a basic `Nix Flake <https://nixos.wiki/wiki/Flakes>`__
+which currently provides suitable versions for Python and Poetry (see below)
+as well as some linter tooling.
+To run a Bash shell with this set up, install Nix (with Flake support),
+then run::
+
+    $ nix develop
+    $ python --version  # or whatever
+
+You can also run Flake apps directly, e.g.::
+
+    $ nix run .#poetry -- --version
+
+
+
+Poetry
+------
+
+Across all environments, we now support Virtualenvs with Pip dependencies,
+managed by `Poetry <https://python-poetry.org/>`__.
+
+Installation, once cloned is just::
+
+    $ poetry install
+
+
+If you want all the *optional* dependencies for various plugins::
+
+    $ poetry install -E plugins
+
+
 |linux-logo| Linux
 ------------------
 
@@ -95,18 +130,3 @@ Check out the `win_installer
 <https://github.com/quodlibet/quodlibet/tree/main/dev-utils/win_installer>`__
 directory in the Git repo for further instructions.
 
-
-Poetry
-------
-
-Across all environments, we now support Virtualenvs with Pip dependencies,
-managed by `Poetry <https://python-poetry.org/>`__.
-
-Installation, once cloned is just::
-
-    $ poetry install
-
-
-If you want all the *optional* dependencies for various plugins::
-
-    $ poetry install -E plugins

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1681202837,
+        "narHash": "sha256-H+Rh19JDwRtpVPAWp64F+rlEtxUWBAQW28eAi3SRSzg=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "cfacdce06f30d2b68473a46042957675eebb3401",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1686431482,
+        "narHash": "sha256-oPVQ/0YP7yC2ztNsxvWLrV+f0NQ2QAwxbrZ+bgGydEM=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "d3bb401dcfc5a46ce51cdfb5762e70cc75d082d2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-23.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,49 @@
+{
+  description = "Development Flake for Quod Libet";
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-23.05";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = {
+    self,
+    nixpkgs,
+    flake-utils,
+  }:
+    flake-utils.lib.eachDefaultSystem (system: let
+      pkgs = nixpkgs.legacyPackages.${system};
+      qlPython = pkgs.python310;
+      qlPoetry = pkgs.poetry.override {python3 = qlPython;};
+    in {
+      # A shell for `nix develop`
+      devShells.default = pkgs.mkShell {
+        packages = [
+          qlPoetry
+          qlPython
+          pkgs.shellcheck
+          pkgs.alejandra
+        ];
+      };
+
+      # Allow `nix fmt` to "just work"
+      formatter = pkgs.alejandra;
+
+      # Nix run .#foo
+      apps = {
+        poetry = flake-utils.lib.mkApp {drv = qlPoetry;};
+      };
+
+      # Allow `nix flake check` to "just work"
+      checks = {
+        shellcheck =
+          pkgs.runCommand
+          "shellcheck"
+          {buildInputs = [pkgs.shellcheck];}
+          ''
+            find ${./.} -iname "*.sh" -exec shellcheck {} \+
+            # We *must* create some output
+            mkdir -p "$out"
+          '';
+      };
+    });
+}


### PR DESCRIPTION
Needs #4400 merged first really

No real change for anyone not using Nix (Flakes), but allows easy and consistent tooling across platforms...

* Basic shell access (i.e. `nix develop`), no building here
* But: allows us to fix Python & Poetry versions for consistency across machines
* Expose Poetry and as an app too so `nix run .#poetry --` just works
* Also add some non-Python tooling e.g. `shellcheck`
* Add integration with direnv, which makes it much nicer
* Also formatter for Nix (of course...)
* Try a new CI workflow to ensure this stays working
* Update dev docs around this

Fixes #4302 