### PR TITLE
Rename remaining `Menu()` methods to `menu()`, and add tests

### DIFF
--- a/quodlibet/ext/songsmenu/duplicates.py
+++ b/quodlibet/ext/songsmenu/duplicates.py
@@ -50,13 +50,11 @@ class DuplicateSongsView(RCMHintedTreeView):
                 selected.append(row[0])
         return selected
 
-    def Menu(self, library):
+    def menu(self, library):
         songs = self.get_selected_songs()
         if not songs:
             return
-
-        menu = SongsMenu(
-            library, songs, delete=True, plugins=False, playlists=False)
+        menu = SongsMenu(library, songs, delete=True, plugins=False, playlists=False)
         menu.show_all()
         return menu
 

--- a/quodlibet/qltk/browser.py
+++ b/quodlibet/qltk/browser.py
@@ -340,7 +340,7 @@ class LibraryBrowser(Window, util.InstanceTracker, PersistentWindowMixin):
             else:
                 header.set_visible(False)
 
-    def __menu(self, view, library):
+    def _menu(self, view, library):
         path, col = view.get_cursor()
         header = col.header_name
         menu = view.menu(header, self.browser, library)

--- a/quodlibet/qltk/browser.py
+++ b/quodlibet/qltk/browser.py
@@ -294,7 +294,7 @@ class LibraryBrowser(Window, util.InstanceTracker, PersistentWindowMixin):
 
         browser.connect("songs-selected", self.__browser_cb)
         browser.finalize(False)
-        view.connect("popup-menu", self.__menu, library)
+        view.connect("popup-menu", self._menu, library)
         view.connect("drag-data-received", self.__drag_data_recv)
         view.connect("row-activated", self.__enqueue, player)
 

--- a/quodlibet/qltk/exfalsowindow.py
+++ b/quodlibet/qltk/exfalsowindow.py
@@ -206,7 +206,7 @@ class ExFalsoWindow(Window, PersistentWindowMixin, AppWindow):
         songs = [s for s in maybe_songs if s]
 
         if songs:
-            menu = self.pm.Menu(self.__library, songs)
+            menu = self.pm.menu(self.__library, songs)
             if menu is None:
                 menu = Gtk.Menu()
             else:

--- a/quodlibet/qltk/quodlibetwindow.py
+++ b/quodlibet/qltk/quodlibetwindow.py
@@ -1334,7 +1334,7 @@ class QuodLibetWindow(Window, PersistentWindowMixin, AppWindow):
     def __songs_popup_menu(self, songlist):
         path, col = songlist.get_cursor()
         header = col.header_name
-        menu = self.songlist.Menu(header, self.browser, self.__library)
+        menu = self.songlist.menu(header, self.browser, self.__library)
         if menu is not None:
             return self.songlist.popup_menu(menu, 0,
                     Gtk.get_current_event_time())

--- a/quodlibet/qltk/songlist.py
+++ b/quodlibet/qltk/songlist.py
@@ -377,7 +377,7 @@ class SongList(AllTreeView, SongListDnDMixin, DragScroll, util.InstanceTracker):
 
     star = list(Query.STAR)
 
-    def Menu(self, header, browser, library):
+    def menu(self, header: str, browser, library):
         songs = self.get_selected_songs()
         if not songs:
             return

--- a/quodlibet/qltk/songsmenu.py
+++ b/quodlibet/qltk/songsmenu.py
@@ -89,7 +89,7 @@ class SongsMenuPluginHandler(PluginHandler):
         if album_confirmer is not None:
             self._confirm_multiple_albums = album_confirmer
 
-    def Menu(self, library, songs):
+    def menu(self, library, songs):
         songs = list_wrapper(songs)
 
         attrs = ["plugin_song", "plugin_songs",
@@ -290,7 +290,7 @@ class SongsMenu(Gtk.Menu):
             self.separate()
 
         if plugins:
-            submenu = self.plugins.Menu(librarian, songs)
+            submenu = self.plugins.menu(librarian, songs)
             if submenu is not None:
                 b = qltk.MenuItem(_("_Plugins"), Icons.SYSTEM_RUN)
                 b.set_sensitive(bool(songs))

--- a/tests/test_plugins_songsmenu.py
+++ b/tests/test_plugins_songsmenu.py
@@ -113,12 +113,12 @@ class TSongsMenuPlugins(TestCase):
         plug = self.pm.plugins[0]
         self.pm.enable(plug, True)
         with capture_output():
-            menu = self.handler.Menu(None, [AudioFile()])
+            menu = self.handler.menu(None, [AudioFile()])
         self.assertFalse(menu and menu.get_children())
 
     def test_Menu(self):
         self.create_plugin(name="Name", desc="Desc", funcs=["plugin_song"])
-        self.handler.Menu(None, [AudioFile()])
+        self.handler.menu(None, [AudioFile()])
 
     def test_handling_songs_without_confirmation(self):
         plugin = Plugin(FakeSongsMenuPlugin)

--- a/tests/test_qltk_browser.py
+++ b/tests/test_qltk_browser.py
@@ -3,19 +3,23 @@
 # the Free Software Foundation; either version 2 of the License, or
 # (at your option) any later version.
 
-import quodlibet.config
+from gi.repository import Gtk
+
+from quodlibet import app
 from quodlibet.browsers.albums import AlbumList
 from quodlibet.browsers.tracks import TrackList
-from quodlibet.library import SongLibrarian, SongLibrary
+from quodlibet.formats import AudioFile
+from quodlibet.library import SongLibrarian
 from quodlibet.player.nullbe import NullPlayer
 from quodlibet.qltk.browser import LibraryBrowser
-from tests import TestCase
+from quodlibet.qltk.songlist import SongList
+from tests import TestCase, init_fake_app, destroy_fake_app
 
 
 class TLibraryBrowser(TestCase):
     def setUp(self):
-        quodlibet.config.init()
-        self.library = SongLibrary()
+        init_fake_app()
+        self.library = app.library
 
     def test_ctr(self):
         win = LibraryBrowser(AlbumList, self.library, NullPlayer())
@@ -30,6 +34,19 @@ class TLibraryBrowser(TestCase):
         self.assertTrue(widget.get_visible())
         widget.destroy()
 
+    def test_popup_menu(self):
+        self.library.librarian = SongLibrarian()
+        widget = LibraryBrowser.open(TrackList, self.library, NullPlayer())
+        songlist: SongList = widget.songlist
+        widget.songlist.set_column_headers(["artist"])
+        a_song = AudioFile({"~filename": "/dev/null"})
+        songlist.add_songs([a_song])
+        songlist.set_cursor(Gtk.TreePath(0), widget.songlist.get_columns()[0])
+        called = []
+        songlist.popup_menu = lambda *args: called.append(args)
+        widget._menu(songlist, self.library)
+        assert len(called) == 1, "Should have called menu once"
+        assert len(called[0][0].get_children()) > 6, "doesn't seem enough items"
+
     def tearDown(self):
-        self.library.destroy()
-        quodlibet.config.quit()
+        destroy_fake_app()

--- a/tests/test_qltk_songlist.py
+++ b/tests/test_qltk_songlist.py
@@ -214,10 +214,10 @@ class TSongList(TestCase):
 
         self.songlist.set_column_headers(["foo"])
 
-        self.assertFalse(self.songlist.Menu("foo", browser, library))
+        self.assertFalse(self.songlist.menu("foo", browser, library))
         sel = self.songlist.get_selection()
         sel.select_all()
-        self.assertTrue(self.songlist.Menu("foo", browser, library))
+        self.assertTrue(self.songlist.menu("foo", browser, library))
         librarian.destroy()
         self.lib.librarian = None
 


### PR DESCRIPTION
* Rename `Menu` to `menu` for compliance and sanity
* Add test for pop-up menu in secondary browsers that should have caught this

Fixes #4438
