### PR TITLE
Fix incorrect property name

### DIFF
--- a/quodlibet/ext/songsmenu/replaygain.py
+++ b/quodlibet/ext/songsmenu/replaygain.py
@@ -340,7 +340,7 @@ class ReplayGainPipeline(GObject.Object):
             if gerror:
                 print_e(gerror.message)
             print_e(debug)
-            self._current.Error = True
+            self._current.error = True
             self._next_song()
 
 
@@ -373,7 +373,7 @@ class RGDialog(Dialog):
 
         def icon_cdf(column, cell, model, iter_, *args):
             item = model[iter_][0]
-            if item.Error:
+            if item.error:
                 cell.set_property("icon-name", Icons.DIALOG_ERROR)
             else:
                 cell.set_property("icon-name", Icons.NONE)


### PR DESCRIPTION
Not sure how this happened, looks like maybe an overeager global search and replace, but the `RGSong` and `RGAlbum` objects do not have an `.Error` property, instead it should be `.error`.

Check-list
----------

 * [ ] There is a linked issue discussing the motivations for this feature or bugfix
 * [ ] Unit tests have been added where possible
 * [ ] I've added / updated documentation for any user-facing features.
 * [x] Performance seems to be comparable or better than current `main`


What this change is adding / fixing
-----------------------------------
<!-- A high-level description of the changes.
Hopefully the commits are atomic and well described, but this is the overall
summary of the change, to other developers / maintainers, plus any TODOs. -->

