### PR TITLE
Add option to hide timestamps from lyrics panel

### DIFF
--- a/quodlibet/ext/events/viewlyrics.py
+++ b/quodlibet/ext/events/viewlyrics.py
@@ -73,16 +73,17 @@ class ViewLyrics(EventPlugin, UserInterfacePlugin):
         self.scrolled_window.destroy()
 
     def _hide_timestamps(self, lyrics: str):
-        """Remove timestamps from the lyrics if they are formatted as an .lrc or .elrc file."""
+        """Remove timestamps from the lyrics if they are formatted as an .lrc file."""
         new_lines = []
         for line in lyrics.splitlines():
             line = line.strip()
-            
+
             if not line:
                 continue
-            
-            match = re.fullmatch(r"\[(\d\d:\d\d\.\d\d\]\s?(.*)|[^\]]+:[^\]]*\])", line)
-        
+
+            match = re.fullmatch(
+                r"\[(\d\d:\d\d\.\d\d\]\s?(.*)|[^\]]+:[^\]]*\])", line)
+
             if match is None:
                 # at least one line isn't formatted as .lrc - keep original text
                 return lyrics
@@ -90,11 +91,12 @@ class ViewLyrics(EventPlugin, UserInterfacePlugin):
             # lines containing ID tags are ignored
             if match.groups()[1] is not None:
                 # remove word timestamps in enhanced format
-                sentence = ''.join(re.split(r"<\d\d:\d\d\.\d\d>\s*", match.groups()[1])).strip()
+                sentence = "".join(
+                    re.split(r"<\d\d:\d\d\.\d\d>\s*", match.groups()[1])).strip()
                 if sentence:
                     new_lines.append(sentence)
-            
-        return '\n'.join(new_lines)
+
+        return "\n".join(new_lines)
 
     def plugin_on_song_started(self, song):
         """Called when a song is started. Loads the lyrics.
@@ -168,9 +170,13 @@ class ViewLyrics(EventPlugin, UserInterfacePlugin):
 
     def PluginPreferences(self, parent):
         box = Gtk.HBox()
-        ccb = ConfigCheckButton(_("Hide timestamps of .lrc or .elrc formatted lyrics"),
-                                "plugins", "view_lyrics_hide_timestamps")
-        hide_timestamps = config.getboolean("plugins", "view_lyrics_hide_timestamps", True)
+        ccb = ConfigCheckButton(
+            _("Hide timestamps of .lrc or .elrc formatted lyrics"),
+            "plugins",
+            "view_lyrics_hide_timestamps"
+        )
+        hide_timestamps = config.getboolean(
+            "plugins", "view_lyrics_hide_timestamps", True)
         ccb.set_active(hide_timestamps)
         box.pack_start(qltk.Frame(_("Preferences"), child=ccb), True, True, 0)
         return box

--- a/quodlibet/ext/events/viewlyrics.py
+++ b/quodlibet/ext/events/viewlyrics.py
@@ -9,11 +9,14 @@
 # (at your option) any later version.
 
 from gi.repository import Gtk, Gdk
+import re
 
-from quodlibet import _, print_d, app
+from quodlibet import _, config, print_d, app
+from quodlibet import qltk
 from quodlibet.plugins.events import EventPlugin
 from quodlibet.plugins.gui import UserInterfacePlugin
 from quodlibet.qltk import Icons, add_css, Button
+from quodlibet.qltk.ccb import ConfigCheckButton
 from quodlibet.qltk.information import Information
 from quodlibet.util.songwrapper import SongWrapper
 
@@ -69,6 +72,30 @@ class ViewLyrics(EventPlugin, UserInterfacePlugin):
         self.textview.destroy()
         self.scrolled_window.destroy()
 
+    def _hide_timestamps(self, lyrics: str):
+        """Remove timestamps from the lyrics if they are formatted as an .lrc or .elrc file."""
+        new_lines = []
+        for line in lyrics.splitlines():
+            line = line.strip()
+            
+            if not line:
+                continue
+            
+            match = re.fullmatch(r"\[(\d\d:\d\d\.\d\d\]\s?(.*)|[^\]]+:[^\]]*\])", line)
+        
+            if match is None:
+                # at least one line isn't formatted as .lrc - keep original text
+                return lyrics
+
+            # lines containing ID tags are ignored
+            if match.groups()[1] is not None:
+                # remove word timestamps in enhanced format
+                sentence = ''.join(re.split(r"<\d\d:\d\d\.\d\d>\s*", match.groups()[1])).strip()
+                if sentence:
+                    new_lines.append(sentence)
+            
+        return '\n'.join(new_lines)
+
     def plugin_on_song_started(self, song):
         """Called when a song is started. Loads the lyrics.
 
@@ -80,6 +107,8 @@ class ViewLyrics(EventPlugin, UserInterfacePlugin):
             print_d("Looking for lyrics for %s" % song("~filename"))
             lyrics = song("~lyrics")
             if lyrics:
+                if config.getboolean("plugins", "view_lyrics_hide_timestamps", True):
+                    lyrics = self._hide_timestamps(lyrics)
                 self.textbuffer.set_text(lyrics)
                 self.adjustment.set_value(0)    # Scroll to the top.
                 self.textview.show()
@@ -136,3 +165,12 @@ class ViewLyrics(EventPlugin, UserInterfacePlugin):
         else:
             return False
         return True
+
+    def PluginPreferences(self, parent):
+        box = Gtk.HBox()
+        ccb = ConfigCheckButton(_("Hide timestamps of .lrc or .elrc formatted lyrics"),
+                                "plugins", "view_lyrics_hide_timestamps")
+        hide_timestamps = config.getboolean("plugins", "view_lyrics_hide_timestamps", True)
+        ccb.set_active(hide_timestamps)
+        box.pack_start(qltk.Frame(_("Preferences"), child=ccb), True, True, 0)
+        return box

--- a/quodlibet/ext/events/viewlyrics.py
+++ b/quodlibet/ext/events/viewlyrics.py
@@ -79,6 +79,7 @@ class ViewLyrics(EventPlugin, UserInterfacePlugin):
             line = line.strip()
 
             if not line:
+                new_lines.append("")
                 continue
 
             match = re.fullmatch(

--- a/tests/plugin/test_viewlyrics.py
+++ b/tests/plugin/test_viewlyrics.py
@@ -51,3 +51,8 @@ class TViewlyrics(PluginTestCase):
         app.player.info = AUDIO_FILE
         self.plugin.enabled()
         self.plugin._edit_button.emit("clicked")
+
+    def test_timestamp_hiding(self):
+        timed_lyrics = "[ar: Snek]\n\n[00:27.18] Hisss\n[03:14.15] <03:14.15> foo <03:15.15> bar <03:16.15>"
+        result = self.plugin._hide_timestamps(timed_lyrics)
+        self.assertEqual(result, "Hisss\nfoo bar")

--- a/tests/plugin/test_viewlyrics.py
+++ b/tests/plugin/test_viewlyrics.py
@@ -56,4 +56,4 @@ class TViewlyrics(PluginTestCase):
         timed_lyrics = "[ar: Snek]\n\n[00:27.18] Hisss\n \
             [03:14.15] <03:14.15> foo <03:15.15> bar <03:16.15>"
         result = self.plugin._hide_timestamps(timed_lyrics)
-        self.assertEqual(result, "Hisss\nfoo bar")
+        self.assertEqual(result, "\nHisss\nfoo bar")

--- a/tests/plugin/test_viewlyrics.py
+++ b/tests/plugin/test_viewlyrics.py
@@ -53,6 +53,7 @@ class TViewlyrics(PluginTestCase):
         self.plugin._edit_button.emit("clicked")
 
     def test_timestamp_hiding(self):
-        timed_lyrics = "[ar: Snek]\n\n[00:27.18] Hisss\n[03:14.15] <03:14.15> foo <03:15.15> bar <03:16.15>"
+        timed_lyrics = "[ar: Snek]\n\n[00:27.18] Hisss\n \
+            [03:14.15] <03:14.15> foo <03:15.15> bar <03:16.15>"
         result = self.plugin._hide_timestamps(timed_lyrics)
         self.assertEqual(result, "Hisss\nfoo bar")


### PR DESCRIPTION
Check-list
----------

 * [x] There is a linked issue discussing the motivations for this feature or bugfix
 * [x] Unit tests have been added where possible
 * [ ] I've added / updated documentation for any user-facing features.
 * [x] Performance seems to be comparable or better than current `main`


What this change is adding / fixing
-----------------------------------
Implements #4522 

See also #1989 - if embedded lyrics are to be supported by the synchronized lyrics plugin, the lyrics panel should be able to deal with them as well.