### PR TITLE
Option to preserve file modified time upon save 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ quodlibet = "quodlibet.main:main"
 
 [tool.poetry.dependencies]
 python = "^3.10"
-mutagen = "^1.45"
+mutagen = "^1.47.1"
 feedparser = "^6.0.11"
 pycairo = "^1.19"
 pygobject = "^3.34.0"

--- a/quodlibet/formats/_apev2.py
+++ b/quodlibet/formats/_apev2.py
@@ -8,6 +8,7 @@
 import mutagen.apev2
 
 from quodlibet.util.path import get_temp_cover_file
+from quodlibet import config
 
 from ._audio import AudioFile
 from ._image import APICType, EmbeddedImage
@@ -200,7 +201,7 @@ class APEv2File(AudioFile):
                 if cover_type is not None:
                     del tag[key]
 
-            tag.save()
+            tag.save(preserve_mtime=config.getboolean("editing", "retain_mtime"))
 
         self.has_images = False
 

--- a/quodlibet/formats/_apev2.py
+++ b/quodlibet/formats/_apev2.py
@@ -201,7 +201,7 @@ class APEv2File(AudioFile):
                 if cover_type is not None:
                     del tag[key]
 
-            tag.save(preserve_mtime=config.getboolean("editing", "retain_mtime"))
+            tag.save(preserve_mtime=config.getboolean("editing", "preserve_mtime"))
 
         self.has_images = False
 

--- a/quodlibet/formats/_id3.py
+++ b/quodlibet/formats/_id3.py
@@ -445,7 +445,7 @@ class ID3File(AudioFile):
             tag.add(t)
 
         with translate_errors():
-            audio.save()
+            audio.save(preserve_mtime=config.getboolean("editing", "retain_mtime"))
         self.sanitize()
 
     can_change_images = True
@@ -458,7 +458,7 @@ class ID3File(AudioFile):
 
             if audio.tags is not None:
                 audio.tags.delall("APIC")
-                audio.save()
+                audio.save(preserve_mtime=config.getboolean("editing", "retain_mtime"))
 
         self.has_images = False
 
@@ -532,6 +532,6 @@ class ID3File(AudioFile):
         tag.add(frame)
 
         with translate_errors():
-            audio.save()
+            audio.save(preserve_mtime=config.getboolean("editing", "retain_mtime"))
 
         self.has_images = True

--- a/quodlibet/formats/_id3.py
+++ b/quodlibet/formats/_id3.py
@@ -445,7 +445,7 @@ class ID3File(AudioFile):
             tag.add(t)
 
         with translate_errors():
-            audio.save(preserve_mtime=config.getboolean("editing", "retain_mtime"))
+            audio.save(preserve_mtime=config.getboolean("editing", "preserve_mtime"))
         self.sanitize()
 
     can_change_images = True
@@ -458,7 +458,7 @@ class ID3File(AudioFile):
 
             if audio.tags is not None:
                 audio.tags.delall("APIC")
-                audio.save(preserve_mtime=config.getboolean("editing", "retain_mtime"))
+                audio.save(preserve_mtime=config.getboolean("editing", "preserve_mtime"))
 
         self.has_images = False
 
@@ -532,6 +532,6 @@ class ID3File(AudioFile):
         tag.add(frame)
 
         with translate_errors():
-            audio.save(preserve_mtime=config.getboolean("editing", "retain_mtime"))
+            audio.save(preserve_mtime=config.getboolean("editing", "preserve_mtime"))
 
         self.has_images = True

--- a/quodlibet/formats/mp4.py
+++ b/quodlibet/formats/mp4.py
@@ -141,7 +141,7 @@ class MP4File(AudioFile):
         if disc:
             audio["disk"] = [(disc, discs)]
         with translate_errors():
-            audio.save()
+            audio.save(preserve_mtime=config.getboolean("editing", "retain_mtime"))
         self.sanitize()
 
     def can_multiple_values(self, key=None):

--- a/quodlibet/formats/mp4.py
+++ b/quodlibet/formats/mp4.py
@@ -142,7 +142,7 @@ class MP4File(AudioFile):
         if disc:
             audio["disk"] = [(disc, discs)]
         with translate_errors():
-            audio.save(preserve_mtime=config.getboolean("editing", "retain_mtime"))
+            audio.save(preserve_mtime=config.getboolean("editing", "preserve_mtime"))
         self.sanitize()
 
     def can_multiple_values(self, key=None):
@@ -205,7 +205,7 @@ class MP4File(AudioFile):
         with translate_errors():
             tag = MP4(self["~filename"])
             tag.pop("covr", None)
-            tag.save(preserve_mtime=config.getboolean("editing", "retain_mtime"))
+            tag.save(preserve_mtime=config.getboolean("editing", "preserve_mtime"))
 
         self.has_images = False
 
@@ -232,7 +232,7 @@ class MP4File(AudioFile):
         tag["covr"] = [cover]
 
         with translate_errors():
-            tag.save(preserve_mtime=config.getboolean("editing", "retain_mtime"))
+            tag.save(preserve_mtime=config.getboolean("editing", "preserve_mtime"))
 
         self.has_images = True
 

--- a/quodlibet/formats/mp4.py
+++ b/quodlibet/formats/mp4.py
@@ -11,6 +11,7 @@ from mutagen.mp4 import MP4, MP4Cover
 
 from quodlibet.util.path import get_temp_cover_file
 from quodlibet.util.string import decode
+from quodlibet import config
 
 from ._audio import AudioFile
 from ._misc import AudioFileError, translate_errors
@@ -204,7 +205,7 @@ class MP4File(AudioFile):
         with translate_errors():
             tag = MP4(self["~filename"])
             tag.pop("covr", None)
-            tag.save()
+            tag.save(preserve_mtime=config.getboolean("editing", "retain_mtime"))
 
         self.has_images = False
 
@@ -231,7 +232,7 @@ class MP4File(AudioFile):
         tag["covr"] = [cover]
 
         with translate_errors():
-            tag.save()
+            tag.save(preserve_mtime=config.getboolean("editing", "retain_mtime"))
 
         self.has_images = True
 

--- a/quodlibet/formats/wma.py
+++ b/quodlibet/formats/wma.py
@@ -139,7 +139,7 @@ class WMAFile(AudioFile):
                 continue
             audio.tags[name] = self.list(key)
         with translate_errors():
-            audio.save(preserve_mtime=config.getboolean("editing", "retain_mtime"))
+            audio.save(preserve_mtime=config.getboolean("editing", "preserve_mtime"))
         self.sanitize()
 
     def can_multiple_values(self, key=None):
@@ -198,7 +198,7 @@ class WMAFile(AudioFile):
         with translate_errors():
             tag = mutagen.asf.ASF(self["~filename"])
             tag.pop("WM/Picture", None)
-            tag.save(preserve_mtime=config.getboolean("editing", "retain_mtime"))
+            tag.save(preserve_mtime=config.getboolean("editing", "preserve_mtime"))
 
         self.has_images = False
 
@@ -221,7 +221,7 @@ class WMAFile(AudioFile):
         tag["WM/Picture"] = [value]
 
         with translate_errors():
-            tag.save(preserve_mtime=config.getboolean("editing", "retain_mtime"))
+            tag.save(preserve_mtime=config.getboolean("editing", "preserve_mtime"))
 
         self.has_images = True
 

--- a/quodlibet/formats/wma.py
+++ b/quodlibet/formats/wma.py
@@ -138,7 +138,7 @@ class WMAFile(AudioFile):
                 continue
             audio.tags[name] = self.list(key)
         with translate_errors():
-            audio.save()
+            audio.save(preserve_mtime=config.getboolean("editing", "retain_mtime"))
         self.sanitize()
 
     def can_multiple_values(self, key=None):

--- a/quodlibet/formats/wma.py
+++ b/quodlibet/formats/wma.py
@@ -10,6 +10,7 @@ import struct
 import mutagen.asf
 
 from quodlibet.util.path import get_temp_cover_file
+from quodlibet import config
 
 from ._audio import AudioFile
 from ._image import EmbeddedImage, APICType
@@ -197,7 +198,7 @@ class WMAFile(AudioFile):
         with translate_errors():
             tag = mutagen.asf.ASF(self["~filename"])
             tag.pop("WM/Picture", None)
-            tag.save()
+            tag.save(preserve_mtime=config.getboolean("editing", "retain_mtime"))
 
         self.has_images = False
 
@@ -220,7 +221,7 @@ class WMAFile(AudioFile):
         tag["WM/Picture"] = [value]
 
         with translate_errors():
-            tag.save()
+            tag.save(preserve_mtime=config.getboolean("editing", "retain_mtime"))
 
         self.has_images = True
 

--- a/quodlibet/formats/xiph.py
+++ b/quodlibet/formats/xiph.py
@@ -207,7 +207,7 @@ class MutagenVCFile(AudioFile):
             audio.pop("metadata_block_picture", None)
             audio.pop("coverart", None)
             audio.pop("coverartmime", None)
-            audio.save(preserve_mtime=config.getboolean("editing", "retain_mtime"))
+            audio.save(preserve_mtime=config.getboolean("editing", "preserve_mtime"))
 
         self.has_images = False
 
@@ -236,7 +236,7 @@ class MutagenVCFile(AudioFile):
             pic.write()).decode("ascii")
 
         with translate_errors():
-            audio.save(preserve_mtime=config.getboolean("editing", "retain_mtime"))
+            audio.save(preserve_mtime=config.getboolean("editing", "preserve_mtime"))
 
         self.has_images = True
 
@@ -318,7 +318,7 @@ class MutagenVCFile(AudioFile):
         self.__prep_write_total(audio.tags, "disctotal", "totaldiscs", "discnumber")
 
         with translate_errors():
-            audio.save(preserve_mtime=config.getboolean("editing", "retain_mtime"))
+            audio.save(preserve_mtime=config.getboolean("editing", "preserve_mtime"))
         self.sanitize()
 
 extensions = []
@@ -442,7 +442,7 @@ class FLACFile(MutagenVCFile):
         with translate_errors():
             tag = FLAC(self["~filename"])
             tag.clear_pictures()
-            tag.save(preserve_mtime=config.getboolean("editing", "retain_mtime"))
+            tag.save(preserve_mtime=config.getboolean("editing", "preserve_mtime"))
 
         # clear vcomment tags
         super().clear_images()
@@ -471,7 +471,7 @@ class FLACFile(MutagenVCFile):
         tag.add_picture(pic)
 
         with translate_errors():
-            tag.save(preserve_mtime=config.getboolean("editing", "retain_mtime"))
+            tag.save(preserve_mtime=config.getboolean("editing", "preserve_mtime"))
 
         # clear vcomment tags
         super().clear_images()

--- a/quodlibet/formats/xiph.py
+++ b/quodlibet/formats/xiph.py
@@ -207,7 +207,7 @@ class MutagenVCFile(AudioFile):
             audio.pop("metadata_block_picture", None)
             audio.pop("coverart", None)
             audio.pop("coverartmime", None)
-            audio.save()
+            audio.save(preserve_mtime=config.getboolean("editing", "retain_mtime"))
 
         self.has_images = False
 
@@ -236,7 +236,7 @@ class MutagenVCFile(AudioFile):
             pic.write()).decode("ascii")
 
         with translate_errors():
-            audio.save()
+            audio.save(preserve_mtime=config.getboolean("editing", "retain_mtime"))
 
         self.has_images = True
 
@@ -318,7 +318,7 @@ class MutagenVCFile(AudioFile):
         self.__prep_write_total(audio.tags, "disctotal", "totaldiscs", "discnumber")
 
         with translate_errors():
-            audio.save()
+            audio.save(preserve_mtime=config.getboolean("editing", "retain_mtime"))
         self.sanitize()
 
 extensions = []

--- a/quodlibet/formats/xiph.py
+++ b/quodlibet/formats/xiph.py
@@ -442,7 +442,7 @@ class FLACFile(MutagenVCFile):
         with translate_errors():
             tag = FLAC(self["~filename"])
             tag.clear_pictures()
-            tag.save()
+            tag.save(preserve_mtime=config.getboolean("editing", "retain_mtime"))
 
         # clear vcomment tags
         super().clear_images()
@@ -471,7 +471,7 @@ class FLACFile(MutagenVCFile):
         tag.add_picture(pic)
 
         with translate_errors():
-            tag.save()
+            tag.save(preserve_mtime=config.getboolean("editing", "retain_mtime"))
 
         # clear vcomment tags
         super().clear_images()

--- a/quodlibet/qltk/edittags.py
+++ b/quodlibet/qltk/edittags.py
@@ -539,7 +539,6 @@ class EditTags(Gtk.VBox):
         hb.pack_start(cb, False, True, 12)
         self.pack_start(hb, False, True, 0)
 
-        config.set("editing", "retain_mtime", str(bool(False)).lower())
         cb = ConfigCheckButton(
             _("_Retain mtime"), "editing", "retain_mtime", populate=True,
             tooltip=_("Do not overwrite file modified time on save"))

--- a/quodlibet/qltk/edittags.py
+++ b/quodlibet/qltk/edittags.py
@@ -539,6 +539,15 @@ class EditTags(Gtk.VBox):
         hb.pack_start(cb, False, True, 12)
         self.pack_start(hb, False, True, 0)
 
+        config.set("editing", "retain_mtime", str(bool(False)).lower())
+        cb = ConfigCheckButton(
+            _("_Retain mtime"), "editing", "retain_mtime", populate=True,
+            tooltip=_("Do not overwrite file modified time on save"))
+        cb.connect("toggled", self.__checkbox_toggled)
+
+        hb.pack_start(cb, False, True, 20)
+        self.pack_start(hb, False, True, 0)
+
         # Add and Remove [tags] buttons
         buttonbox = Gtk.HBox(spacing=18)
         bbox1 = Gtk.HButtonBox()

--- a/quodlibet/qltk/edittags.py
+++ b/quodlibet/qltk/edittags.py
@@ -539,14 +539,6 @@ class EditTags(Gtk.VBox):
         hb.pack_start(cb, False, True, 12)
         self.pack_start(hb, False, True, 0)
 
-        cb = ConfigCheckButton(
-            _("_Retain mtime"), "editing", "retain_mtime", populate=True,
-            tooltip=_("Do not overwrite file modified time on save"))
-        cb.connect("toggled", self.__checkbox_toggled)
-
-        hb.pack_start(cb, False, True, 20)
-        self.pack_start(hb, False, True, 0)
-
         # Add and Remove [tags] buttons
         buttonbox = Gtk.HBox(spacing=18)
         bbox1 = Gtk.HButtonBox()

--- a/quodlibet/qltk/quodlibetwindow.py
+++ b/quodlibet/qltk/quodlibetwindow.py
@@ -407,6 +407,8 @@ MENU = """
       <menuitem action='Preferences' always-show-image='true'/>
       <menuitem action='Plugins' always-show-image='true'/>
       <separator/>
+      <menuitem action='PreserveMTime' always-show-image='true'/>
+      <separator/>
       <menuitem action='RefreshLibrary' always-show-image='true'/>
       <separator/>
       <menuitem action='Quit' always-show-image='true'/>
@@ -1013,6 +1015,15 @@ class QuodLibetWindow(Window, PersistentWindowMixin, AppWindow):
         act.connect("activate", self.__rebuild, False)
         ag.add_action_with_accel(act, "<Primary>R")
 
+        def check_mtime_handler(*args):
+            config.set("editing", "retain_mtime", str(args[0].get_active()))
+
+        act = ToggleAction(
+            name="PreserveMTime", label=_("_Preserve modified time")
+        )
+        act.connect("activate", check_mtime_handler)
+        ag.add_action_with_accel(act, "<Primary>P")
+
         current = config.get("memory", "browser")
         try:
             browsers.get(current)
@@ -1071,6 +1082,9 @@ class QuodLibetWindow(Window, PersistentWindowMixin, AppWindow):
         # attach them.
         ui.get_widget("/Menu/File/RefreshLibrary").set_tooltip_text(
             _("Check for changes in your library"))
+
+        ui.get_widget("/Menu/File/PreserveMTime").set_tooltip_text(
+            _("Do not overwrite file modified time on file update"))
 
         return ui
 

--- a/quodlibet/qltk/quodlibetwindow.py
+++ b/quodlibet/qltk/quodlibetwindow.py
@@ -1016,7 +1016,7 @@ class QuodLibetWindow(Window, PersistentWindowMixin, AppWindow):
         ag.add_action_with_accel(act, "<Primary>R")
 
         def check_mtime_handler(*args):
-            config.set("editing", "retain_mtime", str(args[0].get_active()))
+            config.set("editing", "preserve_mtime", str(args[0].get_active()))
 
         act = ToggleAction(
             name="PreserveMTime", label=_("_Preserve modified time")


### PR DESCRIPTION
This change makes use of functionality I have added to [mutagen in a separate PR](https://github.com/quodlibet/mutagen/pull/645) to enable mtime preservation. These two pull requests should address issue #4463.

The dependency on the mutagen change means the version number used for mutagen in this PR could be subject to change.
