### PR TITLE
sort list of active plugins in config file

### DIFF
--- a/quodlibet/config.py
+++ b/quodlibet/config.py
@@ -288,7 +288,7 @@ INITIAL: dict[str, dict[str, str]] = {
 
     "plugins": {
         # newline-separated plugin IDs
-        "active_plugins": "\n".join(AUTO_ENABLED_PLUGINS),
+        "active_plugins": "\n".join(sorted(AUTO_ENABLED_PLUGINS)),
 
         # Issue 1231: Maximum number of SongsMenu plugins to run at once
         "default_max_plugin_invocations": "30",

--- a/quodlibet/plugins/__init__.py
+++ b/quodlibet/plugins/__init__.py
@@ -90,7 +90,7 @@ def migrate_old_config():
             config._config.remove_option("plugins", key)
 
     if active:
-        config.set("plugins", "active_plugins", "\n".join(active))
+        config.set("plugins", "active_plugins", "\n".join(sorted(active)))
 
 
 def list_plugins(module):
@@ -330,7 +330,7 @@ class PluginManager:
         print_d("Saving plugins: %d active" % len(self.__enabled))
         config.set(self.CONFIG_SECTION,
                    self.CONFIG_OPTION,
-                   "\n".join(self.__enabled))
+                   "\n".join(sorted(self.__enabled)))
 
     def enabled(self, plugin):
         """Returns if the plugin is enabled."""


### PR DESCRIPTION
Check-list
----------

 * [ ] There is a linked issue discussing the motivations for this feature or bugfix
 * [ ] Unit tests have been added where possible
 * [ ] I've added / updated documentation for any user-facing features.
 * [ ] Performance seems to be comparable or better than current `main`


What this change is adding / fixing
-----------------------------------
I store the config in version control (git) and without sorting the list of active plugins it may look changing for version control without any changes