### PR TITLE
Fix: Dereference symbolic links when writing to file (Issue 4543)

### DIFF
--- a/quodlibet/util/atomic.py
+++ b/quodlibet/util/atomic.py
@@ -1,4 +1,4 @@
-# Copyright 2013,2015 Christoph Reiter
+# Copyright 2013,2015 Christoph Reiter, Dino Miniutti
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -11,6 +11,7 @@ import os
 import contextlib
 
 from senf import fsnative
+from pathlib import Path
 
 if os.name == "nt":
     from . import winapi
@@ -82,10 +83,13 @@ def atomic_save(filename, mode):
 
         fileobj.close()
 
+        # dereference symbolic links
+        target = filename if not os.path.islink(filename) else Path(filename).resolve()
+
         if os.name == "nt":
-            _windows_rename(fileobj.name, filename)
+            _windows_rename(fileobj.name, target)
         else:
-            os.rename(fileobj.name, filename)
+            os.rename(fileobj.name, target)
     except Exception:
         try:
             os.unlink(fileobj.name)

--- a/quodlibet/util/atomic.py
+++ b/quodlibet/util/atomic.py
@@ -87,7 +87,7 @@ def atomic_save(filename, mode):
         target = filename if not os.path.islink(filename) else Path(filename).resolve()
 
         if os.name == "nt":
-            _windows_rename(fileobj.name, target.name)
+            _windows_rename(fileobj.name, str(target))
         else:
             os.rename(fileobj.name, target)
     except Exception:

--- a/quodlibet/util/atomic.py
+++ b/quodlibet/util/atomic.py
@@ -87,7 +87,7 @@ def atomic_save(filename, mode):
         target = filename if not os.path.islink(filename) else Path(filename).resolve()
 
         if os.name == "nt":
-            _windows_rename(fileobj.name, target)
+            _windows_rename(fileobj.name, target.name)
         else:
             os.rename(fileobj.name, target)
     except Exception:

--- a/tests/test_util_atomic.py
+++ b/tests/test_util_atomic.py
@@ -96,5 +96,7 @@ class Tatomic_save(TestCase):
             self.assertEqual(fobj.read(), b"foo")
 
         self.assertFalse(os.path.exists(temp_name))
-        self.assertEqual(sorted(os.listdir(self.dir)), sorted([os.path.basename(filename), os.path.basename(symlink)]))
+        self.assertEqual(
+            sorted(os.listdir(self.dir)),
+            sorted([os.path.basename(filename), os.path.basename(symlink)]))
         self.assertTrue(os.path.islink(symlink))


### PR DESCRIPTION
Fix for atomic_save overwriting symbolic links. Move the temporary file to the symbolic link target, rather than replacing the symbolic link.

Check-list
----------

 * [X] There is a linked issue discussing the motivations for this feature or bugfix
 * [X] Unit tests have been added where possible
 * [N/A] I've added / updated documentation for any user-facing features.
 * [X] Performance seems to be comparable or better than current `main`


What this change is adding / fixing
-----------------------------------
Fix for atomic_save overwriting symbolic links - [Issue 4543](https://github.com/quodlibet/quodlibet/issues/4543). The temporary file created in atomic_save is moved to the symbolic link target, rather than replacing the symbolic link itself.

