### PR TITLE
Include configured title/album details in MPRIS plugin

### DIFF
--- a/quodlibet/ext/events/mpris/mpris2.py
+++ b/quodlibet/ext/events/mpris/mpris2.py
@@ -14,6 +14,7 @@ from senf import fsn2uri
 
 from quodlibet import app
 from quodlibet.order.repeat import RepeatListForever, RepeatSongForever
+from quodlibet.qltk.songlist import get_columns
 from quodlibet.util.dbusutils import DBusIntrospectable, DBusProperty
 from quodlibet.util.dbusutils import dbus_unicode_validate as unival
 
@@ -279,7 +280,13 @@ value="false"/>
                 metadata["xesam:" + xesam] = list(map(unival, vals))
 
         # All single values
-        sing_val = {"album": "album", "title": "title", "asText": "~lyrics"}
+        columns = get_columns()
+        title_tag = "~title~version" if "~title~version" in columns \
+                    else "title"
+        album_tag = "~album~discsubtitle" if "~album~discsubtitle" in columns \
+                    else "album"
+
+        sing_val = {"album": album_tag, "title": title_tag, "asText": "~lyrics"}
         for xesam, tag in sing_val.items():
             vals = song.comma(tag)
             if vals:

--- a/quodlibet/ext/events/mpris/mpris2.py
+++ b/quodlibet/ext/events/mpris/mpris2.py
@@ -281,10 +281,10 @@ value="false"/>
 
         # All single values
         columns = get_columns()
-        title_tag = "~title~version" if "~title~version" in columns \
-                    else "title"
-        album_tag = "~album~discsubtitle" if "~album~discsubtitle" in columns \
-                    else "album"
+        title_tag = ("~title~version" if "~title~version" in columns 
+                     else "title")
+        album_tag = ("~album~discsubtitle" if "~album~discsubtitle" in columns
+                     else "album")
 
         sing_val = {"album": album_tag, "title": title_tag, "asText": "~lyrics"}
         for xesam, tag in sing_val.items():


### PR DESCRIPTION
Check-list
----------

 * [-] There is a linked issue discussing the motivations for this feature or bugfix
 * [x] Unit tests have been added where possible
 * [-] I've added / updated documentation for any user-facing features.
 * [x] Performance seems to be comparable or better than current `main`


What this change is adding / fixing
-----------------------------------
<!-- A high-level description of the changes.
Hopefully the commits are atomic and well described, but this is the overall
summary of the change, to other developers / maintainers, plus any TODOs. -->

If the main song list is configured to include the version in the title,
or the disc subtitle in the album, add these to the MPRIS metadata as
well, since MPRIS doesn't define any fields for them.

These are the existing settings I'm reusing (enabled by default):

![image](https://github.com/quodlibet/quodlibet/assets/6501/84634614-0163-4d0f-a47b-d72524911b9c)

Tested with https://extensions.gnome.org/extension/4470/media-controls/ on GNOME.