### PR TITLE
Fix shuffle history (2)

### DIFF
--- a/quodlibet/order/__init__.py
+++ b/quodlibet/order/__init__.py
@@ -132,8 +132,9 @@ class OrderRemembered(Order):
         """Gets a map of all song indices to their song from the `playlist`
         that haven't yet been played"""
 
-        def get_index(iter):
-            return playlist.get_path(iter).get_indices()[0]
+        def get_index(iter) -> int:
+            path = playlist.get_path(iter)
+            return path.get_indices()[0]
 
         played = set(map(get_index, self._played))
         print_d("Played %d of %d song(s)" % (len(self._played), len(playlist)))

--- a/quodlibet/order/__init__.py
+++ b/quodlibet/order/__init__.py
@@ -6,7 +6,9 @@
 # the Free Software Foundation; either version 2 of the License, or
 # (at your option) any later version.
 
-from typing import Optional
+from typing import Any, Dict, List, Optional
+
+from gi.repository import Gtk
 
 from quodlibet import _, print_d
 
@@ -103,39 +105,42 @@ class OrderRemembered(Order):
     """Shared class for all the shuffle modes that keep a memory
     of their previously played songs."""
 
+    _played: List[Gtk.TreeIter]
+
     def __init__(self):
         super().__init__()
         self._played = []
 
     def next(self, playlist, iter):
         if iter is not None:
-            self._played.append(playlist.get_path(iter).get_indices()[0])
+            self._played.append(iter)
 
     def previous(self, playlist, iter):
-        try:
-            path = self._played.pop()
-        except IndexError:
-            return None
-        else:
-            return playlist.get_iter(path)
+        if self._played:
+            return self._played.pop()
+        return None
 
     def set(self, playlist, iter):
         if iter is not None:
-            self._played.append(playlist.get_path(iter).get_indices()[0])
+            self._played.append(iter)
         return iter
 
     def reset(self, playlist):
         del(self._played[:])
 
-    def remaining(self, playlist):
+    def remaining(self, playlist) -> Dict[int, Any]:
         """Gets a map of all song indices to their song from the `playlist`
         that haven't yet been played"""
-        all_indices = set(range(len(playlist)))
-        played = set(self._played)
+
+        def get_index(iter):
+            return playlist.get_path(iter).get_indices()[0]
+
+        played = set(map(get_index, self._played))
         print_d("Played %d of %d song(s)" % (len(self._played), len(playlist)))
-        remaining = list(all_indices.difference(played))
-        all_songs = playlist.get()
-        return {i: all_songs[i] for i in remaining}
+        remaining = (
+            (get_index(iter), value) for iter, value in playlist.iterrows())
+        return {
+            index: song for (index, song) in remaining if index not in played}
 
 
 class OrderInOrder(Order):

--- a/quodlibet/order/reorder.py
+++ b/quodlibet/order/reorder.py
@@ -24,15 +24,14 @@ class OrderShuffle(Reorder, OrderRemembered):
 
     def next(self, playlist, iter):
         super().next(playlist, iter)
-        played = set(self._played)
-        songs = set(range(len(playlist)))
-        remaining = songs.difference(played)
+        remaining = self.remaining(playlist)
 
-        if remaining:
-            return playlist.get_iter((random.choice(list(remaining)),))
+        if not remaining:
+            self.reset(playlist)
+            return None
 
-        self.reset(playlist)
-        return None
+        index = random.choice(list(remaining))
+        return playlist.get_iter((index,))
 
 
 class OrderWeighted(Reorder, OrderRemembered):
@@ -45,7 +44,7 @@ class OrderWeighted(Reorder, OrderRemembered):
         remaining = self.remaining(playlist)
 
         # Don't try to search through an empty / played playlist.
-        if len(remaining) <= 0:
+        if not remaining:
             self.reset(playlist)
             return None
 

--- a/quodlibet/qltk/queue.py
+++ b/quodlibet/qltk/queue.py
@@ -9,7 +9,7 @@
 
 import os
 import time
-from typing import Optional
+from typing import Any, Optional, Sequence
 
 from gi.repository import Gtk, Gdk, Pango, GLib
 
@@ -345,7 +345,35 @@ class QueueExpander(Gtk.Expander):
 
 
 class QueueModel(PlaylistModel):
-    """Own class for debugging"""
+    """
+    A play list model for queues.
+
+    In contrast to `PlaylistModel`, when new songs have been set, its play order
+    will disregard the current song from the old set of songs and start from
+    scratch.
+    """
+
+    __reset = False
+
+    def set(self, songs: Sequence[Any]):
+        self.__reset = True
+        super().set(songs)
+
+    def next(self):
+        print_d(f"Using {self.order}.next_explicit() to get next song")
+
+        iter_ = None if self.__reset else self.current_iter
+        self.__reset = False
+        self.current_iter = self.order.next_explicit(self, iter_)
+
+    def previous(self):
+        iter_ = None if self.__reset else self.current_iter
+        self.__reset = False
+        self.current_iter = self.order.previous_explicit(self, iter_)
+
+    def go_to(self, song_or_iter, explicit=False, source=None):
+        self.__reset = False
+        return super().go_to(song_or_iter, explicit, source)
 
 
 class PlayQueue(SongList):

--- a/quodlibet/qltk/songlist.py
+++ b/quodlibet/qltk/songlist.py
@@ -9,7 +9,7 @@
 # the Free Software Foundation; either version 2 of the License, or
 # (at your option) any later version.
 
-from typing import List, Tuple
+from typing import List, Optional, Sequence, Tuple
 
 from gi.repository import Gtk, GLib, Gdk, GObject
 from senf import uri2fsn
@@ -501,7 +501,6 @@ class SongList(AllTreeView, SongListDnDMixin, DragScroll, util.InstanceTracker):
 
         # set the indicators
         default_order = Gtk.SortType.ASCENDING
-        reversed_ = False
         for c in self.get_columns():
             if c is column:
                 if c.get_sort_indicator():
@@ -509,7 +508,6 @@ class SongList(AllTreeView, SongListDnDMixin, DragScroll, util.InstanceTracker):
                         order = c.get_sort_order()
                     else:
                         order = not c.get_sort_order()
-                        reversed_ = True
                 else:
                     order = default_order
                 c.set_sort_order(order)
@@ -521,10 +519,13 @@ class SongList(AllTreeView, SongListDnDMixin, DragScroll, util.InstanceTracker):
 
         if refresh:
             songs = self.get_songs()
-            if reversed_:
-                # python sort is faster if presorted
-                songs.reverse()
-            self.set_songs(songs, scroll_select=True)
+            song_order = self._get_song_order(songs)
+            self.model.reorder(song_order)
+
+            selection = self.get_selection()
+            _, paths = selection.get_selected_rows()
+            if paths:
+                self.scroll_to_cell(paths[0], use_align=True, row_align=0.5)
 
         self.emit("orders-changed")
 
@@ -783,14 +784,18 @@ class SongList(AllTreeView, SongListDnDMixin, DragScroll, util.InstanceTracker):
             return []
         return model.get()
 
-    def _sort_songs(self, songs: List[AudioFile]):
-        """Sort passed songs in place based on the column sort orders"""
+    def _get_song_order(self, songs: List[AudioFile]) -> Optional[Sequence[int]]:
+        """Returns mapping from new position to position in given list of songs
+        when sorted based on the column sort orders"""
 
-        order = self.get_sort_orders()
-        if not order:
-            return
-        for key, reverse in self.__get_song_sort_key_func(order):
-            songs.sort(key=key, reverse=reverse)
+        orders = self.get_sort_orders()
+        if orders:
+            song_order = list(range(len(songs)))
+            for key, reverse in self.__get_song_sort_key_func(orders):
+                song_order.sort(key=lambda i: key(songs[i]), reverse=reverse)
+            return song_order
+        else:
+            return None
 
     def __get_song_sort_key_func(self, order):
         last_tag = None
@@ -855,13 +860,15 @@ class SongList(AllTreeView, SongListDnDMixin, DragScroll, util.InstanceTracker):
         model = self.get_model()
         assert model is not None
 
+        song_order = None
+
         if not sorted:
             # make sure some sorting is set and visible
             if not self.is_sorted():
                 default = self.find_default_sort_column()
                 if default:
                     self.toggle_column_sort(default, refresh=False)
-            self._sort_songs(songs)
+            song_order = self._get_song_order(songs)
         else:
             self.clear_sort()
 
@@ -871,6 +878,8 @@ class SongList(AllTreeView, SongListDnDMixin, DragScroll, util.InstanceTracker):
 
         with self.without_model() as model:
             model.set(songs)
+            if song_order:
+                model.reorder(song_order)
 
         # scroll to the first selected or current song and restore
         # selection for the first selected item if there was one

--- a/quodlibet/qltk/songlist.py
+++ b/quodlibet/qltk/songlist.py
@@ -1004,8 +1004,7 @@ class SongList(AllTreeView, SongListDnDMixin, DragScroll, util.InstanceTracker):
         Warning: This makes the row-changed signal useless.
         """
         model = self.get_model()
-        if not config.getboolean("memory", "shuffle", False) and \
-            config.getboolean("song_list", "auto_sort") and self.is_sorted():
+        if config.getboolean("song_list", "auto_sort") and self.is_sorted():
             iters, _, complete = self.__find_iters_in_selection(songs)
 
             if not complete:

--- a/quodlibet/qltk/songmodel.py
+++ b/quodlibet/qltk/songmodel.py
@@ -7,8 +7,11 @@
 # the Free Software Foundation; either version 2 of the License, or
 # (at your option) any later version.
 
+from typing import Any, Iterable, List, Optional, Sequence, Type
+
 from gi.repository import Gtk
 
+from quodlibet.order import Order
 from quodlibet.qltk.playorder import OrderInOrder
 from quodlibet.qltk.models import ObjectStore
 from quodlibet.util import print_d
@@ -151,10 +154,10 @@ class TrackCurrentModel(ObjectStore):
         super().__init__(*args, **kwargs)
         self.__iter = None
 
-    last_current = None
+    last_current: Optional[Any] = None
     """The last valid current song"""
 
-    def set(self, songs):
+    def set(self, songs: Sequence[Any]):
         """Clear the model and add the passed songs"""
 
         print_d("Filling view model with %d songs." % len(songs))
@@ -166,13 +169,13 @@ class TrackCurrentModel(ObjectStore):
             if song is oldsong:
                 self.__iter = iter_
 
-    def get(self):
+    def get(self) -> List[Any]:
         """A list of all contained songs"""
 
         return list(self.itervalues())
 
     @property
-    def current(self):
+    def current(self) -> Optional[Any]:
         """The current song or None"""
 
         return self.__iter and self.get_value(self.__iter, 0)
@@ -200,7 +203,7 @@ class TrackCurrentModel(ObjectStore):
         self.__iter = iter_
         self.last_current = self.current
 
-    def find(self, song):
+    def find(self, song: Any):
         """Returns the iter to the first occurrence of song in the model
         or None if it wasn't found.
         """
@@ -215,7 +218,7 @@ class TrackCurrentModel(ObjectStore):
                 return iter_
         return
 
-    def find_all(self, songs):
+    def find_all(self, songs: Iterable[Any]):
         """Returns a list of iters for all occurrences of all songs.
         (since a song can be in the model multiple times)
         """
@@ -244,22 +247,15 @@ class TrackCurrentModel(ObjectStore):
 class PlaylistModel(TrackCurrentModel):
     """A play list model for song lists"""
 
-    order = None
-    """The active `PlayOrder`"""
+    order: Order
+    """The active play order"""
 
     sourced = False
     """True in case this model is the source of the currently playing song"""
 
-    def __init__(self, order_cls=OrderInOrder):
+    def __init__(self, order_cls: Type[Order] = OrderInOrder):
         super().__init__(object)
         self.order = order_cls()
-
-        # The playorder plugins use paths atm to remember songs so
-        # we need to reset them if the paths change somehow.
-        self.__sigs = []
-        for sig in ["row-deleted", "row-inserted", "rows-reordered"]:
-            s = self.connect(sig, lambda pl, *x: self.order.reset(pl))
-            self.__sigs.append(s)
 
     def next(self):
         """Switch to the next song"""
@@ -311,15 +307,11 @@ class PlaylistModel(TrackCurrentModel):
 
         return self.current_iter
 
-    def set(self, songs):
+    def set(self, songs: Sequence[Any]):
         """Clear the model and add the passed songs"""
 
         self.order.reset(self)
-        for signal_id in self.__sigs:
-            self.handler_block(signal_id)
         super().set(songs)
-        for signal_id in self.__sigs:
-            self.handler_unblock(signal_id)
 
     def reset(self):
         """Switch to the first song"""

--- a/quodlibet/qltk/songmodel.py
+++ b/quodlibet/qltk/songmodel.py
@@ -308,6 +308,14 @@ class PlaylistModel(TrackCurrentModel):
         self.order.reset(self)
         super().set(songs)
 
+    def remove(self, iter_):
+        self.order.reset(self)
+        super().remove(iter_)
+
+    def clear(self):
+        self.order.reset(self)
+        super().clear()
+
     def reset(self):
         """Switch to the first song"""
 

--- a/quodlibet/qltk/songmodel.py
+++ b/quodlibet/qltk/songmodel.py
@@ -224,12 +224,7 @@ class TrackCurrentModel(ObjectStore):
         """
 
         songs = set(songs)
-        found = []
-        append = found.append
-        for iter_, value in self.iterrows():
-            if value in songs:
-                append(iter_)
-        return found
+        return [iter_ for iter_, value in self.iterrows() if value in songs]
 
     def remove(self, iter_):
         if self.__iter and self[iter_].path == self[self.__iter].path:

--- a/tests/test_qltk_songmodel.py
+++ b/tests/test_qltk_songmodel.py
@@ -142,6 +142,18 @@ class TPlaylistModel(TestCase):
                     f"expected different item at index {i}")
             self.pl.previous()
 
+    def test_shuffle_next_after_remove(self):
+        self.pl.order = OrderShuffle()
+        history = []
+        items = set(self.pl.itervalues())
+        self.pl.next()
+        for _ in range(10):
+            history.append(self.pl.current)
+            iter = self.pl.current_iter
+            self.pl.next()
+            self.pl.remove(iter)
+        self.assertSetEqual(set(history), items)
+
     def test_shuffle_repeat_forever(self):
         self.pl.order = RepeatSongForever(OrderShuffle())
         old = self.pl.current

--- a/tests/test_qltk_songmodel.py
+++ b/tests/test_qltk_songmodel.py
@@ -3,6 +3,7 @@
 # the Free Software Foundation; either version 2 of the License, or
 # (at your option) any later version.
 
+from quodlibet.qltk.queue import QueueModel
 from tests import TestCase
 
 from gi.repository import Gtk
@@ -251,7 +252,7 @@ class TPlaylistModel(TestCase):
 
 class TPlaylistMux(TestCase):
     def setUp(self):
-        self.q = PlaylistModel()
+        self.q = QueueModel()
         self.pl = PlaylistModel()
         self.p = NullPlayer()
         self.mux = PlaylistMux(self.p, self.q, self.pl)

--- a/tests/test_qltk_songmodel.py
+++ b/tests/test_qltk_songmodel.py
@@ -137,9 +137,9 @@ class TPlaylistModel(TestCase):
             values = list(self.pl.itervalues())
             rand.shuffle(order)
             self.pl.reorder(order)
-            self.assertNotEqual(values, list(self.pl.itervalues()))
-            self.failUnlessEqual(self.pl.current, history[i],
-                    f"expected different item at index {i}")
+            assert values != list(self.pl.itervalues())
+            assert self.pl.current == history[i], (
+                f"expected different item at index {i}")
             self.pl.previous()
 
     def test_shuffle_next_after_remove(self):
@@ -152,7 +152,7 @@ class TPlaylistModel(TestCase):
             iter = self.pl.current_iter
             self.pl.next()
             self.pl.remove(iter)
-        self.assertSetEqual(set(history), items)
+        assert set(history) == items
 
     def test_shuffle_repeat_forever(self):
         self.pl.order = RepeatSongForever(OrderShuffle())

--- a/tests/test_qltk_songmodel.py
+++ b/tests/test_qltk_songmodel.py
@@ -3,6 +3,7 @@
 # the Free Software Foundation; either version 2 of the License, or
 # (at your option) any later version.
 
+from random import Random
 from quodlibet.qltk.queue import QueueModel
 from tests import TestCase
 
@@ -126,6 +127,20 @@ class TPlaylistModel(TestCase):
             self.pl.next()
             self.assertEqual(self.pl.current, None)
             self.pl.order.reset(self.pl)
+
+    def test_shuffle_previous_after_reorder(self):
+        rand = Random(7)
+        self.pl.order = OrderShuffle()
+        history = [self.pl.current for _ in range(10) if self.pl.next() or True]
+        order = list(range(10))
+        for i in reversed(range(10)):
+            values = list(self.pl.itervalues())
+            rand.shuffle(order)
+            self.pl.reorder(order)
+            self.assertNotEqual(values, list(self.pl.itervalues()))
+            self.failUnlessEqual(self.pl.current, history[i],
+                    f"expected different item at index {i}")
+            self.pl.previous()
 
     def test_shuffle_repeat_forever(self):
         self.pl.order = RepeatSongForever(OrderShuffle())


### PR DESCRIPTION
Check-list
----------

 * [x] There is a linked issue discussing the motivations for this feature or bugfix
 * [x] Unit tests have been added where possible
 * [ ] I've added / updated documentation for any user-facing features.
 * [x] Performance seems to be comparable or better than current `main`


What this change is adding / fixing
-----------------------------------

This is https://github.com/quodlibet/quodlibet/pull/4255 again, with a fix for the usage of invalid iters (#4373 and #4381).

For reference I looked at the super class `TrackCurrentModel` which keeps an iter around in `__iter`. My implementation does not hold on to iters for longer than that class.

Fixes #4108