### PR TITLE
TrackNumbers: Up limit to 9999

### DIFF
--- a/quodlibet/qltk/tracknumbers.py
+++ b/quodlibet/qltk/tracknumbers.py
@@ -41,7 +41,7 @@ class TrackNumbers(Gtk.VBox):
         label_start = Gtk.Label(label=_("Start fro_m:"), halign=Gtk.Align.END)
         label_start.set_use_underline(True)
         spin_start = Gtk.SpinButton()
-        spin_start.set_range(0, 999)
+        spin_start.set_range(0, 9999)
         spin_start.set_increments(1, 10)
         spin_start.set_value(1)
         label_start.set_mnemonic_widget(spin_start)
@@ -50,7 +50,7 @@ class TrackNumbers(Gtk.VBox):
             label=_("_Total tracks:"), halign=Gtk.Align.END)
         label_total.set_use_underline(True)
         spin_total = Gtk.SpinButton()
-        spin_total.set_range(0, 999)
+        spin_total.set_range(0, 9999)
         spin_total.set_increments(1, 10)
         label_total.set_mnemonic_widget(spin_total)
 


### PR DESCRIPTION
Check-list
----------

- [x] There is a linked issue discussing the motivations for this feature or bugfix
   - https://github.com/quodlibet/quodlibet/issues/4470
- [ ] Unit tests have been added where possible
- [ ] I've added / updated documentation for any user-facing features.
- [x] Performance seems to be comparable or better than current `main`


What this change is adding / fixing
-----------------------------------

When processing batches of files from multiple discs the current limit of 999 can be exceeded (e.g., audiobooks). This PR raises the limit from 999 to 9999. 

This effectively mirrors the change last made in d8c637012173d75ed574d7f668c6068b47c6797b (nearly 17 years ago) when the limit was raised by a factor of 10 from 99 to 999.