### PR TITLE
test_brainz: Mark as requiring network

### DIFF
--- a/tests/plugin/test_brainz.py
+++ b/tests/plugin/test_brainz.py
@@ -7,6 +7,8 @@
 
 from quodlibet.formats import AudioFile
 
+import pytest
+
 from tests import skipUnless
 from . import PluginTestCase, modules
 
@@ -154,6 +156,7 @@ TEST_PREGAP = \
 "track_or_recording_length": "202106"}]}]}
 
 
+@pytest.mark.network
 @skipUnless(brainz, "brainz plugin not loaded")
 class TBrainz(PluginTestCase):
     """Test CustomCommands plugin and associated classes"""


### PR DESCRIPTION
Check-list
----------

 * [ ] There is a linked issue discussing the motivations for this feature or bugfix
 * [ ] Unit tests have been added where possible
 * [ ] I've added / updated documentation for any user-facing features.
 * [ ] Performance seems to be comparable or better than current `main`


What this change is adding / fixing
-----------------------------------
This test requires network, so skip it when pytest is ran with -m "not network".
