### PR TITLE
Different approach to unsortable columns

### DIFF
--- a/quodlibet/qltk/songlist.py
+++ b/quodlibet/qltk/songlist.py
@@ -454,7 +454,13 @@ class SongList(AllTreeView, SongListDnDMixin, DragScroll, util.InstanceTracker):
         # It's either sortable or clickable columns, both ends in a buggy UI (see #4099)
         always_sortable = config.getboolean("song_list", "always_allow_sorting")
         self._sortable = value or always_sortable
-        self.set_headers_clickable(self._sortable)
+        for col in self.get_columns():
+            try:
+                col.get_widget().set_sensitive(self._sortable)
+            except (TypeError, AttributeError):
+                # Just in case columns don't always work like this
+                pass
+
 
     @property
     def model(self) -> Gtk.TreeModel:
@@ -1115,6 +1121,8 @@ class SongList(AllTreeView, SongListDnDMixin, DragScroll, util.InstanceTracker):
                     column.set_expand(True)
 
             def column_clicked(column, *args):
+                if not self._sortable:
+                    return
                 # if ctrl is held during the sort click, append a sort key
                 # or change order if already sorted
                 ctrl_held = False

--- a/tests/test_qltk_songlist.py
+++ b/tests/test_qltk_songlist.py
@@ -110,8 +110,6 @@ class TSongList(TestCase):
         s.toggle_column_sort(s.get_columns()[0])
         assert self.orders_changed == 0
         assert not s.get_sort_orders()
-        # This appears buggy in tests
-        # assert s.get_headers_clickable() is False
 
 
     def test_sortable_if_config_overrides(self):
@@ -122,7 +120,6 @@ class TSongList(TestCase):
         s.set_column_headers(["foo"])
         s.toggle_column_sort(s.get_columns()[0])
         assert s.get_sort_orders()
-        assert s.get_headers_clickable() is True
 
     def test_find_default_sort_column(self):
         s = self.songlist


### PR DESCRIPTION
* Allows right-clicking to work still, when in playlist with _always allow sorting_ disabled
* ...at the expense of not being obvious something is unsortable.

See #4447

Fixes #4461
