### PR TITLE
🎨 Some leftover tidying of advanced prefs pane

### DIFF
--- a/quodlibet/operon/commands.py
+++ b/quodlibet/operon/commands.py
@@ -219,9 +219,11 @@ class EditCommand(Command):
                 song.add(key, value)
 
     def _text_to_songs(self, text, songs):
-        text = re.sub(r"^#.*", "", text, 0, re.MULTILINE) # remove comments
-        text = re.sub(r"(\r?\n){2,}", "\n", text.strip()) # remove empty lines
-        _, *texts = re.split(r"^File:\s+", text, 0, re.MULTILINE)
+        # remove comments
+        text = re.sub(r"^#.*", "", text, count=0, flags=re.MULTILINE)
+        # remove empty lines
+        text = re.sub(r"(\r?\n){2,}", "\n", text.strip())
+        _, *texts = re.split(r"^File:\s+", text, maxsplit=0, flags=re.MULTILINE)
 
         for text in texts:
             filename, *lines = text.splitlines()

--- a/quodlibet/qltk/advanced_prefs.py
+++ b/quodlibet/qltk/advanced_prefs.py
@@ -62,7 +62,7 @@ def boolean_config(section, option, label, tooltip):
     return lbl, button_box, revert
 
 
-def revert_button(on_reverted: Callable[[...], None]) -> Gtk.Button:
+def revert_button(on_reverted: Callable[..., None]) -> Gtk.Button:
     revert = Gtk.Button()
     revert.add(Gtk.Image.new_from_icon_name(Icons.DOCUMENT_REVERT, Gtk.IconSize.BUTTON))
     revert.connect("clicked", on_reverted)

--- a/quodlibet/qltk/advanced_prefs.py
+++ b/quodlibet/qltk/advanced_prefs.py
@@ -120,101 +120,101 @@ class AdvancedPreferencesPane(Gtk.VBox):
         rows = [
             text_config(
                 "editing", "id3encoding",
-                "ID3 encodings:",
+                "ID3 encodings",
                 ("ID3 encodings separated by spaces. "
                  "UTF-8 is always tried first, and Latin-1 is always tried last.")),
             text_config(
                 "settings", "search_tags",
-                "Extra search tags:",
+                "Extra search tags",
                 ("Tags that get searched in addition to "
                  'the ones present in the song list. Separate with ","')),
             text_config("editing", "multi_line_tags",
-                        "Multi-line tags:",
+                        "Multi-line tags",
                         ("Tags to consider as multi-line (delimited by \\n) "
                          "rather than multi-valued (comma-separated)")),
-            text_config("settings", "rating_symbol_full", "Rating symbol (full):"),
-            text_config("settings", "rating_symbol_blank", "Rating symbol (blank):"),
+            text_config("settings", "rating_symbol_full", "Rating symbol (full)"),
+            text_config("settings", "rating_symbol_blank", "Rating symbol (blank)"),
             text_config(
                 "player", "backend",
-                "Backend:",
+                "Backend",
                 "Identifier of the playback backend to use"),
             boolean_config(
                 "settings", "disable_hints",
-                "Disable hints:",
+                "Disable hints",
                 "Disable popup windows (treeview hints)"),
             int_config(
                 "browsers", "cover_size",
-                "Album cover size:",
+                "Album cover size",
                 ("Size of the album cover images in the album list browser "
                  "(restart required)")),
             text_config(
                 "albumart", "search_filenames",
-                "Album art search filenames:",
+                "Album art search filenames",
                 "Which specific files are (also) tried for album art"),
             boolean_config(
                 "settings", "disable_mmkeys",
-                "Disable multimedia keys:",
+                "Disable multimedia keys",
                 "(restart required)"),
             text_config(
                 "settings", "window_title_pattern",
-                "Main window title:",
+                "Main window title",
                 ("A (tied) tag for the main window title, e.g. ~title~~people "
                  "(restart required)")),
             text_config(
                 "settings", "datecolumn_timestamp_format",
-                "Timestamp date format:",
+                "Timestamp date format",
                 "A timestamp format for dates, e.g. %Y%m%d %X (restart required)"),
             boolean_config(
                 "settings", "scrollbar_always_visible",
-                "Scrollbars always visible:",
+                "Scrollbars always visible",
                 ("Toggles whether the scrollbars on the bottom and side of "
                  "the window always are visible or get hidden when not in use "
                  "(restart required)")),
             boolean_config(
                 "settings", "monospace_query",
-                "Use monospace font for search input:",
+                "Use monospace font for search input",
                 "Helps readability of code-like queries, but looks less consistent "
                 "(restart required)"),
             text_config(
                 "settings", "query_font_size",
-                "Search input font size:",
+                "Search input font size",
                 "Size to apply to the search query entry, "
                 "in any Pango CSS units, e.g. '100%', '1rem'. (restart required)"),
             boolean_config(
                 "settings", "pangocairo_force_fontconfig",
-                "Force Use Fontconfig Backend:",
+                "Force Use Fontconfig Backend",
                 "It's not the default on win/macOS (restart required)"),
             text_config(
                 "browsers", "ignored_characters",
-                "Ignored characters:",
+                "Ignored characters",
                 "Characters to ignore in queries"),
             boolean_config(
                 "settings", "plugins_window_on_top",
-                "Plugin window on top:",
+                "Plugin window on top",
                 "Toggles whether the plugin window appears on top of others"),
             int_config(
                 "autosave", "queue_interval",
-                "Queue autosave interval:",
+                "Queue autosave interval",
                 ("Longest time between play queue auto-saves, or 0 for disabled. "
                  "(restart required)")),
             int_config(
                 "browsers", "searchbar_historic_entries",
-                "Number of history entries in the search bar:",
+                "Number of history entries in the search bar",
                 "8 by default (restart advised)"),
             int_config(
                 "browsers", "searchbar_enqueue_limit",
-                "Search bar confirmation limit for enqueue:",
+                "Search bar confirmation limit for enqueue",
                 ("Maximal size of the song list that can be enqueued from "
                  "the search bar without confirmation.")),
             slider_config(
                 "player", "playcount_minimum_length_proportion",
-                "Minimum length to consider a track as played:",
+                "Minimum length to consider a track as played",
                 ("Consider a track played after listening to this proportion of "
                  "its total duration"),
                 label_value_callback=lambda value: f"{int(value * 100)}%"),
             text_config(
                 "browsers", "missing_title_template",
-                "Missing title template string:",
+                "Missing title template string",
                 ("Template for building title of tracks when title tag is missing. "
                  "Tags are allowed, like <~basename> <~dirname> <~format> <~length> "
                  "<~#bitrate>, etc. See tags documentation for details.")

--- a/quodlibet/qltk/advanced_prefs.py
+++ b/quodlibet/qltk/advanced_prefs.py
@@ -8,13 +8,15 @@
 # the Free Software Foundation; either version 2 of the License, or
 # (at your option) any later version.
 
+from typing import Callable
+
 from gi.repository import Gtk
 
 from quodlibet import _
 from quodlibet import config
+from quodlibet.qltk import Icons
 from quodlibet.qltk.ccb import ConfigSwitch
 from quodlibet.qltk.entry import UndoEntry
-from quodlibet.qltk import Icons
 from quodlibet.util.string import decode
 
 
@@ -32,16 +34,10 @@ def _config(section, option, label, tooltip=None, getter=None):
         config.reset(section, option)
         entry.set_text(config.gettext(section, option))
 
-    revert = Gtk.Button()
-    revert.add(Gtk.Image.new_from_icon_name(
-        Icons.DOCUMENT_REVERT, Gtk.IconSize.BUTTON))
-    revert.connect("clicked", on_reverted)
-    revert.set_tooltip_text(_("Revert to default"))
-
+    revert = revert_button(on_reverted)
     lbl = Gtk.Label(label=label, use_underline=True)
     lbl.set_mnemonic_widget(entry)
-
-    return (lbl, entry, revert)
+    return lbl, entry, revert
 
 
 def text_config(section, option, label, tooltip=None):
@@ -60,13 +56,18 @@ def boolean_config(section, option, label, tooltip):
     button_box = Gtk.VBox(homogeneous=True)
     button_box.pack_start(button, False, False, 0)
 
+    lbl = Gtk.Label(label=label, use_underline=True)
+    lbl.set_mnemonic_widget(button.switch)
+    revert = revert_button(on_reverted)
+    return lbl, button_box, revert
+
+
+def revert_button(on_reverted: Callable[[...], None]) -> Gtk.Button:
     revert = Gtk.Button()
     revert.add(Gtk.Image.new_from_icon_name(Icons.DOCUMENT_REVERT, Gtk.IconSize.BUTTON))
     revert.connect("clicked", on_reverted)
-
-    lbl = Gtk.Label(label=label, use_underline=True)
-    lbl.set_mnemonic_widget(button)
-    return lbl, button_box, revert
+    revert.set_tooltip_text(_("Revert to default"))
+    return revert
 
 
 def int_config(section, option, label, tooltip):
@@ -101,10 +102,7 @@ def slider_config(section, option, label, tooltip, lower=0, upper=1,
         scale.connect("format-value", lambda _, value: label_value_callback(value))
     scale.connect("value-changed", on_change)
 
-    revert = Gtk.Button()
-    revert.add(Gtk.Image.new_from_icon_name(Icons.DOCUMENT_REVERT, Gtk.IconSize.BUTTON))
-    revert.connect("clicked", on_reverted)
-
+    revert = revert_button(on_reverted)
     lbl = Gtk.Label(label=label, use_underline=True)
     lbl.set_mnemonic_widget(scale)
     return lbl, scale, revert

--- a/quodlibet/qltk/ccb.py
+++ b/quodlibet/qltk/ccb.py
@@ -1,5 +1,5 @@
 # Copyright 2005 Joe Wreschnig, Michael Urman
-#        2012-22 Nick Boultbee
+#        2012-23 Nick Boultbee
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -43,11 +43,12 @@ class ConfigSwitch(Gtk.Box):
     def __init__(self, label, section, option, populate=False, tooltip=None,
                  default=None):
         super().__init__()
-        self.label = Gtk.Label(label, use_underline=True)
         self.switch = Gtk.Switch()
-        self.label.set_mnemonic_widget(self.switch)
         eb = Gtk.EventBox()
-        eb.add(self.label)
+        if label is not None:
+            self.label = Gtk.Label(label, use_underline=True)
+            self.label.set_mnemonic_widget(self.switch)
+            eb.add(self.label)
         self.pack_start(eb, False, True, 0)
         self.pack_end(self.switch, False, True, 0)
         if default is None:
@@ -56,7 +57,7 @@ class ConfigSwitch(Gtk.Box):
         if populate:
             self.set_active(config.getboolean(section, option, default))
         if tooltip:
-            self.label.set_tooltip_text(tooltip)
+            self.switch.set_tooltip_text(tooltip)
         self.switch.connect("notify::active", self.__activated, section, option)
         eb.connect("button_press_event",
                    lambda *_: self.switch.set_state(not self.switch.get_state()))

--- a/quodlibet/qltk/prefs.py
+++ b/quodlibet/qltk/prefs.py
@@ -1,6 +1,6 @@
 # Copyright 2004-2009 Joe Wreschnig, Michael Urman, Iñigo Serna,
 #                     Steven Robertson
-#           2011-2022 Nick Boultbee
+#           2011-2023 Nick Boultbee
 #           2013      Christoph Reiter
 #           2014      Jan Path
 #           2023      Jej@github
@@ -751,16 +751,10 @@ class PreferencesWindow(UniqueWindow):
             super().__init__(spacing=MARGIN)
             self.set_border_width(12)
             self.title = _("Advanced")
-
-            advanced_pane = AdvancedPreferencesPane()
-            vbox = advanced_pane.create_display_frame()
-
             scrolledwin = Gtk.ScrolledWindow()
-            scrolledwin.set_policy(Gtk.PolicyType.AUTOMATIC,
-                                Gtk.PolicyType.AUTOMATIC)
-            scrolledwin.add_with_viewport(vbox)
-
-            self.pack_start(scrolledwin, True, True, MARGIN)
+            scrolledwin.set_policy(Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.AUTOMATIC)
+            scrolledwin.add_with_viewport(AdvancedPreferencesPane())
+            self.pack_start(scrolledwin, True, True, 3)
 
     def __init__(self, parent, open_page=None, all_pages=True):
         if self.is_not_unique():


### PR DESCRIPTION
See #4411, now rebased to bits that already achieved

* Inherit from VBox like other panes, makes life a bit simpler
* Tweak padding to match a bit more
* Use customised config Switch, reduces duplication
* Left align labels for consistency with other prefs panes
* Remove some redundant code

### Looks like
![image](https://github.com/quodlibet/quodlibet/assets/3322808/8dd14678-3374-484d-a91b-7ede7bd20f17)
