### PR TITLE
Move to zlib 1.3.1 to fix OS X build failure

### DIFF
--- a/dev-utils/osx_bundle/modulesets/quodlibet.modules
+++ b/dev-utils/osx_bundle/modulesets/quodlibet.modules
@@ -206,9 +206,9 @@
 
   <autotools id="zlib" autogen-sh="configure" skip-autogen="never"
              supports-non-srcdir-builds="no">
-    <branch repo="zlib" version="1.3"
+    <branch repo="zlib" version="1.3.1"
             module="zlib-${version}.tar.xz"
-            hash="sha256:8a9ba2898e1d0d774eca6ba5b4627a11e5588ba85c8851336eb38de4683050a7"/>
+            hash="sha256:38ef96b8dfe510d42707d9c781877914792541133e1870841463bfa73f883e32"/>
   </autotools>
 
   <autotools id="libffi" autogenargs="--disable-builddir"


### PR DESCRIPTION
Move to zlib 1.3.1.  The previous version is no longer available upstream.

Fixes #4490.