### PR TITLE
tests: Filter out unsupported file formats properly

### DIFF
--- a/tests/test_image_support.py
+++ b/tests/test_image_support.py
@@ -8,7 +8,6 @@
 from gi.repository import GdkPixbuf, Gdk
 
 from tests import TestCase, get_data_path
-from quodlibet.util import is_flatpak
 
 
 class Timage_support(TestCase):
@@ -18,23 +17,24 @@ class Timage_support(TestCase):
 
     IMAGES = [
         "image.svg",
+        "image.bmp",
         "image.png",
         "image.gif",
         "image.jpg",
     ]
 
-    # gdk-pixbuf dropped bmp by default and the GNOME flatpak
-    # runtime doesn't include it
-    if not is_flatpak():
-        IMAGES.append("image.bmp")
-
     def test_create_pixbuf(self):
+        supported_formats = GdkPixbuf.Pixbuf.get_formats()
+
         for name in self.IMAGES:
-            file_path = get_data_path(name)
-            pb = GdkPixbuf.Pixbuf.new_from_file(file_path)
-            assert pb
-            assert pb.get_width() == 16
-            assert pb.get_height() == 16
+            extension = name.split(".")[-1]
+
+            if any(extension in x.extensions for x in supported_formats):
+                file_path = get_data_path(name)
+                pb = GdkPixbuf.Pixbuf.new_from_file(file_path)
+                assert pb
+                assert pb.get_width() == 16
+                assert pb.get_height() == 16
 
     def test_cursors(self):
         # make sure cursor images are packaged right


### PR DESCRIPTION
Check-list
----------

 * [ ] There is a linked issue discussing the motivations for this feature or bugfix
 * [ ] Unit tests have been added where possible
 * [ ] I've added / updated documentation for any user-facing features.
 * [ ] Performance seems to be comparable or better than current `main`


What this change is adding / fixing
-----------------------------------
This change fixes tests on Fedora 41 as https://src.fedoraproject.org/rpms/gdk-pixbuf2/c/a5f3d593c19d4ec7a46699422fbbf4ccbbc05db9 is missing from 41 and rawhide for whatever reason.
