### PR TITLE
Fix a few more accidental renamings of `.error` from #4404

### DIFF
--- a/quodlibet/ext/songsmenu/fingerprint/search.py
+++ b/quodlibet/ext/songsmenu/fingerprint/search.py
@@ -415,10 +415,10 @@ class SearchWindow(Window):
             # update display
             if lresult.releases:
                 self.__update_active_releases()
-            elif lresult.Error:
+            elif lresult.error:
                 entry.status = Status.ERROR
                 # we don't expose in the UI, so at least print it
-                print_w(lresult.Error)
+                print_w(lresult.error)
             else:
                 entry.status = Status.UNKNOWN
 

--- a/quodlibet/ext/songsmenu/replaygain.py
+++ b/quodlibet/ext/songsmenu/replaygain.py
@@ -89,7 +89,7 @@ class RGAlbum:
     @property
     def error(self):
         for song in self.songs:
-            if song.Error:
+            if song.error:
                 return True
         return False
 


### PR DESCRIPTION
Fixes #4427

