### PR TITLE
Docs: Add unofficial macOS 4.6.0 builds

### DIFF
--- a/docs/tables/osx_quodlibet.rst
+++ b/docs/tables/osx_quodlibet.rst
@@ -5,6 +5,10 @@
       - File
       - SHA256
       - PGP
+    * - Quod Libet 4.6.1 (unofficial)
+      - `QuodLibet-4.6.1.dmg <https://github.com/jdykstra/quodlibet/releases/download/release-4.6.1/QuodLibet-4.6.1.dmg>`__
+      - N/A
+      - N/A
     * - Quod Libet 4.4.0
       - `QuodLibet-4.4.0.dmg <https://github.com/quodlibet/quodlibet/releases/download/release-4.4.0/QuodLibet-4.4.0.dmg>`__
       - `SHA256 <https://github.com/quodlibet/quodlibet/releases/download/release-4.4.0/QuodLibet-4.4.0.dmg.sha256>`__
@@ -13,7 +17,3 @@
       - `QuodLibet-4.3.0.dmg <https://github.com/quodlibet/quodlibet/releases/download/release-4.3.0/QuodLibet-4.3.0.dmg>`__
       - `SHA256 <https://github.com/quodlibet/quodlibet/releases/download/release-4.3.0/QuodLibet-4.3.0.dmg.sha256>`__
       - `SIG <https://github.com/quodlibet/quodlibet/releases/download/release-4.3.0/QuodLibet-4.3.0.dmg.sig>`__
-    * - Quod Libet 4.2.1
-      - `QuodLibet-4.2.1.dmg <https://github.com/quodlibet/quodlibet/releases/download/release-4.2.1/QuodLibet-4.2.1.dmg>`__
-      - `SHA256 <https://github.com/quodlibet/quodlibet/releases/download/release-4.2.1/QuodLibet-4.2.1.dmg.sha256>`__
-      - `SIG <https://github.com/quodlibet/quodlibet/releases/download/release-4.2.1/QuodLibet-4.2.1.dmg.sig>`__


### PR DESCRIPTION
Obviously it'd be better to have official builds here, but this still seems incrementally better than _not_ having these at all / relying on people browsing Github issues...


See #4464 for discussion