### PR TITLE
🔧 Fix playlist renaming (#4589)

### DIFF
--- a/quodlibet/browsers/playlists/main.py
+++ b/quodlibet/browsers/playlists/main.py
@@ -1,5 +1,5 @@
 # Copyright 2005 Joe Wreschnig
-#      2011-2022 Nick Boultbee
+#      2011-2024 Nick Boultbee
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -624,6 +624,8 @@ class PlaylistsBrowser(Browser, DisplayPatternMixin):
             child_model.remove(
                 self._lists.convert_iter_to_child_iter(row.iter))
             child_model.append(row=[playlist])
+            if playlist not in self.playlists():
+                print_w(f"{playlist} is not in playlists")
             self._select_playlist(playlist, scroll=True)
             return True
 

--- a/quodlibet/library/base.py
+++ b/quodlibet/library/base.py
@@ -1,5 +1,5 @@
 # Copyright 2006 Joe Wreschnig
-#           2011-2022 Nick Boultbee
+#           2011-2024 Nick Boultbee
 #           2013,2014 Christoph Reiter
 #
 # This program is free software; you can redistribute it and/or modify
@@ -194,17 +194,17 @@ class Library(GObject.GObject, DictMixin, Generic[K, V]):
         Return the sequence of items actually removed.
         """
 
-        items = {item for item in items if item in self}
-        if not items:
-            return items
+        removals = {item for item in items if item in self}
+        if not removals:
+            return removals
 
-        print_d(f"Removing {len(items)} item(s).", self._name)
-        for item in items:
+        print_d(f"Removing {len(removals)} item(s).", self._name)
+        for item in removals:
             del self._contents[item.key]
 
         self.dirty = True
-        self.emit("removed", items)
-        return items
+        self.emit("removed", removals)
+        return removals
 
 
 def _load_items(filename) -> Iterable[V]:

--- a/quodlibet/library/playlist.py
+++ b/quodlibet/library/playlist.py
@@ -125,6 +125,15 @@ class PlaylistLibrary(Library[str, Playlist]):
                 pl.write()
             self.changed(changed)
 
+    def rename(self, playlist: Playlist, old_key: str):
+        """Handle the renaming (and thus re-keying) of contained items"""
+        if playlist not in self and old_key in self.keys():
+            del self._contents[old_key]
+            self._contents[playlist.key] = playlist
+            self.emit("changed", [playlist])
+        else:
+            print_w(f"Can't rename {old_key} -> {playlist.key}")
+
     def __songs_changed(self, library, songs) -> None:
         # Q: what if the changes are entirely due to changes *from* this library?
         # A: seems safest to still emit 'changed' as collections can cache metadata etc

--- a/quodlibet/util/collection.py
+++ b/quodlibet/util/collection.py
@@ -1,6 +1,6 @@
 # Copyright 2004-2013 Joe Wreschnig, Michael Urman, Iñigo Serna,
 #                     Christoph Reiter, Steven Robertson
-#           2011-2023 Nick Boultbee
+#           2011-2024 Nick Boultbee
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -369,7 +369,7 @@ class Playlist(Collection, abc.Iterable, HasKey):
         self.pl_lib = pl_lib
         # Libraries are dict-like so falsey if empty
         if self.pl_lib is None:
-            print_d(f"Playlist {name!r} initialised without library")
+            print_w(f"Playlist {name!r} initialised without library")
         else:
             self.pl_lib.add([self])
         self.__inhibit_library_signals = False
@@ -430,10 +430,13 @@ class Playlist(Collection, abc.Iterable, HasKey):
     def rename(self, new_name):
         """Changes this playlist's name and re-saves, or raises an `ValueError`
         if the name is not allowed"""
-        if new_name == self.name:
+        old_name = self.key
+        if new_name == old_name:
             return
         self.name = self._validated_name(new_name)
         self.write()
+        if self.pl_lib:
+            self.pl_lib.rename(self, old_name)
 
     def _validated_name(self, new_name):
         """Returns a transformed (or not) name, or raises a `ValueError`


### PR DESCRIPTION
* Add a `rename` method to the PlaylistLibrary, as it's a particular case of interest, given names are dict keys there
* This then triggers a `changed` signal for listeners
* Call this method, if possible, during a `Playlist.rename`
* This then ensures that renames straight after creation actually work
* ...which means deletions (of the _updated_ key) also then work.
* Add a small test for this, give or take

Fixes #4589 