### PR TITLE
Hide cover art from the main player controls

### DIFF
--- a/quodlibet/config.py
+++ b/quodlibet/config.py
@@ -231,6 +231,9 @@ INITIAL: dict[str, dict[str, str]] = {
         # support sending them to the trash.
         "bypass_trash": "false",
 
+        # hide cover art from the main player window (next to seekbar)
+        "disable_cover": "false",
+
         # osx implementation might be buggy so let users disable it
         "disable_mmkeys": "false",
 

--- a/quodlibet/ext/events/waveformseekbar.py
+++ b/quodlibet/ext/events/waveformseekbar.py
@@ -311,7 +311,7 @@ class WaveformScale(Gtk.EventBox):
     def __init__(self, player):
         super().__init__()
         self._player = player
-        self.set_size_request(40, 40)
+        self.set_size_request(40, CONFIG.height_px)
         self.position = 0
         self._last_drawn_position = 0
         self.override_background_color(Gtk.StateFlags.NORMAL, Gdk.RGBA(alpha=0))
@@ -587,6 +587,7 @@ class Config:
     seek_amount = IntConfProp(_config, "seek_amount", 5000)
     max_data_points = IntConfProp(_config, "max_data_points", 3000)
     show_time_labels = BoolConfProp(_config, "show_time_labels", True)
+    height_px = IntConfProp(_config, "height_px", 40)
 
 
 CONFIG = Config()
@@ -656,6 +657,12 @@ class WaveformSeekBarPlugin(EventPlugin):
             if self._bar is not None:
                 self._bar.set_time_label_visibility(CONFIG.show_time_labels)
 
+        def on_height_px_changed(spinbox):
+            CONFIG.height_px = spinbox.get_value_as_int()
+            if self._bar is not None and self._bar._waveform_scale is not None:
+                self._bar._waveform_scale.set_size_request(40, CONFIG.height_px)
+
+
         def create_color(label_text, color, callback):
             hbox = Gtk.HBox(spacing=6)
             hbox.set_border_width(6)
@@ -700,6 +707,19 @@ class WaveformSeekBarPlugin(EventPlugin):
         seek_amount.set_numeric(True)
         seek_amount.connect("changed", seek_amount_changed)
         hbox.pack_start(seek_amount, True, True, 0)
+        vbox.pack_start(hbox, True, True, 0)
+
+
+        hbox = Gtk.HBox(spacing=6)
+        hbox.set_border_width(6)
+        label = Gtk.Label(label=_("Waveform height (pixels):"))
+        hbox.pack_start(label, False, True, 0)
+        height_px = Gtk.SpinButton(
+            adjustment=Gtk.Adjustment(CONFIG.height_px, 40, 400, 10, 10, 0)
+        )
+        height_px.set_numeric(True)
+        height_px.connect("changed", on_height_px_changed)
+        hbox.pack_start(height_px, True, True, 0)
         vbox.pack_start(hbox, True, True, 0)
 
         return vbox

--- a/quodlibet/qltk/advanced_prefs.py
+++ b/quodlibet/qltk/advanced_prefs.py
@@ -147,6 +147,10 @@ class AdvancedPreferencesPane(Gtk.VBox):
                 "Album cover size",
                 ("Size of the album cover images in the album list browser "
                  "(restart required)")),
+            boolean_config(
+                "settings", "disable_cover",
+                "Disable cover in the main player controls",
+                "(restart required)"),
             text_config(
                 "albumart", "search_filenames",
                 "Album art search filenames",

--- a/quodlibet/qltk/quodlibetwindow.py
+++ b/quodlibet/qltk/quodlibetwindow.py
@@ -287,21 +287,24 @@ class TopBar(Gtk.Toolbar):
         box.pack_start(self._pattern_box, True, True, 0)
 
         # cover image
-        self.image = CoverImage(resize=True)
-        connect_destroy(player, "song-started", self.__new_song)
+        if config.getboolean("settings", "disable_cover"):
+            self.image = None
+        else:
+            self.image = CoverImage(resize=True)
+            connect_destroy(player, "song-started", self.__new_song)
 
-        # FIXME: makes testing easier
-        if app.cover_manager:
-            connect_destroy(
-                app.cover_manager, "cover-changed",
-                self.__song_art_changed, library)
+            # FIXME: makes testing easier
+            if app.cover_manager:
+                connect_destroy(
+                    app.cover_manager, "cover-changed",
+                    self.__song_art_changed, library)
 
-        box.pack_start(Align(self.image, top=3, right=3), False, True, 0)
+            box.pack_start(Align(self.image, top=3, right=3), False, True, 0)
 
-        # On older Gtk+ (3.4, at least)
-        # setting a margin on CoverImage leads to errors and result in the
-        # QL window not being visible for some reason.
-        assert self.image.props.margin == 0
+            # On older Gtk+ (3.4, at least)
+            # setting a margin on CoverImage leads to errors and result in the
+            # QL window not being visible for some reason.
+            assert self.image.props.margin == 0
 
         for child in self.get_children():
             child.show_all()
@@ -321,10 +324,10 @@ class TopBar(Gtk.Toolbar):
         config.set("memory", "volume", str(player.volume))
 
     def __new_song(self, player, song):
-        self.image.set_song(song)
+        if self.image: self.image.set_song(song)
 
     def __song_art_changed(self, player, songs, library):
-        self.image.refresh()
+        if self.image: self.image.refresh()
 
 
 class QueueButton(HighlightToggleButton):


### PR DESCRIPTION
Check-list
----------

 * [ ] There is a linked issue discussing the motivations for this feature or bugfix
 * [ ] Unit tests have been added where possible
 * [ ] I've added / updated documentation for any user-facing features.
 * [X] Performance seems to be comparable or better than current `main`


What this change is adding / fixing
-----------------------------------
A simple boolean option to hide the cover art completely (to save horizontal space, in my case when using the waveform seekbar).