### PR TITLE
Work around internal glib build failure in dependency pkg-config

### DIFF
--- a/dev-utils/osx_bundle/modulesets/quodlibet.modules
+++ b/dev-utils/osx_bundle/modulesets/quodlibet.modules
@@ -128,7 +128,10 @@
             hash="sha256:31747ae633213f1eda3842686f83c2aa1412e0f5691d1c14dbbcc67fe7400cea"/>
   </cmake>
 
-  <autotools id="pkg-config" autogen-sh="configure"
+  <!-- Disable integer conversion warnings (which are fatal in XCode 15.3 and later)
+        to work around issues in pkg-config's internal glib implementation.  
+        https://gitlab.freedesktop.org/pkg-config/pkg-config/-/issues/81 -->
+  <autotools id="pkg-config" autogen-sh="configure" makeargs="CFLAGS='-Wno-int-conversion'"
              autogenargs="--with-internal-glib --with-libiconv_prefix=$JHBUILD_PREFIX">
     <branch repo="pkgconfig"
             module="pkg-config-${version}.tar.gz" version="0.29.2"


### PR DESCRIPTION
XCode 15.3 is treating some compile warnings as errors that it didn't before, breaking the internal glib build in pkg-config.  Turn the errors back into warnings while the pkg-config team addresses the underlying issue. (#4504)

Check-list
----------

 * [ X ] There is a linked issue discussing the motivations for this feature or bugfix
 * [ n/a ] Unit tests have been added where possible
 * [ n/a ] I've added / updated documentation for any user-facing features.
 * [ X ] Performance seems to be comparable or better than current `main`


What this change is adding / fixing
-----------------------------------
XCode 15.3 is treating some compile warnings as errors that it didn't before, breaking the internal glib build in pkg-config.  Turn the errors back into warnings while the pkg-config team addresses the underlying issue. (#4504)
