### PR TITLE
gdist: Fix filtering dirs logic in get_missing()

### DIFF
--- a/gdist/gettextutil.py
+++ b/gdist/gettextutil.py
@@ -348,7 +348,7 @@ def get_missing(po_dir: Path) -> Iterable[str]:
     not_translatable = set()
     for root, dirs, files in os.walk(src_root):
         root = Path(root)
-        for dirname in dirs:
+        for dirname in list(dirs):
             dirpath = (root / dirname).relative_to(src_root)
             if dirpath in skip_files or dirname.startswith("."):
                 dirs.remove(dirname)


### PR DESCRIPTION
We can't iterate and modify the variable at the same time.

Check-list
----------

 * [ ] There is a linked issue discussing the motivations for this feature or bugfix
 * [ ] Unit tests have been added where possible
 * [ ] I've added / updated documentation for any user-facing features.
 * [x] Performance seems to be comparable or better than current `main`


What this change is adding / fixing
-----------------------------------
<!-- A high-level description of the changes.
Hopefully the commits are atomic and well described, but this is the overall
summary of the change, to other developers / maintainers, plus any TODOs. -->

