### PR TITLE
Fix the clickability when always allowing sorting

### DIFF
--- a/quodlibet/qltk/songlist.py
+++ b/quodlibet/qltk/songlist.py
@@ -407,7 +407,7 @@ class SongList(AllTreeView, SongListDnDMixin, DragScroll, util.InstanceTracker):
     def __init__(self, library, player=None, update=False, model_cls=PlaylistModel,
                  sortable: bool = True):
         super().__init__()
-        self._sortable = sortable
+        self.sortable = sortable
         self._register_instance(SongList)
         self.set_model(model_cls())
         self.info = SongSelectionInfo(self)
@@ -454,7 +454,7 @@ class SongList(AllTreeView, SongListDnDMixin, DragScroll, util.InstanceTracker):
         # It's either sortable or clickable columns, both ends in a buggy UI (see #4099)
         always_sortable = config.getboolean("song_list", "always_allow_sorting")
         self._sortable = value or always_sortable
-        self.set_headers_clickable(value)
+        self.set_headers_clickable(self._sortable)
 
     @property
     def model(self) -> Gtk.TreeModel:

--- a/tests/test_qltk_songlist.py
+++ b/tests/test_qltk_songlist.py
@@ -105,10 +105,14 @@ class TSongList(TestCase):
         config.set("song_list", "always_allow_sorting", False)
         s = self.songlist
         s.sortable = False
+
         s.set_column_headers(["foo"])
         s.toggle_column_sort(s.get_columns()[0])
         assert self.orders_changed == 0
         assert not s.get_sort_orders()
+        # This appears buggy in tests
+        # assert s.get_headers_clickable() is False
+
 
     def test_sortable_if_config_overrides(self):
         config.set("song_list", "always_allow_sorting", True)
@@ -118,6 +122,7 @@ class TSongList(TestCase):
         s.set_column_headers(["foo"])
         s.toggle_column_sort(s.get_columns()[0])
         assert s.get_sort_orders()
+        assert s.get_headers_clickable() is True
 
     def test_find_default_sort_column(self):
         s = self.songlist


### PR DESCRIPTION
Override wasn't affecting the _clickability_ of the column header

Unit testing this is proving pretty impossible though...

Fixes #4447
