### PR TITLE
Fix paned browser total rendering (#4415)

### DIFF
--- a/quodlibet/browsers/paned/pane.py
+++ b/quodlibet/browsers/paned/pane.py
@@ -1,4 +1,5 @@
 # Copyright 2013 Christoph Reiter
+#           2023 Nick Boultbee
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -51,7 +52,7 @@ class Pane(AllTreeView):
         column.connect("button-press-event", on_column_header_clicked)
         column.set_use_markup(True)
         column.set_sizing(Gtk.TreeViewColumnSizing.FIXED)
-        column.set_fixed_width(50)
+        column.set_fixed_width(60)
 
         render = Gtk.CellRendererText()
         render.set_property("ellipsize", Pango.EllipsizeMode.END)
@@ -71,7 +72,10 @@ class Pane(AllTreeView):
 
         render_count = Gtk.CellRendererText()
         render_count.set_property("xalign", 1.0)
-        column.pack_start(render_count, False)
+        render_count.set_property("max-width-chars", 5)
+        column.pack_end(render_count, True)
+        # Tiny columns break too much rendering
+        column.set_min_width(150)
 
         def count_cdf(column, cell, model, iter_, data):
             entry = model.get_value(iter_)


### PR DESCRIPTION
(Various tidyings shelved, to be pushed separately)

* Allow expansion of last widget (totals)
* And pack from the end, no real difference I guess but feels nicer
* Nudge the "fixed" column width upwards; hard to tell if this affects anything
* But also set metadata on the renderer to hard limit to 5 digits
* Set an overall min width, as crazy small makes for breakage even with above.

### Before

![Screenshot from 2023-11-05 21-02-56](https://github.com/quodlibet/quodlibet/assets/3322808/a92bac48-acc2-4e29-80f2-eacbb128c433)

### After
![Screenshot from 2023-11-05 21-02-14](https://github.com/quodlibet/quodlibet/assets/3322808/44aef673-83fc-4a55-96b0-5a7ba413c410)


Fixes #4415 