### PR TITLE
Use correct build-system for PEP-517 support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,4 +137,5 @@ omit = ["quodlibet/packages/*"]
 include = ["quodlibet/*"]
 
 [build-system]
-requires = ["setuptools", "wheel"]
+requires = ["poetry-core>=1.0.0", "setuptools", "wheel"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
Check-list
----------

 * [ ] There is a linked issue discussing the motivations for this feature or bugfix
 * [ ] Unit tests have been added where possible
 * [ ] I've added / updated documentation for any user-facing features.
 * [ ] Performance seems to be comparable or better than current `main`


What this change is adding / fixing
-----------------------------------
Before and after:

$ python /usr/lib/rpm/redhat/pyproject_buildrequires.py --output deps.txt 2> /dev/null && cat deps.txt
python3dist(setuptools)
python3dist(wheel)
python3dist(setuptools) >= 40.8
python3dist(wheel)
python3dist(wheel)

$ python /usr/lib/rpm/redhat/pyproject_buildrequires.py --output deps.txt 2> /dev/null && cat deps.txt
python3dist(poetry-core) >= 1
python3dist(setuptools)
python3dist(wheel)
(python3dist(feedparser) < 7~~ with python3dist(feedparser) >= 6.0.11)
(python3dist(mutagen) < 2~~ with python3dist(mutagen) >= 1.45)
(python3dist(pycairo) < 2~~ with python3dist(pycairo) >= 1.19)
(python3dist(pygobject) < 4~~ with python3dist(pygobject) >= 3.34)

See https://python-poetry.org/docs/pyproject/#poetry-and-pep-517

