### PR TITLE
gdist: fix create_po command in case LANG isn't set

### DIFF
--- a/gdist/gettextutil.py
+++ b/gdist/gettextutil.py
@@ -293,7 +293,7 @@ def check_pot(pot_path: Path) -> None:
     po_path = Path(po_path)
     os.close(fd)
     po_path.unlink()
-    create_po(pot_path, po_path)
+    create_po(pot_path, po_path, "C")
 
     try:
         check_po(po_path, ignore_header=True)
@@ -301,7 +301,7 @@ def check_pot(pot_path: Path) -> None:
         os.remove(po_path)
 
 
-def create_po(pot_path: Path, po_path: Path) -> None:
+def create_po(pot_path: Path, po_path: Path, lang_code: str) -> None:
     """Create a new <po_path> file based on <pot_path>
 
     :raises GettextError: in case something went wrong or the file already exists.
@@ -315,7 +315,8 @@ def create_po(pot_path: Path, po_path: Path) -> None:
 
     try:
         subprocess.check_output(
-            ["msginit", "--no-translator", "-i", str(pot_path), "-o", str(po_path)],
+            ["msginit", "--no-translator", "--locale", lang_code,
+             "-i", str(pot_path), "-o", str(po_path)],
             universal_newlines=True, stderr=subprocess.STDOUT)
     except subprocess.CalledProcessError as e:
         raise GettextError(e.output) from e

--- a/gdist/po.py
+++ b/gdist/po.py
@@ -140,7 +140,7 @@ class CreatePo(Command):
         po_directory = Path(self.distribution.po_directory)
         po_path = gettextutil.get_po_path(po_directory, self.lang)
         with gettextutil.create_pot(po_directory) as pot_path:
-            gettextutil.create_po(pot_path, po_path)
+            gettextutil.create_po(pot_path, po_path, self.lang)
             print(f"Created {po_path.absolute()}")
 
 


### PR DESCRIPTION
msginit defaults to LANG for the language it writes into the .po file and fails if LANG is not sure, which is usually only the case on Windows. And everwhere else it would write the wrong language ID into the file.

Explicitely pass the locale to msginit to fix this.
