### PR TITLE
PlaycountEqualizer extension improvements

### DIFF
--- a/quodlibet/ext/playorder/playcounteq.py
+++ b/quodlibet/ext/playorder/playcounteq.py
@@ -56,7 +56,7 @@ class PlaycountEqualizer(ShufflePlugin, OrderRemembered, PluginConfigMixin):
         weights_sum = sum(weights.values())
         choice = int(max(1, math.ceil(weights_sum * random.random())))
 
-        print_d("Weighted random: %s for weights sum:%s" % (choice, weights_sum))
+        print_d(f"Weighted random: {choice} for the weights sum: {weights_sum}")
 
         # Search for a track.
         for i, weight in weights.items():
@@ -78,7 +78,7 @@ class PlaycountEqualizer(ShufflePlugin, OrderRemembered, PluginConfigMixin):
         hbox.pack_start(lbl, False, True, 0)
 
         val = cls.config_get("magnitude", cls._MAGNITUDE_DEFAULT)
-        
+
         spin = Gtk.SpinButton(
             adjustment=Gtk.Adjustment.new(int(val), 1, 100, 1, 10, 0))
         spin.connect("value-changed", magnitude_changed)

--- a/quodlibet/ext/playorder/playcounteq.py
+++ b/quodlibet/ext/playorder/playcounteq.py
@@ -9,14 +9,17 @@
 import math
 import random
 
-from quodlibet import _
+from gi.repository import Gtk
+
+from quodlibet import _, print_d
 from quodlibet.order.reorder import Reorder
+from quodlibet.plugins import PluginConfigMixin
 from quodlibet.plugins.playorder import ShufflePlugin
 from quodlibet.order import OrderRemembered
 from quodlibet.qltk import Icons
 
 
-class PlaycountEqualizer(ShufflePlugin, OrderRemembered):
+class PlaycountEqualizer(ShufflePlugin, OrderRemembered, PluginConfigMixin):
     PLUGIN_ID = "playcounteq"
     PLUGIN_NAME = _("Playcount Equalizer")
     PLUGIN_DESC = _("Adds a shuffle mode "
@@ -26,6 +29,8 @@ class PlaycountEqualizer(ShufflePlugin, OrderRemembered):
     accelerated_name = _("Prefer _less played")
 
     priority = Reorder.priority
+
+    _MAGNITUDE_DEFAULT = 1
 
     # Select the next track.
     def next(self, playlist, current):
@@ -37,11 +42,21 @@ class PlaycountEqualizer(ShufflePlugin, OrderRemembered):
         if len(remaining) <= 0:
             return None
 
+        mag_cfg = float(self.config_get("magnitude", self._MAGNITUDE_DEFAULT))
+        # Adjusting input to range from 1 to 3
+        # weights will be calculated as a power of this value.
+        magn = (mag_cfg * 2.0) / 100.0 + 1.0
+
         # Set-up the search information.
         max_count = max([song("~#playcount") for song in remaining.values()])
-        weights = {i: max_count - song("~#playcount")
+
+        weights = {i: math.ceil(math.pow(max_count - song("~#playcount") + 1, magn))
                    for i, song in remaining.items()}
-        choice = int(max(1, math.ceil(sum(weights) * random.random())))
+
+        weights_sum = sum(weights.values())
+        choice = int(max(1, math.ceil(weights_sum * random.random())))
+
+        print_d("Weighted random: %s for weights sum:%s" % (choice, weights_sum))
 
         # Search for a track.
         for i, weight in weights.items():
@@ -50,3 +65,24 @@ class PlaycountEqualizer(ShufflePlugin, OrderRemembered):
                 return playlist.get_iter([i])
         else:  # This should only happen if all songs have equal play counts.
             return playlist.get_iter([random.choice(list(remaining.keys()))])
+
+    @classmethod
+    def PluginPreferences(cls, parent):
+        def magnitude_changed(spin):
+            cls.config_set("magnitude", int(spin.get_value_as_int()))
+
+        vb = Gtk.VBox(spacing=10)
+        vb.set_border_width(10)
+        hbox = Gtk.HBox(spacing=6)
+        lbl = Gtk.Label(label=_("Priority for less played tracks"))
+        hbox.pack_start(lbl, False, True, 0)
+
+        val = cls.config_get("magnitude", cls._MAGNITUDE_DEFAULT)
+        
+        spin = Gtk.SpinButton(
+            adjustment=Gtk.Adjustment.new(int(val), 1, 100, 1, 10, 0))
+        spin.connect("value-changed", magnitude_changed)
+        hbox.pack_start(spin, False, True, 0)
+        vb.pack_start(hbox, True, True, 0)
+        vb.show_all()
+        return vb


### PR DESCRIPTION
Check-list
----------

 * [x] There is a linked issue discussing the motivations for this feature or bugfix
 * [x] Unit tests have been added where possible
 * [x] I've added / updated documentation for any user-facing features.
 * [x] Performance seems to be comparable or better than current `main`


What this change is adding / fixing
-----------------------------------
Hi I've realized that your plugin PlaycountEqualizer does not work good for huge playlists. 

After several days I was able to notice track repeating in the 1000+ playlist several times.
Plus there were still many not played tracks. I guess this is because random distribution does not work well when you have like 500 never played tracks and 500 tracks played only once.

So my solution is to introduce additional weight magnitude that will increase probability for a less played tracks. So now weights will be like `math.pow(old_weight, magnitude)`

Closes #4500

_P.S. I've decided that maximum magnitude power should be 3 but you could increase it to 4 I guess._
