### PR TITLE
Support floats in MPD seekcur command

### DIFF
--- a/quodlibet/ext/events/mpdserver/main.py
+++ b/quodlibet/ext/events/mpdserver/main.py
@@ -815,7 +815,7 @@ def _cmd_seekcur(conn, service, args):
         relative = True
 
     try:
-        time_ = int(time_)
+        time_ = float(time_)
     except ValueError as e:
         raise MPDRequestError("arg not a number") from e
 

--- a/tests/plugin/test_mpdserver.py
+++ b/tests/plugin/test_mpdserver.py
@@ -123,6 +123,11 @@ class TMPDCommands(PluginTestCase):
         for cmd in cmds:
             self._cmd(cmd.encode("ascii") + b"\n")
 
+    def test_seekcur(self):
+        # Ensure we can handle both integer and float arguments.
+        for cmd in ["seekcur 1", "seekcur 1.5"]:
+            self._cmd(cmd.encode("ascii") + b"\n")
+
     def test_idle_close(self):
         for cmd in ["idle", "noidle", "close"]:
             self._cmd(cmd.encode("ascii") + b"\n")


### PR DESCRIPTION
What this change is adding / fixing
-----------------------------------
Some MPD clients use the `seekcur` command with non-integer arguments, which results in an error from Quod Libet. For example, attempting to seek in Home Assistant's [MPD integration](https://www.home-assistant.io/integrations/mpd/) results in the following error:

![image](https://github.com/quodlibet/quodlibet/assets/637285/3ab5da01-cd88-4014-844e-405bd6af787b)

This PR has been confirmed to work locally and includes some new unit tests.