### PR TITLE
Parse year from MM/DD/YYYY dates

### DIFF
--- a/quodlibet/formats/_audio.py
+++ b/quodlibet/formats/_audio.py
@@ -440,17 +440,17 @@ class AudioFile(dict, ImageContainer, HasKey):
                     return default
                 return util.date_key(date)
             elif key == "year":
-                return self.get("date", default)[:4]
+                return util.parse_year(self.get("date", default))
             elif key == "#year":
                 try:
-                    return int(self.get("date", default)[:4])
+                    return int(util.parse_year(self.get("date", default)))
                 except (ValueError, TypeError, KeyError):
                     return default
             elif key == "originalyear":
-                return self.get("originaldate", default)[:4]
+                return util.parse_year(self.get("originaldate", default))
             elif key == "#originalyear":
                 try:
-                    return int(self.get("originaldate", default)[:4])
+                    return int(util.parse_year(self.get("originaldate", default)))
                 except (ValueError, TypeError, KeyError):
                     return default
             elif key == "#tracks":

--- a/quodlibet/util/__init__.py
+++ b/quodlibet/util/__init__.py
@@ -319,6 +319,12 @@ def parse_date(datestr):
         raise ValueError(e) from e
 
 
+def parse_year(yearstr):
+    """Parses dates of various formats and returns the year."""
+    if "/" in yearstr:
+        return yearstr[-4:]
+    return yearstr[:4]
+
 def format_int_locale(value):
     """Turn an integer into a grouped, locale-dependent string
     e.g. 12345 -> "12,345" or "12.345" etc

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -354,6 +354,14 @@ class Tparse_date(TestCase):
             util.parse_date("2004-01-01") < util.parse_date("2004-01-02"))
 
 
+class Tparse_year(TestCase):
+
+    def test_common_date_formats(self):
+        self.assertEqual(util.parse_year("2022"), "2022")
+        self.assertEqual(util.parse_year("2022-02-28"), "2022")
+        self.assertEqual(util.parse_year("02/28/2022"), "2022")
+
+
 class Tdate_key(TestCase):
 
     def test_compare(self):


### PR DESCRIPTION
Check-list
----------

 * [x] There is a linked issue discussing the motivations for this feature or bugfix
 * [x] Unit tests have been added where possible
 * ~~I've added / updated documentation for any user-facing features.~~
 * [x] Performance seems to be comparable or better than current `main`


What this change is adding / fixing
-----------------------------------

https://github.com/quodlibet/quodlibet/issues/4555

Allows displaying year for tracks that use the MM/DD/YYYY date format, through a somewhat naive implementation.

I don't know of any documentation that is affected by this change.

I intentionally left out tests for bad date formats, to keep it close to the previous implementation.