### PR TITLE
Fix paned browser UI regression after #4421

### DIFF
--- a/quodlibet/browsers/paned/models.py
+++ b/quodlibet/browsers/paned/models.py
@@ -96,8 +96,8 @@ class AllEntry(BaseEntry):
     def get_count_markup(self, config: PaneConfig) -> str:
         return ""
 
-    def get_markup(self, config):
-        return True, util.bold(_("All"))
+    def get_markup(self, config: PaneConfig) -> str:
+        return util.bold(_("All"))
 
     def contains_text(self, text):
         return False

--- a/quodlibet/browsers/paned/pane.py
+++ b/quodlibet/browsers/paned/pane.py
@@ -60,7 +60,8 @@ class Pane(AllTreeView):
 
         def text_cdf(column, cell, model, iter_, data):
             entry = model.get_value(iter_)
-            cell.markup = entry.get_markup(self.config)
+            markup = entry.get_markup(self.config)
+            cell.set_property("markup", markup)
 
         column.set_cell_data_func(render, text_cdf)
 


### PR DESCRIPTION
* Fix remaining tuple return type (hence reported `TypeError`), which MyPy also didn't seem to warn about
* Seems like `markup` setter is not very useful by itself 😕

Fixes #4422
