### PR TITLE
🧹 Migrate lots of old unittest assertions to native

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -54,17 +54,6 @@ class TestCase(OrigTestCase):
                              delta=None):
         super().assertNotAlmostEqual(second, first, places, msg, delta)
 
-    # silence deprec warnings about useless renames
-    failUnless = OrigTestCase.assertTrue
-    failIf = OrigTestCase.assertFalse
-    failUnlessRaises = OrigTestCase.assertRaises
-
-    assertEquals = assertEqual
-    failUnlessEqual = assertEqual
-    failIfEqual = assertNotEqual
-    failUnlessAlmostEqual = assertAlmostEqual
-    failIfAlmostEqual = assertNotAlmostEqual
-
 
 skip = unittest.skip
 skipUnless = unittest.skipUnless

--- a/tests/plugin/test_brainz.py
+++ b/tests/plugin/test_brainz.py
@@ -224,9 +224,9 @@ class TBrainz(PluginTestCase):
         self.assertEqual(release.track_count, 2)
         self.assertEqual(len(release.tracks), 2)
         self.assertEqual(release.title, "\xe6\xb3o & h\xb3\xe6")
-        self.assertTrue(release.is_single_artist)
-        self.assertFalse(release.is_various_artists)
-        self.assertTrue(release.artists)
+        assert release.is_single_artist
+        assert not release.is_various_artists
+        assert release.artists
 
     def test_release_tracks(self):
         Release = brainz.mb.Release
@@ -259,7 +259,7 @@ class TBrainz(PluginTestCase):
         self.assertEqual(artist.id, "410c9baf-5469-44f6-9852-826524b80c61")
         self.assertEqual(artist.name, "Autechre")
         self.assertEqual(artist.sort_name, "Autechre")
-        self.assertFalse(artist.is_various)
+        assert not artist.is_various
 
     def test_build_metadata(self):
         Release = brainz.mb.Release

--- a/tests/plugin/test_console.py
+++ b/tests/plugin/test_console.py
@@ -39,7 +39,7 @@ class TConsole(PluginTestCase):
     def test_sidebar_plugin(self):
         plugin = self.mod.PyConsoleSidebar()
         plugin.enabled()
-        self.assertTrue(isinstance(plugin.create_sidebar(), Gtk.Widget), True)
+        assert isinstance(plugin.create_sidebar(), Gtk.Widget), True
         plugin.plugin_on_songs_selected([AUDIO_FILE])
         self.assertEqual(plugin.console.namespace.get("songs"),
                              [AUDIO_FILE])

--- a/tests/plugin/test_custom_commands.py
+++ b/tests/plugin/test_custom_commands.py
@@ -55,13 +55,13 @@ class TCustomCommands(PluginTestCase):
         plugin._handle_songs = proxy
         # Test that as a Playlist plugin it delegates correctly
         plugin.plugin_playlist(pl)
-        self.assertTrue(self.called_songs)
+        assert self.called_songs
         self.assertEqual(self.called_pl, pl)
         self.assertEqual(self.called_songs, pl.songs)
 
     def test_plugin_loads_json_once(self):
         plugin = self.plugin()
-        self.assertTrue(plugin._commands)
+        assert plugin._commands
         # Hack the commands without the plugin noticing
         fake = {"songs": Command(name="bar")}
         self.plugin._commands = fake

--- a/tests/plugin/test_fingerprint.py
+++ b/tests/plugin/test_fingerprint.py
@@ -50,12 +50,12 @@ class TFingerprint(PluginTestCase):
         t = time.time()
         while not done and time.time() - t < self.TIMEOUT:
             Gtk.main_iteration_do(False)
-        self.assertTrue(done)
+        assert done
         s, result, error = done
         # silence doesn't produce a fingerprint
-        self.assertTrue(error)
-        self.assertFalse(result)
-        self.assertTrue(song is s)
+        assert error
+        assert not result
+        assert song is s
 
     def test_analyze_pool(self):
         pool = self.mod.analyze.FingerPrintPool()
@@ -104,7 +104,7 @@ class TAcoustidLookup(PluginTestCase):
         self.assertEqual(tags["date"], "2002-01")
         self.assertEqual(tags["tracknumber"], "7/15")
         self.assertEqual(tags["discnumber"], "")
-        self.assertTrue("musicbrainz_albumid" in tags)
+        assert "musicbrainz_albumid" in tags
 
     def test_parse_response_2(self):
         parse = self.mod.acoustid.parse_acoustid_response
@@ -114,13 +114,13 @@ class TAcoustidLookup(PluginTestCase):
         tags = release.tags
         self.assertEqual(tags["albumartist"], "Kinderzimmer Productions")
         self.assertEqual(tags["album"], "Wir sind da wo oben ist")
-        self.assertTrue("musicbrainz_albumid" in tags)
+        assert "musicbrainz_albumid" in tags
 
     def test_parse_response_2_mb(self):
         parse = self.mod.acoustid.parse_acoustid_response
 
         release = parse(ACOUSTID_RESPONSE)[1]
-        self.assertTrue("musicbrainz_albumid" in release.tags)
+        assert "musicbrainz_albumid" in release.tags
         self.assertEqual(release.sources, 6)
         self.assertEqual(
             release.tags["musicbrainz_trackid"],

--- a/tests/plugin/test_html.py
+++ b/tests/plugin/test_html.py
@@ -42,11 +42,11 @@ class THTMLExport(PluginTestCase):
 
     def test_empty_export(self):
         text = self.to_html([])
-        self.assertTrue("<html" in text)
+        assert "<html" in text
 
     def test_export(self):
         text = self.to_html(SONGS)
-        self.assertTrue("\xf6\xe4\xfc" in text)
+        assert "\xf6\xe4\xfc" in text
 
     def tearDown(self):
         config.quit()

--- a/tests/plugin/test_mediaserver.py
+++ b/tests/plugin/test_mediaserver.py
@@ -50,7 +50,7 @@ class TMediaServer(PluginTestCase):
         self._replies.append(args)
 
     def _error(self, *args):
-        self.assertFalse(args)
+        assert not args
 
     def _wait(self):
         while not self._replies:
@@ -67,7 +67,7 @@ class TMediaServer(PluginTestCase):
     def test_entry_name(self):
         iface = self._entry_props_iface()
         iface.Get("org.gnome.UPnP.MediaObject2", "DisplayName", **self._args)
-        self.assertTrue("Quod Libet" in self._wait()[0])
+        assert "Quod Libet" in self._wait()[0]
 
     def test_name_owner(self):
         bus = dbus.SessionBus()

--- a/tests/plugin/test_mpris.py
+++ b/tests/plugin/test_mpris.py
@@ -67,7 +67,7 @@ class TMPRIS(PluginTestCase):
         self.assertTrue(
             bus.name_has_owner(self.BUS_NAME))
         self.m.disabled()
-        self.assertFalse(bus.name_has_owner(self.BUS_NAME))
+        assert not bus.name_has_owner(self.BUS_NAME)
 
         destroy_fake_app()
         config.quit()
@@ -75,7 +75,7 @@ class TMPRIS(PluginTestCase):
 
     def test_name_owner(self):
         bus = dbus.SessionBus()
-        self.assertTrue(bus.name_has_owner(self.BUS_NAME))
+        assert bus.name_has_owner(self.BUS_NAME)
 
     def _main_iface(self):
         bus = dbus.SessionBus()
@@ -105,7 +105,7 @@ class TMPRIS(PluginTestCase):
         self._replies.append(args)
 
     def _error(self, *args):
-        self.assertFalse(args)
+        assert not args
 
     def _wait(self, msg=""):
         start = time.time()
@@ -120,10 +120,10 @@ class TMPRIS(PluginTestCase):
         piface = "org.mpris.MediaPlayer2"
 
         app.window.hide()
-        self.assertFalse(app.window.get_visible())
+        assert not app.window.get_visible()
         self._main_iface().Raise(**args)
-        self.assertFalse(self._wait())
-        self.assertTrue(app.window.get_visible())
+        assert not self._wait()
+        assert app.window.get_visible()
         app.window.hide()
 
         props = {
@@ -140,10 +140,10 @@ class TMPRIS(PluginTestCase):
             self._prop().Get(piface, key, **args)
             resp = self._wait()[0]
             self.assertEqual(resp, value)
-            self.assertTrue(isinstance(resp, type(value)))
+            assert isinstance(resp, type(value))
 
         self._prop().Get(piface, "SupportedMimeTypes", **args)
-        self.assertTrue("audio/vorbis" in self._wait()[0])
+        assert "audio/vorbis" in self._wait()[0]
 
         self._introspect_iface().Introspect(**args)
         assert self._wait()
@@ -173,7 +173,7 @@ class TMPRIS(PluginTestCase):
             self._prop().Get(piface, key, **args)
             resp = self._wait(msg="for key '%s'" % key)[0]
             self.assertEqual(resp, value)
-            self.assertTrue(isinstance(resp, type(value)))
+            assert isinstance(resp, type(value))
 
     def test_volume_property(self):
         args = {"reply_handler": self._reply, "error_handler": self._error}
@@ -199,7 +199,7 @@ class TMPRIS(PluginTestCase):
         resp = self._wait()[0]
         self.assertEqual(resp["mpris:trackid"],
                              "/net/sacredchao/QuodLibet/NoTrack")
-        self.assertTrue(isinstance(resp["mpris:trackid"], dbus.ObjectPath))
+        assert isinstance(resp["mpris:trackid"], dbus.ObjectPath)
 
         # go to next song
         self._player_iface().Next(**args)
@@ -212,11 +212,11 @@ class TMPRIS(PluginTestCase):
                          "/net/sacredchao/QuodLibet/NoTrack")
 
         # mpris stuff
-        self.assertFalse(resp["mpris:trackid"].startswith("/org/mpris/"))
-        self.assertTrue(isinstance(resp["mpris:trackid"], dbus.ObjectPath))
+        assert not resp["mpris:trackid"].startswith("/org/mpris/")
+        assert isinstance(resp["mpris:trackid"], dbus.ObjectPath)
 
         self.assertEqual(resp["mpris:length"], 123 * 10 ** 6)
-        self.assertTrue(isinstance(resp["mpris:length"], dbus.Int64))
+        assert isinstance(resp["mpris:length"], dbus.Int64)
 
         # list text values
         self.assertEqual(resp["xesam:artist"], ["fooman", "go"])
@@ -229,14 +229,14 @@ class TMPRIS(PluginTestCase):
 
         # integers
         self.assertEqual(resp["xesam:audioBPM"], 123)
-        self.assertTrue(isinstance(resp["xesam:audioBPM"], dbus.Int32))
+        assert isinstance(resp["xesam:audioBPM"], dbus.Int32)
 
         self.assertEqual(resp["xesam:trackNumber"], 6)
-        self.assertTrue(isinstance(resp["xesam:trackNumber"], dbus.Int32))
+        assert isinstance(resp["xesam:trackNumber"], dbus.Int32)
 
         # rating
         self.assertAlmostEqual(resp["xesam:userRating"], 0.75)
-        self.assertTrue(isinstance(resp["xesam:userRating"], dbus.Double))
+        assert isinstance(resp["xesam:userRating"], dbus.Double)
 
         # time
         from time import strptime

--- a/tests/plugin/test_query.py
+++ b/tests/plugin/test_query.py
@@ -53,8 +53,8 @@ class TQueryPlugins(PluginTestCase):
         self.assertRaises(QueryPluginError, plugin.parse_body,
                               "invalid/query")
 
-        self.assertTrue(plugin.parse_body("a=first,b=second,c=third"))
-        self.assertTrue(plugin.parse_body("@(ext),#(numcmp > 0),!negation"))
+        assert plugin.parse_body("a=first,b=second,c=third")
+        assert plugin.parse_body("@(ext),#(numcmp > 0),!negation")
 
         body = plugin.parse_body("artist=a, genre=rock, genre=classical")
 
@@ -92,8 +92,8 @@ class TQueryPlugins(PluginTestCase):
             query1 = plugin.parse_body("Query 1", query_path_=filename)
             query2 = plugin.parse_body("another query", query_path_=filename)
             song = AudioFile({"artist": "a", "genre": "dance"})
-            self.assertTrue(plugin.search(song, query1))
-            self.assertFalse(plugin.search(song, query2))
+            assert plugin.search(song, query1)
+            assert not plugin.search(song, query2)
         finally:
             os.remove(filename)
 
@@ -108,8 +108,8 @@ class TQueryPlugins(PluginTestCase):
         self.assertRaises(QueryPluginError, plugin.parse_body, "\\")
         self.assertRaises(QueryPluginError, plugin.parse_body, "unclosed[")
         self.assertRaises(QueryPluginError, plugin.parse_body, "return s")
-        self.assertTrue(plugin.parse_body("3"))
-        self.assertTrue(plugin.parse_body("s"))
+        assert plugin.parse_body("3")
+        assert plugin.parse_body("s")
 
         body1 = plugin.parse_body("s('~#rating') > 0.5")
         body2 = plugin.parse_body(
@@ -120,9 +120,9 @@ class TQueryPlugins(PluginTestCase):
                            "genre": "jazz"})
         song2 = AudioFile({"title": "baz", "~#rating": 0.4, "genre": "aapop"})
 
-        self.assertTrue(plugin.search(song1, body1))
-        self.assertFalse(plugin.search(song1, body2))
-        self.assertFalse(plugin.search(song1, body3))
-        self.assertFalse(plugin.search(song2, body1))
-        self.assertTrue(plugin.search(song2, body2))
-        self.assertTrue(plugin.search(song2, body3))
+        assert plugin.search(song1, body1)
+        assert not plugin.search(song1, body2)
+        assert not plugin.search(song1, body3)
+        assert not plugin.search(song2, body1)
+        assert plugin.search(song2, body2)
+        assert plugin.search(song2, body3)

--- a/tests/plugin/test_randomalbum.py
+++ b/tests/plugin/test_randomalbum.py
@@ -75,12 +75,12 @@ class TRandomAlbum(PluginTestCase):
     def test_empty_integration_weighted(self):
         # See issue #2756
         self.plugin.use_weights = True
-        self.assertFalse(self.plugin.plugin_on_song_started(None))
+        assert not self.plugin.plugin_on_song_started(None)
 
     def test_empty_integration(self):
         # See issue #2756
         self.plugin.use_weights = False
-        self.assertFalse(self.plugin.plugin_on_song_started(None))
+        assert not self.plugin.plugin_on_song_started(None)
 
     def test_score_rating(self):
         weights = self.plugin.weights = self.WEIGHTS.copy()

--- a/tests/plugin/test_replaygain.py
+++ b/tests/plugin/test_replaygain.py
@@ -43,15 +43,15 @@ class TReplayGain(PluginTestCase):
 
     def test_RGSong_properties(self):
         rgs = self.mod.RGSong(self.song)
-        self.assertFalse(rgs.has_album_tags)
-        self.assertFalse(rgs.has_track_tags)
-        self.assertFalse(rgs.has_all_rg_tags)
+        assert not rgs.has_album_tags
+        assert not rgs.has_track_tags
+        assert not rgs.has_all_rg_tags
 
         rgs.done = True
         rgs._write(-1.23, 0.99)
-        self.assertTrue(rgs.has_album_tags, msg="Didn't write album tags")
-        self.assertFalse(rgs.has_track_tags)
-        self.assertFalse(rgs.has_all_rg_tags)
+        assert rgs.has_album_tags, "Didn't write album tags"
+        assert not rgs.has_track_tags
+        assert not rgs.has_all_rg_tags
 
     def test_RGSong_zero(self):
         rgs = self.mod.RGSong(self.song)
@@ -62,7 +62,7 @@ class TReplayGain(PluginTestCase):
 
     def test_RGAlbum_properties(self):
         rga = self.mod.RGAlbum([self.mod.RGSong(self.song)], UpdateMode.ALWAYS)
-        self.assertFalse(rga.done)
+        assert not rga.done
         self.assertEqual(rga.title, "foo - the album")
 
     def test_delete_bs1770gain(self):
@@ -77,7 +77,7 @@ class TReplayGain(PluginTestCase):
         rgs._write(0.0, 0.0)
 
         for tag in tags:
-            self.assertFalse(self.song(tag))
+            assert not self.song(tag)
 
     def _analyse_song(self, song):
         mode = self.mod.UpdateMode.ALWAYS
@@ -101,12 +101,12 @@ class TReplayGain(PluginTestCase):
             pipeline.disconnect(sig)
 
         _run_main_loop()
-        self.assertTrue(self.analysed, "Timed out")
+        assert self.analysed, "Timed out"
 
     def test_analyze_sinewave(self):
         song = MusicFile(get_data_path("sine-110hz.flac"))
         self.assertEqual(song("~#length"), 2)
-        self.assertFalse(song("~replaygain_track_gain"))
+        assert not song("~replaygain_track_gain")
 
         self._analyse_song(song)
 
@@ -114,15 +114,15 @@ class TReplayGain(PluginTestCase):
                                    msg="Track peak should be 1.0")
 
         track_gain = song("~#replaygain_track_gain")
-        self.assertTrue(track_gain, msg="No Track Gain added")
-        self.assertTrue(re.match(r"\-[0-9]\.[0-9]{1,2}", str(track_gain)))
+        assert track_gain, "No Track Gain added"
+        assert re.match(r"\-[0-9]\.[0-9]{1,2}", str(track_gain))
 
         # For one-song album, track == album
         self.assertEqual(track_gain, song("~#replaygain_album_gain"))
 
     def test_analyze_silence(self):
         song = MusicFile(get_data_path("silence-44-s.ogg"))
-        self.assertFalse(song("~replaygain_track_gain"))
+        assert not song("~replaygain_track_gain")
 
         self._analyse_song(song)
 
@@ -130,7 +130,7 @@ class TReplayGain(PluginTestCase):
                                    msg="Track peak should be 0.0")
 
         track_gain = song("~#replaygain_track_gain")
-        self.assertTrue(track_gain, msg="No Track Gain added")
+        assert track_gain, "No Track Gain added"
 
         # For one-song album, track == album
         self.assertEqual(track_gain, song("~#replaygain_album_gain"))

--- a/tests/plugin/test_songsmenu.py
+++ b/tests/plugin/test_songsmenu.py
@@ -75,6 +75,6 @@ class TPluginsSongsMenu(PluginTestCase):
         for plugin in self.plugins.values():
             if isinstance(plugin, SongsMenuPlugin):
                 ha = plugin.handles_albums
-                self.assertFalse(hasattr(plugin, "plugin_single_album") and not ha)
-                self.assertFalse(hasattr(plugin, "plugin_plugin_album") and not ha)
-                self.assertFalse(hasattr(plugin, "plugin_albums") and not ha)
+                assert not hasattr(plugin, "plugin_single_album") and not ha
+                assert not hasattr(plugin, "plugin_plugin_album") and not ha
+                assert not hasattr(plugin, "plugin_albums") and not ha

--- a/tests/plugin/test_synchronize_to_device.py
+++ b/tests/plugin/test_synchronize_to_device.py
@@ -179,8 +179,8 @@ class TSyncToDevice(PluginTestCase):
 
         song = model[path][self.plugin._model_col_id("entry")]._song
         if song and data[2] and data[3]:
-            self.assertTrue(song[data[2]].startswith(data[3]),
-                f'Data in given field "{song[data[2]]}" does not start with {data[3]}')
+            msg = f'Data in given field "{song[data[2]]}" does not start with {data[3]}'
+            assert song[data[2]].startswith(data[3]), msg
 
         return False
 
@@ -241,7 +241,7 @@ class TSyncToDevice(PluginTestCase):
     def test_pluginpreferences_missing_saved_queries_file(self):
         os.remove(self.plugin.path_query)
         self.main_vbox = self._start_plugin()
-        self.assertFalse(os.path.exists(self.plugin.path_query))
+        assert not os.path.exists(self.plugin.path_query)
         self.assertEqual(type(self.main_vbox), Gtk.Frame)
 
     def test_pluginpreferences_no_saved_queries(self):
@@ -254,10 +254,10 @@ class TSyncToDevice(PluginTestCase):
         self.assertEqual(type(self.main_vbox), Gtk.VBox)
 
         self.assertEqual(len(self.plugin.queries), len(QUERIES))
-        self.assertTrue(all(isinstance(button, ConfigCheckButton) for button in
-                            self.plugin.saved_search_vbox.get_children()))
-        self.assertFalse(any(button.get_active() for button in
-                             self.plugin.saved_search_vbox.get_children()))
+        assert all(isinstance(button, ConfigCheckButton) for button in
+                            self.plugin.saved_search_vbox.get_children())
+        assert not any(button.get_active()
+                       for button in self.plugin.saved_search_vbox.get_children())
 
         self.assertNotEqual(
             self.plugin.destination_entry.get_placeholder_text(), "")
@@ -270,23 +270,23 @@ class TSyncToDevice(PluginTestCase):
         n_cols = self.plugin.model.get_n_columns()
         self.assertEqual(n_cols, len(self.plugin.model_cols))
 
-        self.assertTrue(self.plugin.preview_start_button.get_visible())
-        self.assertFalse(self.plugin.preview_stop_button.get_visible())
-        self.assertFalse(self.plugin.status_operation.get_visible())
+        assert self.plugin.preview_start_button.get_visible()
+        assert not self.plugin.preview_stop_button.get_visible()
+        assert not self.plugin.status_operation.get_visible()
         self.assertEqual(self.plugin.status_operation.get_text(), "")
-        self.assertFalse(self.plugin.status_progress.get_visible())
+        assert not self.plugin.status_progress.get_visible()
         self.assertEqual(self.plugin.status_progress.get_text(), "")
-        self.assertFalse(self.plugin.status_duplicates.get_visible())
-        self.assertFalse(self.plugin.status_deletions.get_visible())
+        assert not self.plugin.status_duplicates.get_visible()
+        assert not self.plugin.status_deletions.get_visible()
 
-        self.assertTrue(self.plugin.sync_start_button.get_visible())
-        self.assertFalse(self.plugin.sync_stop_button.get_visible())
+        assert self.plugin.sync_start_button.get_visible()
+        assert not self.plugin.sync_stop_button.get_visible()
 
     def test_select_saved_search(self):
         button = self.plugin.saved_search_vbox.get_children()[0]
 
         button.set_active(True)
-        self.assertTrue(button.get_active())
+        assert button.get_active()
         query_config = self._make_query_config(button.get_label())
         self.assertTrue(
             config.getboolean(PM.CONFIG_SECTION, query_config, None))
@@ -376,7 +376,7 @@ class TSyncToDevice(PluginTestCase):
         self.plugin._start_preview(self.plugin.preview_start_button)
         mock_message.assert_not_called()
 
-        self.assertTrue(self.plugin.status_progress.get_visible())
+        assert self.plugin.status_progress.get_visible()
         self.assertNotEqual(self.plugin.status_progress.get_text(), "")
         n_children = self.plugin.model.iter_n_children(None)
         self.assertEqual(n_children, QUERIES[query_name]["results"])
@@ -394,7 +394,7 @@ class TSyncToDevice(PluginTestCase):
 
         self.plugin._start_preview(self.plugin.preview_start_button)
 
-        self.assertTrue(self.plugin.status_progress.get_visible())
+        assert self.plugin.status_progress.get_visible()
         self.assertNotEqual(self.plugin.status_progress.get_text(), "")
         n_children = self.plugin.model.iter_n_children(None)
         self.assertEqual(n_children, QUERIES[query_name]["results"])
@@ -412,7 +412,7 @@ class TSyncToDevice(PluginTestCase):
 
         self.plugin._start_preview(self.plugin.preview_start_button)
 
-        self.assertTrue(self.plugin.status_progress.get_visible())
+        assert self.plugin.status_progress.get_visible()
         self.assertNotEqual(self.plugin.status_progress.get_text(), "")
         n_children = self.plugin.model.iter_n_children(None)
         self.assertEqual(n_children, QUERIES[query_name]["results"])
@@ -433,13 +433,13 @@ class TSyncToDevice(PluginTestCase):
 
         self.plugin._start_preview(self.plugin.preview_start_button)
 
-        self.assertTrue(self.plugin.status_progress.get_visible())
+        assert self.plugin.status_progress.get_visible()
         self.assertNotEqual(self.plugin.status_progress.get_text(), "")
         n_children = self.plugin.model.iter_n_children(None)
         self.assertEqual(n_children, n_expected)
 
-        self.assertFalse(self.plugin.status_duplicates.get_visible())
-        self.assertFalse(self.plugin.status_deletions.get_visible())
+        assert not self.plugin.status_duplicates.get_visible()
+        assert not self.plugin.status_deletions.get_visible()
 
     def test_start_preview_export_path_check(self):
         def _verify_path(model, path, iter_, *data):
@@ -496,8 +496,8 @@ class TSyncToDevice(PluginTestCase):
         n_children = self.plugin.model.iter_n_children(None)
         self.assertEqual(n_children, num_files)
 
-        self.assertFalse(self.plugin.status_duplicates.get_visible())
-        self.assertTrue(self.plugin.status_deletions.get_visible())
+        assert not self.plugin.status_duplicates.get_visible()
+        assert self.plugin.status_deletions.get_visible()
 
     def test_start_preview_query_and_file_deletion(self):
         self._make_library()
@@ -636,14 +636,14 @@ class TSyncToDevice(PluginTestCase):
         cell_id_edit = 0
         cell_id_copy = 1
         self._mark_song_duplicate(cell_id_edit, cell_id_copy)
-        self.assertTrue(self.plugin.status_duplicates.get_visible())
+        assert self.plugin.status_duplicates.get_visible()
 
         old_c_songs_copy = self.plugin.c_songs_copy
         old_c_song_dupes = self.plugin.c_song_dupes
         self._mark_song_unique(cell_id_edit)
         self.assertEqual(self.plugin.c_songs_copy, old_c_songs_copy + 1)
         self.assertEqual(self.plugin.c_song_dupes, old_c_song_dupes - 1)
-        self.assertFalse(self.plugin.status_duplicates.get_visible())
+        assert not self.plugin.status_duplicates.get_visible()
 
     def test_row_edited_duplicate_to_duplicate(self):
         self._make_library()
@@ -659,8 +659,8 @@ class TSyncToDevice(PluginTestCase):
         self._mark_song_duplicate(cell_id_edit, cell_id_copy_2)
         self.assertEqual(self.plugin.c_song_dupes, old_c_song_dupes)
 
-        self.assertTrue(self.plugin.status_duplicates.get_visible())
-        self.assertFalse(self.plugin.status_deletions.get_visible())
+        assert self.plugin.status_duplicates.get_visible()
+        assert not self.plugin.status_deletions.get_visible()
 
     def test_row_edited_duplicate_to_delete(self):
         self._make_library()
@@ -859,10 +859,10 @@ class TSyncToDevice(PluginTestCase):
         cell_id_copy = 0
         for cell_id in range(cell_id_copy + 1, n_songs):
             self._mark_song_duplicate(cell_id, cell_id_copy)
-        self.assertTrue(self.plugin.status_duplicates.get_visible())
+        assert self.plugin.status_duplicates.get_visible()
 
         self.plugin._start_sync(self.plugin.sync_start_button)
-        self.assertFalse(self.plugin.status_duplicates.get_visible())
+        assert not self.plugin.status_duplicates.get_visible()
 
         expected_sync = 1
         expected_skip = n_songs - expected_sync
@@ -886,10 +886,10 @@ class TSyncToDevice(PluginTestCase):
         self.dest_entry.set_text(self.path_dest)
         self.plugin._start_preview(self.plugin.preview_start_button)
         n_songs = QUERIES[query_name]["results"]
-        self.assertTrue(self.plugin.status_deletions.get_visible())
+        assert self.plugin.status_deletions.get_visible()
 
         self.plugin._start_sync(self.plugin.sync_start_button)
-        self.assertFalse(self.plugin.status_deletions.get_visible())
+        assert not self.plugin.status_deletions.get_visible()
 
         self.assertEqual(self.plugin.c_files_copy, n_songs)
         self.assertEqual(self.plugin.c_files_delete, n_files)

--- a/tests/plugin/test_trayicon.py
+++ b/tests/plugin/test_trayicon.py
@@ -50,7 +50,7 @@ class TTrayIcon(PluginTestCase):
         get_paused_pixbuf = \
             self.modules["Tray Icon"].systemtray.get_paused_pixbuf
 
-        self.assertTrue(get_paused_pixbuf((1, 1), 0))
+        assert get_paused_pixbuf((1, 1), 0)
         self.assertRaises(ValueError, get_paused_pixbuf, (0, 0), 0)
         self.assertRaises(ValueError, get_paused_pixbuf, (1, 1), -1)
 
@@ -62,15 +62,15 @@ class TTrayIcon(PluginTestCase):
         for w, h in [(150, 1), (1, 150), (1, 1)]:
             pb = GdkPixbuf.Pixbuf.new(GdkPixbuf.Colorspace.RGB, True, 8, w, h)
             success, new = new_with_paused_emblem(pb)
-            self.assertFalse(success)
-            self.assertTrue(new)
+            assert not success
+            assert new
 
         # those should work
         for w, h in [(20, 20), (10, 10), (5, 5), (150, 5), (5, 150)]:
             pb = GdkPixbuf.Pixbuf.new(GdkPixbuf.Colorspace.RGB, True, 8, w, h)
             success, new = new_with_paused_emblem(pb)
-            self.assertTrue(success)
-            self.assertTrue(new)
+            assert success
+            assert new
 
 
 @skipIf(sys.platform == "darwin", "segfaults..")
@@ -91,17 +91,17 @@ class TIndicatorMenu(TestCase):
         icons = [item.get_image().get_icon_name()[0]
                  for item in menu.get_children()
                  if isinstance(item, Gtk.ImageMenuItem)]
-        self.assertTrue(Icons.EDIT in icons)
-        self.assertTrue(Icons.FOLDER_DRAG_ACCEPT in icons)
-        self.assertTrue(Icons.MEDIA_PLAYBACK_START in icons)
-        self.assertTrue(Icons.MEDIA_SKIP_FORWARD in icons)
-        self.assertTrue(Icons.MEDIA_SKIP_BACKWARD in icons)
-        self.assertTrue(Icons.APPLICATION_EXIT in icons)
-        self.assertTrue(Icons.FAVORITE in icons)
+        assert Icons.EDIT in icons
+        assert Icons.FOLDER_DRAG_ACCEPT in icons
+        assert Icons.MEDIA_PLAYBACK_START in icons
+        assert Icons.MEDIA_SKIP_FORWARD in icons
+        assert Icons.MEDIA_SKIP_BACKWARD in icons
+        assert Icons.APPLICATION_EXIT in icons
+        assert Icons.FAVORITE in icons
 
     def test_playlist_menu_populates(self):
         from quodlibet.ext.events.trayicon.menu import IndicatorMenu
         menu = IndicatorMenu(app)
         song = AudioFile({"~filename": "/dev/null"})
         menu._new_playlist_submenu_for(song)
-        self.assertTrue(menu._playlists_item.get_submenu())
+        assert menu._playlists_item.get_submenu()

--- a/tests/test___init__.py
+++ b/tests/test___init__.py
@@ -23,25 +23,25 @@ class TQuodlibet(TestCase):
         config.quit()
 
     def test_first_session(self):
-        self.assertTrue(quodlibet.is_first_session("quodlibet"))
-        self.assertTrue(quodlibet.is_first_session("quodlibet"))
+        assert quodlibet.is_first_session("quodlibet")
+        assert quodlibet.is_first_session("quodlibet")
         quodlibet.finish_first_session("exfalso")
-        self.assertTrue(quodlibet.is_first_session("quodlibet"))
+        assert quodlibet.is_first_session("quodlibet")
         quodlibet.finish_first_session("quodlibet")
-        self.assertFalse(quodlibet.is_first_session("quodlibet"))
+        assert not quodlibet.is_first_session("quodlibet")
 
     def test_dirs(self):
-        self.assertTrue(isinstance(quodlibet.get_base_dir(), fsnative))
-        self.assertTrue(isinstance(quodlibet.get_image_dir(), fsnative))
-        self.assertTrue(isinstance(quodlibet.get_user_dir(), fsnative))
-        self.assertTrue(isinstance(quodlibet.get_cache_dir(), fsnative))
+        assert isinstance(quodlibet.get_base_dir(), fsnative)
+        assert isinstance(quodlibet.get_image_dir(), fsnative)
+        assert isinstance(quodlibet.get_user_dir(), fsnative)
+        assert isinstance(quodlibet.get_cache_dir(), fsnative)
 
     def test_get_build_description(self):
         quodlibet.get_build_description()
 
     def test_get_build_version(self):
         ver = quodlibet.get_build_version()
-        self.assertTrue(isinstance(ver, tuple))
+        assert isinstance(ver, tuple)
 
 
 class TVersion(TestCase):
@@ -52,4 +52,4 @@ class TVersion(TestCase):
         try:
             v.check((1, 1))
         except ImportError as e:
-            self.assertTrue("bla" in str(e))
+            assert "bla" in str(e)

--- a/tests/test_appdata_files.py
+++ b/tests/test_appdata_files.py
@@ -40,7 +40,7 @@ class _TAppDataFileMixin:
     PATH = None
 
     def test_filename(self):
-        self.assertTrue(self.PATH.endswith(".appdata.xml.in"))
+        assert self.PATH.endswith(".appdata.xml.in")
 
     def test_validate(self):
         try:

--- a/tests/test_browsers___init__.py
+++ b/tests/test_browsers___init__.py
@@ -12,16 +12,16 @@ browsers.init()
 
 class TBrowsers(TestCase):
     def test_presence(self):
-        self.assertTrue(browsers.tracks)
-        self.assertTrue(browsers.paned)
-        self.assertTrue(browsers.iradio)
-        self.assertTrue(browsers.podcasts)
-        self.assertTrue(browsers.albums)
-        self.assertTrue(browsers.playlists)
-        self.assertTrue(browsers.filesystem)
+        assert browsers.tracks
+        assert browsers.paned
+        assert browsers.iradio
+        assert browsers.podcasts
+        assert browsers.albums
+        assert browsers.playlists
+        assert browsers.filesystem
 
     def test_get(self):
-        self.assertTrue(browsers.get("SearchBar") is browsers.tracks.TrackList)
+        assert browsers.get("SearchBar") is browsers.tracks.TrackList
         self.assertTrue(
             browsers.get("FileSystem") is browsers.filesystem.FileSystem)
         self.assertEqual(browsers.get("Paned"), browsers.paned.PanedBrowser)

--- a/tests/test_browsers__base.py
+++ b/tests/test_browsers__base.py
@@ -52,12 +52,12 @@ class TBrowser(TestCase):
 
     def test_can_filter(self):
         for key in ["foo", "title", "fake~key", "~woobar", "~#huh"]:
-            self.assertFalse(self.browser.can_filter(key))
+            assert not self.browser.can_filter(key)
 
     def test_defaults(self):
-        self.assertTrue(self.browser.background)
-        self.assertFalse(self.browser.can_reorder)
-        self.assertFalse(self.browser.headers)
+        assert self.browser.background
+        assert not self.browser.can_reorder
+        assert not self.browser.headers
 
     def test_status_bar(self):
         self.assertEqual(self.browser.status_text(1, "21s"),
@@ -97,7 +97,7 @@ class TBrowserMixin:
         if self.b.name == "Playlists":
             return
         menu = self.b.menu([], self.library, [])
-        self.assertTrue(isinstance(menu, Gtk.Menu))
+        assert isinstance(menu, Gtk.Menu)
 
     def test_key(self):
         self.assertEqual(browsers.get(browsers.name(self.Kind)), self.Kind)
@@ -111,13 +111,13 @@ class TBrowserMixin:
         to_pack = Gtk.Button()
         to_pack.hide()
         container = self.b.pack(to_pack)
-        self.assertFalse(to_pack.get_visible())
+        assert not to_pack.get_visible()
         self.b.unpack(container, to_pack)
-        self.assertFalse(to_pack.get_visible())
+        assert not to_pack.get_visible()
 
     def test_name(self):
-        self.assertFalse("_" in self.b.name)
-        self.assertTrue("_" in self.b.accelerated_name)
+        assert "_" not in self.b.name
+        assert "_" in self.b.accelerated_name
 
     def test_init(self):
         self.Kind.init(self.library)
@@ -146,9 +146,9 @@ class TBrowserMixin:
 
     def test_filters_caps(self):
         with realized(self.b):
-            self.assertTrue(isinstance(self.b.can_filter_tag("foo"), bool))
-            self.assertTrue(isinstance(self.b.can_filter_text(), bool))
-            self.assertTrue(isinstance(self.b.can_filter("foo"), bool))
+            assert isinstance(self.b.can_filter_tag("foo"), bool)
+            assert isinstance(self.b.can_filter_text(), bool)
+            assert isinstance(self.b.can_filter("foo"), bool)
 
     def test_filter_text(self):
         with realized(self.b):

--- a/tests/test_browsers_albums.py
+++ b/tests/test_browsers_albums.py
@@ -174,15 +174,15 @@ class TAlbumBrowser(TestCase):
         with realized(self.bar):
             view = self.bar.view
             view.row_activated(Gtk.TreePath((0,)), view.get_column(0))
-            self.assertTrue(self.activated)
+            assert self.activated
 
     def test_can_filter(self):
         with realized(self.bar):
-            self.assertTrue(self.bar.can_filter(None))
-            self.assertTrue(self.bar.can_filter("album"))
-            self.assertTrue(self.bar.can_filter("foobar"))
-            self.assertFalse(self.bar.can_filter("~#length"))
-            self.assertFalse(self.bar.can_filter("title"))
+            assert self.bar.can_filter(None)
+            assert self.bar.can_filter("album")
+            assert self.bar.can_filter("foobar")
+            assert not self.bar.can_filter("~#length")
+            assert not self.bar.can_filter("title")
 
     def test_set_text(self):
         with realized(self.bar):
@@ -212,7 +212,7 @@ class TAlbumBrowser(TestCase):
             self.assertEqual(self.songs[0]("artist"), "piman")
 
     def test_header(self):
-        self.assertFalse(self.bar.headers)
+        assert not self.bar.headers
 
     def test_list(self):
         albums = self.bar.list_albums()
@@ -226,15 +226,15 @@ class TAlbumBrowser(TestCase):
         with realized(self.bar):
             self.bar.filter("artist", ["piman"])
             self._wait()
-            self.assertTrue(self.bar.active_filter(self.songs[0]))
+            assert self.bar.active_filter(self.songs[0])
             for s in SONGS:
                 if s is not self.songs[0]:
-                    self.assertFalse(self.bar.active_filter(s))
+                    assert not self.bar.active_filter(s)
 
     def test_default_display_pattern(self):
         pattern_text = self.bar.display_pattern_text
         self.assertEqual(pattern_text, DEFAULT_PATTERN_TEXT)
-        self.assertTrue("<album>" in pattern_text)
+        assert "<album>" in pattern_text
 
     def tearDown(self):
         self.bar.disconnect(self._id)

--- a/tests/test_browsers_collection.py
+++ b/tests/test_browsers_collection.py
@@ -59,19 +59,19 @@ class TCollectionAlbums(TestCase):
     def test_build_tree(self):
         tags = [("~people", 0)]
         tree = build_tree(tags, self.albums)
-        self.assertTrue("mu" in tree)
-        self.assertTrue("boris" in tree)
-        self.assertTrue("piman" in tree)
-        self.assertTrue(UnknownNode in tree)
+        assert "mu" in tree
+        assert "boris" in tree
+        assert "piman" in tree
+        assert UnknownNode in tree
         self.assertEqual(len(tree), 4)
 
     def test_build_tree_merge(self):
         tags = [("~people", 1)]
         tree = build_tree(tags, self.albums)
-        self.assertTrue(MultiNode in tree)
-        self.assertTrue(UnknownNode in tree)
-        self.assertTrue("boris" in tree)
-        self.assertTrue("piman" in tree)
+        assert MultiNode in tree
+        assert UnknownNode in tree
+        assert "boris" in tree
+        assert "piman" in tree
         self.assertEqual(len(tree), 4)
 
     def test_model(self):
@@ -91,18 +91,18 @@ class TCollectionAlbums(TestCase):
 
         path = model.get_path_for_album(a[0])
         albums = model.get_albums_for_path(path)
-        self.assertTrue(a[0] in albums)
+        assert a[0] in albums
 
         albums = model.get_albums_for_iter(model.get_iter(path))
-        self.assertTrue(a[0] in albums)
+        assert a[0] in albums
 
         x = model.get_album(model.get_iter_first())
-        self.assertFalse(x)
+        assert not x
         x = model.get_album(model.get_iter(path))
         self.assertEqual(x, a[0])
 
         for r in model:
-            self.assertTrue(model.get_markup(model.tags, r.iter))
+            assert model.get_markup(model.tags, r.iter)
 
         x = list(model.iter_albums(None))
         self.assertEqual(set(x), set(a))

--- a/tests/test_browsers_covergrid.py
+++ b/tests/test_browsers_covergrid.py
@@ -91,15 +91,15 @@ class TCoverGridBrowser(TestCase):
             child = view.get_child_at_index(0)
             child.emit("activate")
             self._wait()
-            self.assertTrue(self.activated)
+            assert self.activated
 
     def test_can_filter(self):
         with realized(self.bar):
-            self.assertTrue(self.bar.can_filter(None))
-            self.assertTrue(self.bar.can_filter("album"))
-            self.assertTrue(self.bar.can_filter("foobar"))
-            self.assertFalse(self.bar.can_filter("~#length"))
-            self.assertFalse(self.bar.can_filter("title"))
+            assert self.bar.can_filter(None)
+            assert self.bar.can_filter("album")
+            assert self.bar.can_filter("foobar")
+            assert not self.bar.can_filter("~#length")
+            assert not self.bar.can_filter("title")
 
     def test_set_text(self):
         with realized(self.bar):
@@ -129,7 +129,7 @@ class TCoverGridBrowser(TestCase):
             self.assertEqual(self.songs[0]("artist"), "piman")
 
     def test_header(self):
-        self.assertFalse(self.bar.headers)
+        assert not self.bar.headers
 
     def test_list(self):
         albums = self.bar.list_albums()
@@ -143,12 +143,12 @@ class TCoverGridBrowser(TestCase):
         with realized(self.bar):
             self.bar.filter("artist", ["piman"])
             self._wait()
-            self.assertTrue(self.bar.active_filter(self.songs[0]))
+            assert self.bar.active_filter(self.songs[0])
             for s in SONGS:
                 if s is not self.songs[0]:
-                    self.assertFalse(self.bar.active_filter(s))
+                    assert not self.bar.active_filter(s)
 
     def test_default_display_pattern(self):
         pattern_text = self.bar.display_pattern_text
         self.assertEqual(pattern_text, DEFAULT_PATTERN_TEXT)
-        self.assertTrue("<album>" in pattern_text)
+        assert "<album>" in pattern_text

--- a/tests/test_browsers_iradio.py
+++ b/tests/test_browsers_iradio.py
@@ -78,7 +78,7 @@ class TQuestionBar(TestCase):
 
     def test_main(self):
         b = QuestionBar()
-        self.assertFalse(b.get_visible())
+        assert not b.get_visible()
 
 
 class TInternetRadio(TestCase):
@@ -87,8 +87,8 @@ class TInternetRadio(TestCase):
         self.bar = InternetRadio(SongLibrary())
 
     def test_can_filter(self):
-        self.assertTrue(self.bar.can_filter("foo"))
-        self.assertTrue(self.bar.can_filter_text())
+        assert self.bar.can_filter("foo")
+        assert self.bar.can_filter_text()
 
     def test_status_bar_text(self):
         self.assertEqual(self.bar.status_text(1), "1 station")
@@ -124,7 +124,7 @@ class TIRFile(TestCase):
         self.assertEqual(self.s.get("title"), "foo")
 
     def test_title_split_stream(self):
-        self.assertFalse(self.s("artist"))
+        assert not self.s("artist")
         self.s["title"] = "artist - title"
         self.s.multisong = False
         self.assertEqual(self.s("title"), "title")
@@ -133,15 +133,15 @@ class TIRFile(TestCase):
         self.assertEqual(self.s.get("artist"), "artist")
 
     def test_title_split(self):
-        self.assertTrue(self.s.multisong)
+        assert self.s.multisong
         self.s["title"] = "artist - title"
         self.assertEqual(self.s("title"), self.s["title"])
 
     def test_format(self):
         self.assertEqual(self.s("~format"), self.s.format)
         self.s["audio-codec"] = "SomeCodec"
-        self.assertTrue("SomeCodec" in self.s("~format"))
-        self.assertTrue(self.s.format in self.s("~format"))
+        assert "SomeCodec" in self.s("~format")
+        assert self.s.format in self.s("~format")
 
     def test_people(self):
         self.s["title"] = "artist - title"
@@ -150,9 +150,9 @@ class TIRFile(TestCase):
         self.assertEqual(self.s("~~people~foo"), "artist")
 
     def testcan_write(self):
-        self.assertTrue(self.s.can_change("title"))
+        assert self.s.can_change("title")
         self.s.streamsong = True
-        self.assertFalse(self.s.can_change("title"))
+        assert not self.s.can_change("title")
 
     def test_dump_to_file(self):
         self.s["title"] = "artist - title"
@@ -167,8 +167,8 @@ class TIRFile(TestCase):
         dump = self.s.to_dump()
         new = AudioFile()
         new.from_dump(dump)
-        self.assertTrue("title" not in new)
-        self.assertTrue("artist" not in new)
+        assert "title" not in new
+        assert "artist" not in new
 
 
 class Bzip2GetHandler(BaseHTTPRequestHandler):

--- a/tests/test_browsers_paned.py
+++ b/tests/test_browsers_paned.py
@@ -81,9 +81,9 @@ class TPanedBrowser(TestCase):
 
     def test_can_filter(self):
         for key in ["foo", "title", "fake~key", "~woobar", "~#huh"]:
-            self.assertFalse(self.bar.can_filter_tag(key))
-        self.assertTrue(self.bar.can_filter("artist"))
-        self.assertTrue(self.bar.can_filter_text())
+            assert not self.bar.can_filter_tag(key)
+        assert self.bar.can_filter("artist")
+        assert self.bar.can_filter_text()
 
     def test_filter_text(self):
         self.bar.activate()
@@ -141,7 +141,7 @@ class TPanedBrowser(TestCase):
         self.bar.activate()
         run_gtk_loop()
         for song in self.last:
-            self.assertTrue("piman" in song.list("artist"))
+            assert "piman" in song.list("artist")
 
     def test_set_all_panes(self):
         self.bar.activate()
@@ -183,8 +183,8 @@ class TPaneConfig(TestCase):
         self.assertEqual(p.tags, {"title"})
 
         self.assertEqual(p.format(SONGS[0]), [("three", "three")])
-        self.assertTrue(str(len(ALBUM.songs)) in p.format_display(ALBUM))
-        self.assertFalse(p.has_markup)
+        assert str(len(ALBUM.songs)) in p.format_display(ALBUM)
+        assert not p.has_markup
 
     def test_numeric(self):
         a_date_format = "%Y-%m-%d"
@@ -195,7 +195,7 @@ class TPaneConfig(TestCase):
 
         zero_date = format_date(0, a_date_format)
         self.assertEqual(p.format(SONGS[0]), [(zero_date, zero_date)])
-        self.assertFalse(p.has_markup)
+        assert not p.has_markup
 
     def test_tied(self):
         p = PaneConfig("~title~artist")
@@ -209,13 +209,13 @@ class TPaneConfig(TestCase):
         p = PaneConfig("<foo>")
         self.assertEqual(p.title, "Foo")
         self.assertEqual(p.tags, {"foo"})
-        self.assertTrue(p.has_markup)
+        assert p.has_markup
 
     def test_condition(self):
         p = PaneConfig("<foo|a <bar>|quux>")
         self.assertEqual(p.title, "a Bar")
         self.assertEqual(p.tags, {"bar"})
-        self.assertTrue(p.has_markup)
+        assert p.has_markup
 
     def test_group(self):
         p = PaneConfig(r"a\:b:<title>")
@@ -235,9 +235,9 @@ class TPaneEntry(TestCase):
 
     def test_all_have(self):
         sel = SongsEntry("foo", "foo", SONGS)
-        self.assertFalse(sel.all_have("artist", "one"))
-        self.assertFalse(sel.all_have("~#mtime", 4))
-        self.assertTrue(sel.all_have("foo", "bar"))
+        assert not sel.all_have("artist", "one")
+        assert not sel.all_have("~#mtime", 4)
+        assert sel.all_have("foo", "bar")
 
     def test_all(self):
         entry = AllEntry()
@@ -245,7 +245,7 @@ class TPaneEntry(TestCase):
         assert not entry.get_count_markup(conf)
         entry.get_markup(conf)
         self.assertEqual(list(entry.songs), [])
-        self.assertFalse(entry.contains_text(""))
+        assert not entry.contains_text("")
         repr(entry)
 
     def test_unknown(self):
@@ -253,7 +253,7 @@ class TPaneEntry(TestCase):
         conf = PaneConfig("title:artist")
         self.assertEqual(entry.songs, set(SONGS))
         self.assertEqual(entry.key, "")
-        self.assertFalse(entry.contains_text(""))
+        assert not entry.contains_text("")
         assert util.escape(SONGS[0]("artist")) in entry.get_count_markup(conf)
         entry.get_markup(conf)
         repr(entry)
@@ -295,15 +295,15 @@ class TPane(TestCase):
             self.pane.add(SONGS)
         with realized(self.pane):
             self.pane.remove(SONGS)
-        self.assertFalse(self.pane.list("arist"))
+        assert not self.pane.list("arist")
 
     def test_matches(self):
-        self.assertTrue(self.pane.matches(SONGS[0]))
+        assert self.pane.matches(SONGS[0])
         self.pane.fill(SONGS)
         selection = self.pane.get_selection()
         selection.unselect_all()
         selection.select_path(Gtk.TreePath(3))
-        self.assertFalse(self.pane.matches(SONGS[1]))
+        assert not self.pane.matches(SONGS[1])
 
     def test_fill(self):
         self.pane.fill(SONGS)
@@ -371,9 +371,9 @@ class TMultiPane(TestCase):
         VALUE = "J-Pop"
         self.p1.fill(SONGS)
         keys = self.p1.list("genre")
-        self.assertTrue(VALUE in keys)
+        assert VALUE in keys
         self.p1.set_selected([VALUE], force_any=False)
-        self.assertTrue(self.last)
+        assert self.last
         for song in self.last:
             self.assertEqual(song("genre"), VALUE)
         self.assertEqual(self.count, 2)
@@ -390,12 +390,12 @@ class TPaneModel(TestCase):
 
     def _verify_model(self, model):
         if len(model) == 1:
-            self.assertFalse(isinstance(model[0][0], AllEntry))
+            assert not isinstance(model[0][0], AllEntry)
         elif len(model) > 1:
-            self.assertTrue(isinstance(model[0][0], AllEntry))
+            assert isinstance(model[0][0], AllEntry)
 
             for row in list(model)[1:-1]:
-                self.assertTrue(isinstance(row[0], SongsEntry))
+                assert isinstance(row[0], SongsEntry)
 
             self.assertTrue(
                 isinstance(model[-1][0], SongsEntry | UnknownEntry))
@@ -404,8 +404,8 @@ class TPaneModel(TestCase):
         conf = PaneConfig("artist")
         m = PaneModel(conf)
         m.add_songs(SONGS)
-        self.assertTrue(isinstance(m[0][0], AllEntry))
-        self.assertTrue(isinstance(m[-1][0], UnknownEntry))
+        assert isinstance(m[0][0], AllEntry)
+        assert isinstance(m[-1][0], UnknownEntry)
         self.assertEqual(len(m), len(SONGS) + 1 - 1)
 
         m.add_songs([])
@@ -500,7 +500,7 @@ class TPaneModel(TestCase):
         m.remove_songs(SONGS, False)
         self._verify_model(m)
         self.assertEqual(length, len(m))
-        self.assertFalse(m.get_songs([r.path for r in m]))
+        assert not m.get_songs([r.path for r in m])
 
     def test_remove_songs_remove_rows(self):
         conf = PaneConfig("artist")
@@ -524,14 +524,14 @@ class TPaneModel(TestCase):
         conf = PaneConfig("artist")
         m = PaneModel(conf)
         m.add_songs(SONGS)
-        self.assertFalse(m.matches([], SONGS[0]))
-        self.assertTrue(m.matches([0], SONGS[0]))
-        self.assertTrue(m.matches([1], SONGS[0]))
-        self.assertFalse(m.matches([2], SONGS[0]))
+        assert not m.matches([], SONGS[0])
+        assert m.matches([0], SONGS[0])
+        assert m.matches([1], SONGS[0])
+        assert not m.matches([2], SONGS[0])
 
         m.add_songs([UNKNOWN_ARTIST])
         self._verify_model(m)
-        self.assertTrue(m.matches([len(m) - 1], UNKNOWN_ARTIST))
+        assert m.matches([len(m) - 1], UNKNOWN_ARTIST)
 
 
 class TPanedPreferences(TestCase):

--- a/tests/test_browsers_playlists.py
+++ b/tests/test_browsers_playlists.py
@@ -48,7 +48,7 @@ class TParsePlaylistMixin:
         with temp_filename() as name:
             with open(name) as f:
                 pl = self.Parse(f, name, pl_lib=self.pl_lib)
-        self.assertFalse(pl)
+        assert not pl
         pl.delete()
 
     def test_parse_onesong(self):
@@ -165,9 +165,9 @@ class TPlaylistIntegration(TestCase):
     def test_remove_no_lib(self):
         pl = FileBackedPlaylist.new(self._dir, "Foobar")
         pl.extend(self.SONGS)
-        self.assertTrue(len(pl))
+        assert len(pl)
         pl.remove_songs(self.SONGS, False)
-        self.assertFalse(len(pl))
+        assert not len(pl)
 
 
 class TPlaylistsBrowser(TestCase):
@@ -247,7 +247,7 @@ class TPlaylistsBrowser(TestCase):
 
     def _do(self):
         run_gtk_loop()
-        self.assertTrue(self.success or self.expected is None)
+        assert self.success or self.expected is None
 
     def test_saverestore(self):
         # Flush previous signals, etc. Hmm.
@@ -271,22 +271,21 @@ class TPlaylistsBrowser(TestCase):
         self.bar._select_playlist(self.bar.playlists()[1])
 
         # Second playlist should not have any of `SONGS`
-        self.assertFalse(self.bar.active_filter(SONGS[0]))
+        assert not self.bar.active_filter(SONGS[0])
 
         # But it should have `ANOTHER_SONG`
-        self.assertTrue(self.bar.active_filter(self.ANOTHER_SONG),
-                        msg="Couldn't find song from second playlist")
+        msg = "Couldn't find song from second playlist"
+        assert self.bar.active_filter(self.ANOTHER_SONG), msg
 
         # ... and setting a reasonable filter on that song should match still
         self.bar.filter_text("lonely")
-        self.assertTrue(self.bar.active_filter(self.ANOTHER_SONG),
-                        msg="Couldn't find song from second playlist with "
-                            "filter of 'lonely'")
+        msg = "Couldn't find song from second playlist with filter of 'lonely'"
+        assert self.bar.active_filter(self.ANOTHER_SONG), msg
 
         # ...unless it doesn't match that song
         self.bar.filter_text("piman")
-        self.assertFalse(self.bar.active_filter(self.ANOTHER_SONG),
-                         msg="Shouldn't have matched 'piman' on second list")
+        msg = "Shouldn't have matched 'piman' on second list"
+        assert not self.bar.active_filter(self.ANOTHER_SONG), msg
 
     def test_rename(self):
         self.assertEqual(self.bar.playlists()[1], self.small)
@@ -300,7 +299,7 @@ class TPlaylistsBrowser(TestCase):
     def test_default_display_pattern(self):
         pattern_text = self.bar.display_pattern_text
         self.assertEqual(pattern_text, DEFAULT_PATTERN_TEXT)
-        self.assertTrue("<~name>" in pattern_text)
+        assert "<~name>" in pattern_text
 
     def test_drag_data_get(self):
         b = self.bar
@@ -357,7 +356,7 @@ class TPlaylistsBrowser(TestCase):
                                            scroll=False, one=True)
         original_length = len(first_pl)
         ret = b.key_pressed(event)
-        self.assertTrue(ret, msg="Didn't simulate a delete keypress")
+        assert ret, "Didn't simulate a delete keypress"
         self.assertEqual(len(first_pl), original_length - 1)
 
     def test_playlist_deletion_ACCEPT(self):
@@ -369,7 +368,7 @@ class TPlaylistsBrowser(TestCase):
         b._select_playlist(first_pl)
 
         ret = b._PlaylistsBrowser__key_pressed(b, event)
-        self.assertTrue(ret, msg="Didn't simulate a delete keypress")
+        assert ret, "Didn't simulate a delete keypress"
         self.assertEqual(len(b.playlists()), orig_length - 1)
         self.assertEqual(b.playlists()[0], second_pl)
 
@@ -382,7 +381,7 @@ class TPlaylistsBrowser(TestCase):
         b._select_playlist(first_pl)
 
         ret = b._PlaylistsBrowser__key_pressed(b, event)
-        self.assertTrue(ret, msg="Didn't simulate a delete keypress")
+        assert ret, "Didn't simulate a delete keypress"
         self.assertEqual(len(b.playlists()), orig_length)
         self.assertEqual(b.playlists()[0], first_pl)
         self.assertEqual(b.playlists()[1], second_pl)

--- a/tests/test_browsers_podcasts.py
+++ b/tests/test_browsers_podcasts.py
@@ -23,7 +23,7 @@ class TAudioFeeds(TestCase):
 
     def test_can_filter(self):
         for key in ["foo", "title", "fake~key", "~woobar", "~#huh"]:
-            self.assertFalse(self.bar.can_filter(key))
+            assert not self.bar.can_filter(key)
 
     def tearDown(self):
         self.bar.destroy()
@@ -56,7 +56,7 @@ class TFeed(TestCase):
         # Assume en_US / en_GB locale here in tests
         self.assertNotEqual(feed.name, "Unknown", msg="Didn't find feed name")
         # Do this after the above, as many exceptions can be swallowed
-        self.assertTrue(result)
+        assert result
         self.assertEqual(len(feed), 2)
         self.assertEqual(feed[0]("title"),
                              "Full Episode: Tuesday, November 28, 2017")

--- a/tests/test_browsers_search.py
+++ b/tests/test_browsers_search.py
@@ -62,11 +62,11 @@ class TSearchBar(TestCase):
 
     def _do(self):
         run_gtk_loop()
-        self.assertTrue(self.success or self.expected is None)
+        assert self.success or self.expected is None
 
     def test_can_filter(self):
         for key in ["foo", "title", "fake~key", "~woobar", "~#huh"]:
-            self.assertTrue(self.bar.can_filter(key))
+            assert self.bar.can_filter(key)
 
     def test_empty_is_all(self):
         self.bar.filter_text("")
@@ -74,10 +74,10 @@ class TSearchBar(TestCase):
         self._do()
 
     def test_active_filter(self):
-        self.assertTrue(self.bar.active_filter(SONGS[0]))
+        assert self.bar.active_filter(SONGS[0])
         self.bar.filter_text("this does not match any song")
         self.expected = []
-        self.assertFalse(self.bar.active_filter(SONGS[0]))
+        assert not self.bar.active_filter(SONGS[0])
         self._do()
 
     def test_filter(self):

--- a/tests/test_browsers_soundcloud.py
+++ b/tests/test_browsers_soundcloud.py
@@ -96,5 +96,5 @@ class TestHttpsDefault(TestCase):
         config.quit()
 
     def test_setup_default(self):
-        self.assertTrue(SoundcloudApiClient().root.startswith("https://"),
-                        msg="API client should use HTTPS")
+        msg = "API client should use HTTPS"
+        assert SoundcloudApiClient().root.startswith("https://"), msg

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -15,8 +15,8 @@ class Tcli(TestCase):
     def test_process_no_arguments_works(self):
         with capture_output() as (out, err):
             cli.process_arguments(["myprog"])
-            self.assertFalse(out.getvalue())
-            self.assertFalse(err.getvalue())
+            assert not out.getvalue()
+            assert not err.getvalue()
 
     def test_process_arguments_errors_on_invalid_opt(self):
         with self.assertRaises(SystemExit):

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -104,7 +104,7 @@ class TCommands(TCommandBase):
                  for fn in ["one", "two, please", "slash\\.mp3", "four"]]
         app.library.add(songs)
 
-        self.assertFalse(app.window.playlist.q.get())
+        assert not app.window.playlist.q.get()
         self._send("enqueue-files "
                     "one,two\\, please,slash\\\\.mp3,four")
         self.assertEqual(app.window.playlist.q.get(), songs)
@@ -129,7 +129,7 @@ class TCommandWithPattern(TCommandBase):
                  for fn in ["one", "two, please", "slash\\.mp3", "4.0-four"]]
         app.library.add(songs)
 
-        self.assertFalse(app.window.playlist.q.get())
+        assert not app.window.playlist.q.get()
         self._send("enqueue-files "
                     "one,two\\, please,slash\\\\.mp3,4.0-four")
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4,10 +4,10 @@
 # (at your option) any later version.
 
 import os
-from quodlibet.config import RatingsPrefs
-from tests import TestCase, mkstemp
 
 from quodlibet import config
+from quodlibet.config import RatingsPrefs
+from tests import TestCase, mkstemp
 
 
 class Tconfig(TestCase):
@@ -25,12 +25,12 @@ class Tconfig(TestCase):
             f.write(garbage)
 
         config.init(filename)
-        self.assertTrue(config.options("player"))
+        assert config.options("player")
 
         invalid_filename = filename + ".not-valid"
-        self.assertTrue(os.path.exists(invalid_filename))
+        assert os.path.exists(invalid_filename)
         with open(invalid_filename, "rb") as f:
-            self.assertEqual(f.read(), garbage)
+             assert f.read() == garbage
 
         os.remove(filename)
         os.remove(invalid_filename)
@@ -48,32 +48,32 @@ class TRatingsPrefs(TestCase):
 
     def test_getters(self):
         # A little pointless, and brittle, but still.
-        self.assertEqual(self.prefs.number, self.initial_number)
-        self.assertEqual(self.prefs.precision, 1.0 / self.initial_number)
+        assert self.prefs.number == self.initial_number
+        assert self.prefs.precision == 1.0 / self.initial_number
         symbol_full = config.INITIAL["settings"]["rating_symbol_full"]
-        self.assertEqual(self.prefs.full_symbol, symbol_full)
+        assert self.prefs.full_symbol == symbol_full
         symbol_blank = config.INITIAL["settings"]["rating_symbol_blank"]
-        self.assertEqual(self.prefs.blank_symbol, symbol_blank)
+        assert self.prefs.blank_symbol == symbol_blank
 
     def test_caching(self):
-        self.assertEqual(self.prefs.number, self.initial_number)
+        assert self.prefs.number == self.initial_number
         self.prefs.number = 10
         self.prefs.default = 0.1
         # Read it back, and it's fine
-        self.assertEqual(self.prefs.number, 10)
-        self.assertEqual(self.prefs.default, 0.1)
-        # .. but modify behind the scenes (unsupported)...
+        assert self.prefs.number == 10
+        assert self.prefs.default == 0.1
+        # ... but modify behind the scenes (unsupported)...
         config.reset("settings", "ratings")
         config.reset("settings", "default_rating")
         # ...and caching will return the old one
-        self.assertEqual(self.prefs.number, 10)
-        self.assertEqual(self.prefs.default, 0.1)
+        assert self.prefs.number == 10
+        assert self.prefs.default == 0.1
 
     def test_all(self):
         self.prefs.number = 5
         # Remember zero is a possible rating too
-        self.assertEqual(len(self.prefs.all), 6)
-        self.assertEqual(self.prefs.all, [0, 0.2, 0.4, 0.6, 0.8, 1.0])
+        assert len(self.prefs.all) == 6
+        assert self.prefs.all, [0, 0.2, 0.4, 0.6, 0.8 == 1.0]
 
     def tearDown(self):
         config.quit()

--- a/tests/test_desktop_files.py
+++ b/tests/test_desktop_files.py
@@ -19,7 +19,7 @@ class _TDesktopFileMixin:
     PATH = None
 
     def test_filename(self):
-        self.assertTrue(self.PATH.endswith(".desktop.in"))
+        assert self.PATH.endswith(".desktop.in")
 
     def test_validate(self):
         with open(self.PATH, "rb") as template:

--- a/tests/test_formats___init__.py
+++ b/tests/test_formats___init__.py
@@ -27,53 +27,53 @@ class TFormats(TestCase):
         config.quit()
 
     def test_presence(self):
-        self.assertTrue(formats.aac)
-        self.assertTrue(formats.aiff)
-        self.assertTrue(formats.midi)
-        self.assertTrue(formats.mod)
-        self.assertTrue(formats.monkeysaudio)
-        self.assertTrue(formats.mp3)
-        self.assertTrue(formats.mp4)
-        self.assertTrue(formats.mpc)
-        self.assertTrue(formats.spc)
-        self.assertTrue(formats.trueaudio)
-        self.assertTrue(formats.vgm)
-        self.assertTrue(formats.wav)
-        self.assertTrue(formats.wavpack)
-        self.assertTrue(formats.wma)
-        self.assertTrue(formats.xiph)
+        assert formats.aac
+        assert formats.aiff
+        assert formats.midi
+        assert formats.mod
+        assert formats.monkeysaudio
+        assert formats.mp3
+        assert formats.mp4
+        assert formats.mpc
+        assert formats.spc
+        assert formats.trueaudio
+        assert formats.vgm
+        assert formats.wav
+        assert formats.wavpack
+        assert formats.wma
+        assert formats.xiph
 
     def test_loaders(self):
-        self.assertTrue(formats.loaders[".mp3"] is formats.mp3.MP3File)
+        assert formats.loaders[".mp3"] is formats.mp3.MP3File
 
     def test_migration(self):
-        self.assertTrue(formats.mp3 is sys.modules["quodlibet.formats.mp3"])
-        self.assertTrue(formats.mp3 is sys.modules["quodlibet/formats/mp3"])
-        self.assertTrue(formats.mp3 is sys.modules["formats.mp3"])
+        assert formats.mp3 is sys.modules["quodlibet.formats.mp3"]
+        assert formats.mp3 is sys.modules["quodlibet/formats/mp3"]
+        assert formats.mp3 is sys.modules["formats.mp3"]
 
-        self.assertTrue(formats.xiph is sys.modules["formats.flac"])
-        self.assertTrue(formats.xiph is sys.modules["formats.oggvorbis"])
+        assert formats.xiph is sys.modules["formats.flac"]
+        assert formats.xiph is sys.modules["formats.oggvorbis"]
 
     def test_filter(self):
-        self.assertTrue(formats.filter("foo.mp3"))
-        self.assertFalse(formats.filter("foo.doc"))
-        self.assertFalse(formats.filter("foomp3"))
+        assert formats.filter("foo.mp3")
+        assert not formats.filter("foo.doc")
+        assert not formats.filter("foomp3")
 
     def test_music_file(self):
         path = get_data_path("silence-44-s.mp3")
-        self.assertTrue(formats.MusicFile(path))
+        assert formats.MusicFile(path)
 
         # non existing
         with capture_output() as (stdout, stderr):
             song = formats.MusicFile(get_data_path("nope.mp3"))
-            self.assertFalse(song)
-            self.assertTrue(stderr.getvalue())
+            assert not song
+            assert stderr.getvalue()
 
         # unknown extension
         with capture_output() as (stdout, stderr):
             song = formats.MusicFile(get_data_path("nope.xxx"))
-            self.assertFalse(song)
-            self.assertFalse(stderr.getvalue())
+            assert not song
+            assert not stderr.getvalue()
 
 
 class TPickle(TestCase):

--- a/tests/test_formats__audio.py
+++ b/tests/test_formats__audio.py
@@ -111,9 +111,9 @@ class TAudioFile(TestCase):
         self.assertNotEqual(bar_2_1, bar_1_2)
 
     def test_realkeys(self):
-        self.assertFalse("artist" in self.quux.realkeys())
-        self.assertFalse("~filename" in self.quux.realkeys())
-        self.assertTrue("album" in self.quux.realkeys())
+        assert "artist" not in self.quux.realkeys()
+        assert "~filename" not in self.quux.realkeys()
+        assert "album" in self.quux.realkeys()
 
     def test_iterrealitems(self):
         af = AudioFile({
@@ -133,8 +133,8 @@ class TAudioFile(TestCase):
         self.assertEqual(bar_1_1("~#disc"), 1)
         self.assertEqual(bar_1_1("~#tracks"), 3)
         self.assertEqual(bar_1_1("~#discs"), 2)
-        self.assertFalse(bar_1_2("~#discs"))
-        self.assertFalse(bar_2_1("~#tracks"))
+        assert not bar_1_2("~#discs")
+        assert not bar_2_1("~#tracks")
 
     def test_setitem_keys(self):
         af = AudioFile()
@@ -159,7 +159,7 @@ class TAudioFile(TestCase):
 
         # fake/generated key checks
         af = AudioFile()
-        self.assertFalse(af("not a key"))
+        assert not af("not a key")
         self.assertEqual(af("not a key", "foo"), "foo")
         self.assertEqual(af("artist"), "")
 
@@ -317,10 +317,10 @@ class TAudioFile(TestCase):
     def test_comma(self):
         for key in bar_1_1.realkeys():
             self.assertEqual(bar_1_1.comma(key), bar_1_1(key))
-        self.assertTrue(", " in bar_2_1.comma("artist"))
+        assert ", " in bar_2_1.comma("artist")
 
     def test_comma_filename(self):
-        self.assertTrue(isinstance(bar_1_1.comma("~filename"), str))
+        assert isinstance(bar_1_1.comma("~filename"), str)
 
     def test_comma_mountpoint(self):
         assert not bar_1_1("~mountpoint")
@@ -328,33 +328,33 @@ class TAudioFile(TestCase):
         assert bar_1_1.comma("~mountpoint") == ""
 
     def test_exist(self):
-        self.assertFalse(bar_2_1.exists())
-        self.assertTrue(self.quux.exists())
+        assert not bar_2_1.exists()
+        assert self.quux.exists()
 
     def test_valid(self):
-        self.assertFalse(bar_2_1.valid())
+        assert not bar_2_1.valid()
 
         quux = self.quux
         quux["~#mtime"] = 0
-        self.assertFalse(quux.valid())
+        assert not quux.valid()
         quux["~#mtime"] = os.path.getmtime(quux["~filename"])
-        self.assertTrue(quux.valid())
+        assert quux.valid()
         os.utime(quux["~filename"], (quux["~#mtime"], quux["~#mtime"] - 1))
-        self.assertFalse(quux.valid())
+        assert not quux.valid()
         quux["~#mtime"] = os.path.getmtime(quux["~filename"])
-        self.assertTrue(quux.valid())
+        assert quux.valid()
 
         os.utime(quux["~filename"], (quux["~#mtime"], quux["~#mtime"] - 1))
         quux.sanitize()
-        self.assertTrue(quux.valid())
+        assert quux.valid()
 
     def test_can_change(self):
         af = AudioFile()
-        self.assertFalse(af.can_change("~foobar"))
-        self.assertFalse(af.can_change("=foobar"))
-        self.assertFalse(af.can_change("foo=bar"))
-        self.assertFalse(af.can_change(""))
-        self.assertTrue(af.can_change("foo bar"))
+        assert not af.can_change("~foobar")
+        assert not af.can_change("=foobar")
+        assert not af.can_change("foo=bar")
+        assert not af.can_change("")
+        assert af.can_change("foo bar")
 
     def test_is_writable(self):
         fn = self.quux["~filename"]
@@ -366,7 +366,7 @@ class TAudioFile(TestCase):
     def test_can_multiple_values(self):
         af = AudioFile()
         self.assertEqual(af.can_multiple_values(), True)
-        self.assertTrue(af.can_multiple_values("artist"))
+        assert af.can_multiple_values("artist")
 
     def test_rename(self):
         old_fn = self.quux["~filename"]
@@ -418,12 +418,12 @@ class TAudioFile(TestCase):
     def test_lyric_filename(self):
         song = AudioFile()
         song["~filename"] = fsnative("filename")
-        self.assertTrue(isinstance(song.lyric_filename, fsnative))
+        assert isinstance(song.lyric_filename, fsnative)
         song["title"] = "Title"
         song["artist"] = "Artist"
-        self.assertTrue(isinstance(song.lyric_filename, fsnative))
+        assert isinstance(song.lyric_filename, fsnative)
         song["lyricist"] = "Lyricist"
-        self.assertTrue(isinstance(song.lyric_filename, fsnative))
+        assert isinstance(song.lyric_filename, fsnative)
 
     def lyric_filename_search_test_song(self, pathfile):
         s = AudioFile()
@@ -577,8 +577,8 @@ class TAudioFile(TestCase):
                 rootp = os.path.sep.join([ts.root, p])
                 if not RootPathFile(ts.root, rootp).valid:
                     rootp = os.path.sep.join([ts.root, escape_filename(p)])
-                self.assertTrue(RootPathFile(ts.root, rootp).valid,
-                                "even escaped target dir part is not valid!")
+                msg = "even escaped target dir part is not valid!"
+                assert RootPathFile(ts.root, rootp).valid, msg
                 if not os.path.exists(rootp):
                     mkdir(rootp)
                     rmdirs.append(rootp)
@@ -773,10 +773,10 @@ class TAudioFile(TestCase):
         num = len(set(bar_1_1.keys()) | NUMERIC_ZERO_DEFAULT)
         self.assertEqual(dump.count(b"\n"), num + 2)
         for key, value in bar_1_1.items():
-            self.assertTrue(key.encode("utf-8") in dump)
-            self.assertTrue(value.encode("utf-8") in dump)
+            assert key.encode("utf-8") in dump
+            assert value.encode("utf-8") in dump
         for key in NUMERIC_ZERO_DEFAULT:
-            self.assertTrue(key.encode("utf-8") in dump)
+            assert key.encode("utf-8") in dump
 
         n = AudioFile()
         n.from_dump(dump)
@@ -793,7 +793,7 @@ class TAudioFile(TestCase):
 
     def test_add(self):
         song = AudioFile()
-        self.assertFalse("foo" in song)
+        assert "foo" not in song
         song.add("foo", "bar")
         self.assertEqual(song["foo"], "bar")
         song.add("foo", "another")
@@ -809,7 +809,7 @@ class TAudioFile(TestCase):
         song.remove("foo", "bar")
         self.assertEqual(song.list("foo"), ["one more"])
         song.remove("foo", "one more")
-        self.assertFalse("foo" in song)
+        assert "foo" not in song
 
     def test_remove_unknown(self):
         song = AudioFile()
@@ -824,13 +824,13 @@ class TAudioFile(TestCase):
         song.add("foo", "another")
         song.add("foo", "one more")
         song.remove("foo")
-        self.assertFalse("foo" in song)
+        assert "foo" not in song
 
     def test_remove_empty(self):
         song = AudioFile()
         song.add("foo", "")
         song.remove("foo", "")
-        self.assertFalse("foo" in song)
+        assert "foo" not in song
 
     def test_change(self):
         song = AudioFile()
@@ -865,7 +865,7 @@ class TAudioFile(TestCase):
         af = AudioFile({"bookmark": "foo"})
         af.bookmarks = []
         self.assertEqual([], AudioFile().bookmarks)
-        self.assertFalse("~bookmark" in af)
+        assert "~bookmark" not in af
 
     def test_set_bookmarks_simple(self):
         af = AudioFile()
@@ -886,21 +886,21 @@ class TAudioFile(TestCase):
 
     def test_has_rating(self):
         song = AudioFile()
-        self.assertFalse(song.has_rating)
+        assert not song.has_rating
         song["~#rating"] = 0.5
-        self.assertTrue(song.has_rating)
+        assert song.has_rating
         song.remove_rating()
-        self.assertFalse(song.has_rating)
+        assert not song.has_rating
 
     def test_remove_rating(self):
         song = AudioFile()
-        self.assertFalse(song.has_rating)
+        assert not song.has_rating
         song.remove_rating()
-        self.assertFalse(song.has_rating)
+        assert not song.has_rating
         song["~#rating"] = 0.5
-        self.assertTrue(song.has_rating)
+        assert song.has_rating
         song.remove_rating()
-        self.assertFalse(song.has_rating)
+        assert not song.has_rating
 
     def test_album_key(self):
         album_key_tests = [
@@ -919,8 +919,8 @@ class TAudioFile(TestCase):
             self.assertEqual(afile.album_key, expected)
 
     def test_eq_ne(self):
-        self.assertFalse(AudioFile({"a": "b"}) == AudioFile({"a": "b"}))
-        self.assertTrue(AudioFile({"a": "b"}) != AudioFile({"a": "b"}))
+        assert not AudioFile({"a": "b"}) == AudioFile({"a": "b"})
+        assert AudioFile({"a": "b"}) != AudioFile({"a": "b"})
 
     def test_invalid_fs_encoding(self):
         # issue 798
@@ -1071,7 +1071,7 @@ class Tdecode_value(TestCase):
         self.assertEqual(decode_value("~#foo", 0.25), "0.25")
         self.assertEqual(decode_value("~#foo", 4), "4")
         self.assertEqual(decode_value("~#foo", "bar"), "bar")
-        self.assertTrue(isinstance(decode_value("~#foo", "bar"), str))
+        assert isinstance(decode_value("~#foo", "bar"), str)
         path = fsnative("/foobar")
         self.assertEqual(decode_value("~filename", path), fsn2text(path))
 
@@ -1144,10 +1144,10 @@ class Treplay_gain(TestCase):
             self.song.replay_gain(["track"], 12.0, 0), 1.0 / 0.9)
 
     def test_trackgain(self):
-        self.assertTrue(self.song.replay_gain(["track"]) > 1)
+        assert self.song.replay_gain(["track"]) > 1
 
     def test_albumgain(self):
-        self.assertTrue(self.song.replay_gain(["album"]) < 1)
+        assert self.song.replay_gain(["album"]) < 1
 
     def test_invalid(self):
         self.song["replaygain_album_gain"] = "fdsodgbdf"
@@ -1163,7 +1163,7 @@ class Treplay_gain(TestCase):
 
     def test_numeric_rg_tags(self):
         """Tests fully-numeric (ie no "db") RG tags.  See Issue 865"""
-        self.assertTrue(self.song("replaygain_album_gain"), "-1.00 db")
+        assert self.song("replaygain_album_gain"), "-1.00 db"
         for key, exp in self.rg_data.items():
             # Hack the nasties off and produce the "real" expected value
             exp = float(exp.split(" ")[0])

--- a/tests/test_formats__id3.py
+++ b/tests/test_formats__id3.py
@@ -33,10 +33,10 @@ class TID3ImagesBase(TestCase):
 class TID3ImagesMixin:
 
     def test_can_change_images(self):
-        self.assertTrue(self.KIND(self.filename).can_change_images)
+        assert self.KIND(self.filename).can_change_images
 
     def test_get_primary_image(self):
-        self.assertFalse(self.KIND(self.filename).has_images)
+        assert not self.KIND(self.filename).has_images
 
         f = mutagen.File(self.filename)
         apic = mutagen.id3.APIC(encoding=3, mime="image/jpeg", type=4,
@@ -45,7 +45,7 @@ class TID3ImagesMixin:
         f.save()
 
         song = self.KIND(self.filename)
-        self.assertTrue(song.has_images)
+        assert song.has_images
         image = song.get_primary_image()
         self.assertEqual(image.mime_type, "image/jpeg")
         fn = image.file
@@ -57,13 +57,13 @@ class TID3ImagesMixin:
         f.save()
 
         song = self.KIND(self.filename)
-        self.assertTrue(song.has_images)
+        assert song.has_images
         image = song.get_primary_image()
         self.assertEqual(image.read(), b"bar2")
 
         # get_images()
         images = song.get_images()
-        self.assertTrue(images and len(images) == 2)
+        assert images and len(images) == 2
         self.assertEqual(images[0].type, 3)
         self.assertEqual(images[1].type, 4)
 
@@ -75,23 +75,23 @@ class TID3ImagesMixin:
         f.save()
 
         song = self.KIND(self.filename)
-        self.assertTrue(song.has_images)
+        assert song.has_images
         song.clear_images()
 
         song = self.KIND(self.filename)
-        self.assertFalse(song.has_images)
+        assert not song.has_images
 
     def test_set_image(self):
         fileobj = BytesIO(b"foo")
         image = EmbeddedImage(fileobj, "image/jpeg", 10, 10, 8)
 
         song = self.KIND(self.filename)
-        self.assertFalse(song.has_images)
+        assert not song.has_images
         song.set_image(image)
-        self.assertTrue(song.has_images)
+        assert song.has_images
 
         song = self.KIND(self.filename)
-        self.assertTrue(song.has_images)
+        assert song.has_images
         self.assertEqual(song.get_primary_image().mime_type, "image/jpeg")
 
     def test_set_image_no_tag(self):
@@ -103,7 +103,7 @@ class TID3ImagesMixin:
         song.set_image(image)
 
         song = self.KIND(self.filename)
-        self.assertTrue(song.has_images)
+        assert song.has_images
 
 
 class TID3ImagesMP3(TID3ImagesBase, TID3ImagesMixin):
@@ -271,7 +271,7 @@ class TID3FileMixin:
             af.write()
             tags = mutagen.File(self.filename).tags
             self.assertEqual(tags["TXXX:QuodLibet::language"], val)
-            self.assertFalse("TLAN" in tags)
+            assert "TLAN" not in tags
 
     def test_write_lang_iso(self):
         """Tests that if you use an ISO 639-2 code, TLAN gets populated"""
@@ -335,7 +335,7 @@ class TID3FileMixin:
         del song["musicbrainz_trackid"]
         song.write()
         f = mutagen.File(self.filename)
-        self.assertFalse(f.tags.get("UFID:http://musicbrainz.org"))
+        assert not f.tags.get("UFID:http://musicbrainz.org")
 
     def test_mb_release_track_id(self):
         f = mutagen.File(self.filename)
@@ -349,7 +349,7 @@ class TID3FileMixin:
         song.write()
         f = mutagen.File(self.filename)
         frames = f.tags.getall("TXXX:MusicBrainz Release Track Id")
-        self.assertTrue(frames)
+        assert frames
         self.assertEqual(frames[0].text, ["foo"])
 
     def test_load_comment(self):
@@ -372,7 +372,7 @@ class TID3FileMixin:
 
         # check if all keys are str
         for k in self.KIND(self.filename).keys():
-            self.assertTrue(isinstance(k, str))
+            assert isinstance(k, str)
 
         # remove value, save, reload and check if still gone
         del song["replaygain_track_gain"]
@@ -421,7 +421,7 @@ class TID3FileMixin:
 
         f = mutagen.File(self.filename)
         for k in ["track_peak", "track_gain", "album_peak", "album_gain"]:
-            self.assertTrue(f[f"TXXX:REPLAYGAIN_{k.upper()}"])
+            assert f[f"TXXX:REPLAYGAIN_{k.upper()}"]
 
     def test_foobar2k_rg_caseinsensitive(self):
         f = mutagen.File(self.filename)
@@ -433,12 +433,12 @@ class TID3FileMixin:
         song.write()
         f = mutagen.File(self.filename)
         frames = f.tags.getall("TXXX:REPLAYGAIN_TRACK_GAIN")
-        self.assertTrue(frames)
+        assert frames
         self.assertEqual(frames[0].desc, "REPLAYGAIN_TRACK_GAIN")
         del song["replaygain_track_gain"]
         song.write()
         f = mutagen.File(self.filename)
-        self.assertFalse(f.tags.getall("TXXX:REPLAYGAIN_TRACK_GAIN"))
+        assert not f.tags.getall("TXXX:REPLAYGAIN_TRACK_GAIN")
 
     def test_quodlibet_txxx_inval(self):
         # This shouldn't happen in our namespace, but check anyway since
@@ -459,19 +459,19 @@ class TID3FileMixin:
 
         # check if all keys are valid
         for k in self.KIND(self.filename).keys():
-            self.assertTrue(isinstance(k, str))
+            assert isinstance(k, str)
 
         song = self.KIND(self.filename)
-        self.assertFalse("foo=" in song)
-        self.assertFalse("öäü" in song)
+        assert "foo=" not in song
+        assert "öäü" not in song
         self.assertEqual(set(song.list("comment")), {"a", "b"})
         self.assertEqual(song("valid"), "quux")
         del song["valid"]
         song.write()
 
         f = mutagen.File(self.filename)
-        self.assertTrue(f.tags.getall("TXXX:QuodLibet::foo="))
-        self.assertFalse(f.tags.getall("TXXX:QuodLibet::valid"))
+        assert f.tags.getall("TXXX:QuodLibet::foo=")
+        assert not f.tags.getall("TXXX:QuodLibet::valid")
         self.assertEqual(len(f.tags.getall("COMM")), 2)
         self.assertEqual(len(f.tags.getall("COMM:")), 1)
 
@@ -498,13 +498,13 @@ class TID3FileMixin:
         f.save()
 
         song = self.KIND(self.filename)
-        self.assertFalse("invalid" in song)
-        self.assertFalse("öäü" in song)
+        assert "invalid" not in song
+        assert "öäü" not in song
         song.write()
 
         f = mutagen.File(self.filename)
-        self.assertTrue(f[t1.HashKey])
-        self.assertTrue(f[t2.HashKey])
+        assert f[t1.HashKey]
+        assert f[t2.HashKey]
 
     def test_woar(self):
         f = mutagen.File(self.filename)
@@ -555,7 +555,7 @@ class TID3FileMixin:
         f.save()
 
         song = self.KIND(self.filename)
-        self.assertTrue("performer:foo" in song)
+        assert "performer:foo" in song
         self.assertEqual(song("performer:foo"), "bar")
 
     def test_nonascii_unsup_tcon(self):

--- a/tests/test_formats__image.py
+++ b/tests/test_formats__image.py
@@ -39,17 +39,17 @@ class TImageContainer(TestCase):
         self.a = AudioFile()
 
     def test_default_get(self):
-        self.assertFalse(self.a.get_primary_image())
+        assert not self.a.get_primary_image()
 
     def test_has_image(self):
-        self.assertFalse(self.a.has_images)
+        assert not self.a.has_images
         self.a["~picture"] = "y"
-        self.assertTrue(self.a.has_images)
+        assert self.a.has_images
         self.a.has_images = False
-        self.assertFalse(self.a.has_images)
+        assert not self.a.has_images
 
     def test_default_can_change(self):
-        self.assertFalse(self.a.can_change_images)
+        assert not self.a.can_change_images
 
 
 class TEmbeddedImages(TestCase):
@@ -71,7 +71,7 @@ class TEmbeddedImages(TestCase):
 
     def test_from_path(self):
         image = EmbeddedImage.from_path(self.filename)
-        self.assertTrue(image)
+        assert image
         self.assertEqual(image.file.name, self.filename)
         self.assertEqual(image.mime_type, "image/png")
         self.assertEqual(image.width, 150)
@@ -80,22 +80,22 @@ class TEmbeddedImages(TestCase):
 
     def test_from_path_bogus(self):
         image = EmbeddedImage.from_path(self.filename + "nope")
-        self.assertFalse(image)
+        assert not image
 
     def test_not_an_image(self):
         path = get_data_path("test-2.wma")
         image = EmbeddedImage.from_path(path)
-        self.assertFalse(image)
+        assert not image
 
     def test_get_extensions(self):
         image = EmbeddedImage.from_path(self.filename)
-        self.assertTrue("png" in image.extensions)
+        assert "png" in image.extensions
 
     def test_from_path_empty(self):
         h, empty = mkstemp()
         os.close(h)
         try:
             image = EmbeddedImage.from_path(empty)
-            self.assertFalse(image)
+            assert not image
         finally:
             os.remove(empty)

--- a/tests/test_formats_aac.py
+++ b/tests/test_formats_aac.py
@@ -39,17 +39,17 @@ class _TAACFileMixin:
         self.song.write()
 
     def test_can_change(self):
-        self.assertTrue(self.song.can_change("title"))
-        self.assertFalse(self.song.can_change("foobar"))
-        self.assertTrue("title" in self.song.can_change())
+        assert self.song.can_change("title")
+        assert not self.song.can_change("foobar")
+        assert "title" in self.song.can_change()
 
     def test_can_multiple_values(self):
         self.assertEqual(self.song.can_multiple_values(), True)
-        self.assertTrue(self.song.can_multiple_values("title"))
+        assert self.song.can_multiple_values("title")
 
     def test_invalid(self):
         path = get_data_path("empty.xm")
-        self.assertTrue(os.path.exists(path))
+        assert os.path.exists(path)
         self.assertRaises(Exception, AACFile, path)
 
     def test_format_codec(self):

--- a/tests/test_formats_all.py
+++ b/tests/test_formats_all.py
@@ -57,7 +57,7 @@ class TAudioFileAllBase:
 
     def test_get_primary_image_noent(self):
         os.remove(self.filename)
-        self.assertTrue(self.song.get_primary_image() is None)
+        assert self.song.get_primary_image() is None
 
     def test_get_images_noent(self):
         os.remove(self.filename)

--- a/tests/test_formats_apev2.py
+++ b/tests/test_formats_apev2.py
@@ -69,18 +69,18 @@ class TAPEv2FileMixin:
         self.assertEqual(self.s.get("foo"), None)
         self.s.write()
         m = mutagen.apev2.APEv2(self.f)
-        self.assertTrue("foo" in m)
+        assert "foo" in m
 
     def test_titlecase(self):
         self.s["isRc"] = "1234"
         self.s["fOoBaR"] = "5678"
         self.s.write()
         self.s.reload()
-        self.assertTrue("isrc" in self.s)
-        self.assertTrue("foobar" in self.s)
+        assert "isrc" in self.s
+        assert "foobar" in self.s
         m = mutagen.apev2.APEv2(self.f)
-        self.assertTrue("ISRC" in m)
-        self.assertTrue("Foobar" in m)
+        assert "ISRC" in m
+        assert "Foobar" in m
 
     def test_disc_mapping(self):
         m = mutagen.apev2.APEv2(self.f)
@@ -179,7 +179,7 @@ class TWvCoverArt(TestCase):
 
     def test_get_primary_image(self):
         cover = self.s.get_primary_image()
-        self.assertTrue(cover)
+        assert cover
         self.assertEqual(cover.type, APICType.COVER_FRONT)
 
     def test_get_images(self):
@@ -189,17 +189,17 @@ class TWvCoverArt(TestCase):
         self.assertEqual(types, [APICType.COVER_FRONT, APICType.COVER_BACK])
 
     def test_can_change_images(self):
-        self.assertTrue(self.s.can_change_images)
+        assert self.s.can_change_images
 
     def test_clear_images(self):
         # cover case
         image = self.s.get_primary_image()
-        self.assertTrue(image)
+        assert image
         self.s.clear_images()
-        self.assertFalse(self.s.has_images)
+        assert not self.s.has_images
         self.s.reload()
         image = self.s.get_primary_image()
-        self.assertFalse(image)
+        assert not image
 
         # no cover case
         self.s.clear_images()
@@ -208,7 +208,7 @@ class TWvCoverArt(TestCase):
         fileobj = BytesIO(b"foo")
         image = EmbeddedImage(fileobj, "image/jpeg", 10, 10, 8)
         self.s.set_image(image)
-        self.assertTrue(self.s.has_images)
+        assert self.s.has_images
 
         images = self.s.get_images()
         self.assertEqual(len(images), 1)

--- a/tests/test_formats_midi.py
+++ b/tests/test_formats_midi.py
@@ -26,8 +26,8 @@ class TMidiFile(TestCase):
 
     def test_can_change(self):
         self.assertEqual(self.song.can_change(), ["title"])
-        self.assertTrue(self.song.can_change("title"))
-        self.assertFalse(self.song.can_change("album"))
+        assert self.song.can_change("title")
+        assert not self.song.can_change("album")
 
     def test_invalid(self):
         path = get_data_path("empty.xm")

--- a/tests/test_formats_mp4.py
+++ b/tests/test_formats_mp4.py
@@ -117,23 +117,23 @@ class TMP4File(TestCase):
         self.song.write()
 
     def test_can_change(self):
-        self.assertTrue(self.song.can_change("title"))
-        self.assertFalse(self.song.can_change("foobar"))
-        self.assertTrue("albumartist" in self.song.can_change())
+        assert self.song.can_change("title")
+        assert not self.song.can_change("foobar")
+        assert "albumartist" in self.song.can_change()
 
     def test_invalid(self):
         path = get_data_path("empty.xm")
-        self.assertTrue(os.path.exists(path))
+        assert os.path.exists(path)
         self.assertRaises(Exception, MP4File, path)
 
     def test_get_image(self):
         image = self.song.get_primary_image()
-        self.assertTrue(image)
+        assert image
         self.assertEqual(image.mime_type, "image/png")
 
     def test_get_images(self):
         images = self.song.get_images()
-        self.assertTrue(images and len(images) == 2)
+        assert images and len(images) == 2
 
     def test_get_image_non(self):
         tag = mutagen.mp4.MP4(self.f)
@@ -141,34 +141,34 @@ class TMP4File(TestCase):
         tag.save()
         self.song.reload()
 
-        self.assertFalse(self.song.get_primary_image())
+        assert not self.song.get_primary_image()
 
     def test_clear_images(self):
-        self.assertTrue(self.song.valid())
-        self.assertTrue(self.song.has_images)
+        assert self.song.valid()
+        assert self.song.has_images
         self.song.clear_images()
-        self.assertFalse(self.song.has_images)
-        self.assertFalse(self.song.get_primary_image())
+        assert not self.song.has_images
+        assert not self.song.get_primary_image()
 
         tag = mutagen.mp4.MP4(self.f)
-        self.assertFalse("covr" in tag)
+        assert "covr" not in tag
 
     def test_set_image(self):
-        self.assertTrue(self.song.has_images)
+        assert self.song.has_images
         fileobj = BytesIO(b"foo")
         image = EmbeddedImage(fileobj, "image/jpeg", 10, 10, 8)
         self.song.set_image(image)
         image = self.song.get_primary_image()
-        self.assertTrue(image)
+        assert image
         self.assertEqual(image.read(), b"foo")
-        self.assertTrue(self.song.has_images)
+        assert self.song.has_images
 
     def test_can_change_images(self):
-        self.assertTrue(self.song.can_change_images)
+        assert self.song.can_change_images
 
     def test_can_multiple_values(self):
         self.assertEqual(self.song.can_multiple_values(), [])
-        self.assertFalse(self.song.can_multiple_values("artist"))
+        assert not self.song.can_multiple_values("artist")
 
     def test_m4b_support(self):
         path = get_data_path("test.m4a")

--- a/tests/test_formats_mpc.py
+++ b/tests/test_formats_mpc.py
@@ -35,7 +35,7 @@ class TMPCFile(TestCase):
 
     def test_invalid(self):
         path = get_data_path("empty.xm")
-        self.assertTrue(os.path.exists(path))
+        assert os.path.exists(path)
         self.assertRaises(Exception, MPCFile, path)
 
     def test_format(self):

--- a/tests/test_formats_remote.py
+++ b/tests/test_formats_remote.py
@@ -16,12 +16,12 @@ class TRemoteFile(TestCase):
 
     def test_path_types(self):
         f = RemoteFile("http://example.com")
-        self.assertTrue(isinstance(f["~mountpoint"], fsnative))
-        self.assertTrue(isinstance(f["~filename"], fsnative))
+        assert isinstance(f["~mountpoint"], fsnative)
+        assert isinstance(f["~filename"], fsnative)
 
     def test_fix_old_types(self):
         f = RemoteFile("http://example.com")
         dict.__setitem__(f, "~filename", b"foo")
-        self.assertTrue(isinstance(f["~filename"], fsnative))
+        assert isinstance(f["~filename"], fsnative)
         dict.__setitem__(f, "~filename", "foo")
-        self.assertTrue(isinstance(f["~filename"], fsnative))
+        assert isinstance(f["~filename"], fsnative)

--- a/tests/test_formats_spc.py
+++ b/tests/test_formats_spc.py
@@ -33,11 +33,11 @@ class TSPCFile(TestCase):
         self.song.write()
 
     def test_can_change(self):
-        self.assertTrue(self.song.can_change("title"))
+        assert self.song.can_change("title")
 
     def test_invalid(self):
         path = get_data_path("empty.xm")
-        self.assertTrue(os.path.exists(path))
+        assert os.path.exists(path)
         self.assertRaises(Exception, SPCFile, path)
 
     def test_format_codec(self):

--- a/tests/test_formats_vgm.py
+++ b/tests/test_formats_vgm.py
@@ -38,8 +38,8 @@ class TVgmFile(TestCase):
 
     def test_can_change(self):
         self.assertEqual(self.song.can_change(), ["title"])
-        self.assertTrue(self.song.can_change("title"))
-        self.assertFalse(self.song.can_change("album"))
+        assert self.song.can_change("title")
+        assert not self.song.can_change("album")
 
     def test_invalid(self):
         path = get_data_path("empty.xm")

--- a/tests/test_formats_wav.py
+++ b/tests/test_formats_wav.py
@@ -18,7 +18,7 @@ class TWAVEFile(TestCase):
 
     def test_title_tag(self):
         self.assertEqual(self.song["title"], "test")
-        self.assertTrue(isinstance(self.song["title"], str))
+        assert isinstance(self.song["title"], str)
 
     def test_length(self):
         self.assertAlmostEqual(self.song("~#length"), 0.227, 2)
@@ -36,11 +36,11 @@ class TWAVEFile(TestCase):
         self.song.write()
 
     def test_can_change(self):
-        self.assertTrue(self.song.can_change("artist"))
+        assert self.song.can_change("artist")
 
     def test_invalid(self):
         path = get_data_path("empty.xm")
-        self.assertTrue(os.path.exists(path))
+        assert os.path.exists(path)
         self.assertRaises(Exception, WAVEFile, path)
 
     def test_format_codec(self):

--- a/tests/test_formats_wma.py
+++ b/tests/test_formats_wma.py
@@ -73,9 +73,9 @@ class TWMAFile(TestCase):
         self.song3.write()
 
     def test_can_change(self):
-        self.assertTrue(self.song.can_change("title"))
-        self.assertFalse(self.song.can_change("foobar"))
-        self.assertTrue("albumartist" in self.song.can_change())
+        assert self.song.can_change("title")
+        assert not self.song.can_change("foobar")
+        assert "albumartist" in self.song.can_change()
 
     def test_format(self):
         self.assertEqual(self.song("~format"), "ASF")
@@ -114,7 +114,7 @@ class TWMAFile(TestCase):
 
     def test_invalid(self):
         path = get_data_path("empty.xm")
-        self.assertTrue(os.path.exists(path))
+        assert os.path.exists(path)
         self.assertRaises(Exception, WMAFile, path)
 
     def test_get_images(self):
@@ -124,27 +124,27 @@ class TWMAFile(TestCase):
         self.song2.reload()
 
         images = self.song2.get_images()
-        self.assertTrue(images and len(images) == 2)
+        assert images and len(images) == 2
 
     def test_get_image(self):
-        self.assertFalse(self.song.get_primary_image())
+        assert not self.song.get_primary_image()
 
         image = self.song2.get_primary_image()
-        self.assertTrue(image)
+        assert image
         self.assertEqual(image.mime_type, "image/jpeg")
-        self.assertTrue(image.read())
+        assert image.read()
 
     def test_get_image_invalid_data(self):
         tag = asf.ASF(self.f)
         tag["WM/Picture"] = [asf.ASFValue(b"nope", asf.BYTEARRAY)]
         tag.save()
 
-        self.assertFalse(self.song.has_images)
+        assert not self.song.has_images
         self.song.reload()
-        self.assertTrue(self.song.has_images)
+        assert self.song.has_images
 
         image = self.song.get_primary_image()
-        self.assertFalse(image)
+        assert not image
 
     def test_unpack_image_min(self):
         data = b"\x03" + b"\x00" * 4 + b"\x00" * 4
@@ -172,12 +172,12 @@ class TWMAFile(TestCase):
     def test_clear_images(self):
         # cover case
         image = self.song2.get_primary_image()
-        self.assertTrue(image)
+        assert image
         self.song2.clear_images()
-        self.assertFalse(self.song2.has_images)
+        assert not self.song2.has_images
         self.song2.reload()
         image = self.song2.get_primary_image()
-        self.assertFalse(image)
+        assert not image
 
         # no cover case
         self.song.clear_images()
@@ -185,17 +185,17 @@ class TWMAFile(TestCase):
     def test_set_image(self):
         fileobj = BytesIO(b"foo")
         image = EmbeddedImage(fileobj, "image/jpeg", 10, 10, 8)
-        self.assertFalse(self.song.has_images)
+        assert not self.song.has_images
         self.song.set_image(image)
-        self.assertTrue(self.song.has_images)
+        assert self.song.has_images
 
         image = self.song.get_primary_image()
         self.assertEqual(image.mime_type, "image/jpeg")
         self.assertEqual(image.read(), b"foo")
 
     def test_can_change_images(self):
-        self.assertTrue(self.song.can_change_images)
+        assert self.song.can_change_images
 
     def test_can_multiple_values(self):
-        self.assertTrue("artist" in self.song.can_multiple_values())
-        self.assertTrue(self.song.can_multiple_values("genre"))
+        assert "artist" in self.song.can_multiple_values()
+        assert self.song.can_multiple_values("genre")

--- a/tests/test_formats_xiph.py
+++ b/tests/test_formats_xiph.py
@@ -39,14 +39,14 @@ class TXiphPickle(TestCase):
     # so unpickling old libraries works.
 
     def test_modules_flac(self):
-        self.assertTrue("formats.flac" in sys.modules)
+        assert "formats.flac" in sys.modules
         mod = sys.modules["formats.flac"]
-        self.assertTrue(mod.FLACFile is FLACFile)
+        assert mod.FLACFile is FLACFile
 
     def test_modules_vorbis(self):
-        self.assertTrue("formats.oggvorbis" in sys.modules)
+        assert "formats.oggvorbis" in sys.modules
         mod = sys.modules["formats.oggvorbis"]
-        self.assertTrue(mod.OggFile is OggFile)
+        assert mod.OggFile is OggFile
 
 
 class TVCFile(TestCase):
@@ -118,11 +118,11 @@ class TVCFileMixin:
 
     def test_parameter(self):
         for bad in ["rating", "playcount", "rating:foo", "playcount:bar"]:
-            self.assertFalse(self.song.can_change(bad))
+            assert not self.song.can_change(bad)
 
     def test_parameter_ci(self):
         for bad in ["ratinG", "plaYcount", "raTing:foo", "playCount:bar"]:
-            self.assertFalse(self.song.can_change(bad))
+            assert not self.song.can_change(bad)
 
     def test_case_insensitive(self):
         self.song["foo"] = "1"
@@ -146,7 +146,7 @@ class TVCFileMixin:
         self.assertEqual(song("~#rating"), RATINGS.default)
 
     def test_can_change(self):
-        self.assertTrue(self.song.can_change())
+        assert self.song.can_change()
 
 
 class TTotalTagsBase(TestCase):
@@ -179,11 +179,11 @@ class TTotalTagsMixin:
         for key, value in expected.items():
             self.assertEqual(song(key), value)
         if self.MAIN not in expected:
-            self.assertFalse(self.MAIN in song)
+            assert self.MAIN not in song
         if self.SINGLE not in expected:
-            self.assertFalse(self.SINGLE in song)
+            assert self.SINGLE not in song
         if self.FALLBACK not in expected:
-            self.assertFalse(self.FALLBACK in song)
+            assert self.FALLBACK not in song
 
     def test_load_old_single(self):
         self.__load_tags(
@@ -229,16 +229,16 @@ class TTotalTagsMixin:
         m = OggVorbis(self.filename)
         # test if all values ended up where we wanted
         for key, value in expected.items():
-            self.assertTrue(key in m.tags)
+            assert key in m.tags
             self.assertEqual(m.tags[key], [value])
 
         # test if not specified are not there
         if self.MAIN not in expected:
-            self.assertFalse(self.MAIN in m.tags)
+            assert self.MAIN not in m.tags
         if self.FALLBACK not in expected:
-            self.assertFalse(self.FALLBACK in m.tags)
+            assert self.FALLBACK not in m.tags
         if self.SINGLE not in expected:
-            self.assertFalse(self.SINGLE in m.tags)
+            assert self.SINGLE not in m.tags
 
     def test_save_single(self):
         self.__save_tags(
@@ -303,13 +303,13 @@ class TFLACFile(TVCFile, TVCFileMixin):
         assert self.song("~#bitdepth") == 16
 
     def test_mime(self):
-        self.assertTrue(self.song.mimes)
+        assert self.song.mimes
 
     def test_save_empty(self):
         self.song.write()
         flac = FLAC(self.filename)
-        self.assertFalse(flac.tags)
-        self.assertFalse(flac.tags is None)
+        assert not flac.tags
+        assert flac.tags is not None
 
     def test_strip_id3(self):
         self.song["title"] = "Test"
@@ -341,12 +341,12 @@ class TVCCoverMixin:
 
     def test_can_change_images(self):
         song = self.QLType(self.filename)
-        self.assertTrue(song.can_change_images)
+        assert song.can_change_images
 
     def test_no_cover(self):
         song = self.QLType(self.filename)
-        self.assertFalse(song("~picture"))
-        self.assertFalse(song.get_primary_image())
+        assert not song("~picture")
+        assert not song.get_primary_image()
 
     def test_get_images(self):
         # coverart + coverartmime
@@ -383,8 +383,8 @@ class TVCCoverMixin:
 
         song = self.QLType(self.filename)
         self.assertEqual(song("~picture"), "y")
-        self.assertFalse(song("coverart"))
-        self.assertFalse(song("coverartmime"))
+        assert not song("coverart")
+        assert not song("coverartmime")
         song.write()
 
         self.assertEqual(song.get_primary_image().mime_type, "image/jpeg")
@@ -404,9 +404,9 @@ class TVCCoverMixin:
 
         song = self.QLType(self.filename)
         self.assertEqual(song("~picture"), "y")
-        self.assertFalse(song("coverart"))
-        self.assertFalse(song.get_primary_image())
-        self.assertFalse(song("~picture"))
+        assert not song("coverart")
+        assert not song.get_primary_image()
+        assert not song("~picture")
         song.write()
 
         song = self.MutagenType(self.filename)
@@ -435,8 +435,8 @@ class TVCCoverMixin:
         song.write()
 
         song = self.MutagenType(self.filename)
-        self.assertTrue(b64pic_other in song["metadata_block_picture"])
-        self.assertTrue(b64pic_cover in song["metadata_block_picture"])
+        assert b64pic_other in song["metadata_block_picture"]
+        assert b64pic_cover in song["metadata_block_picture"]
         song["metadata_block_picture"] = [b64pic_other]
         song.save()
 
@@ -452,9 +452,9 @@ class TVCCoverMixin:
 
         song = self.QLType(self.filename)
         self.assertEqual(song("~picture"), "y")
-        self.assertFalse(song("metadata_block_picture"))
-        self.assertFalse(song.get_primary_image())
-        self.assertFalse(song("~picture"))
+        assert not song("metadata_block_picture")
+        assert not song.get_primary_image()
+        assert not song("~picture")
         song.write()
 
         song = self.MutagenType(self.filename)
@@ -466,8 +466,8 @@ class TVCCoverMixin:
         song["metadata_block_picture"] = base64.b64encode(crap).decode("ascii")
         song.save()
         song = self.QLType(self.filename)
-        self.assertFalse(song.get_primary_image())
-        self.assertFalse(song.get_images())
+        assert not song.get_primary_image()
+        assert not song.get_images()
 
     def test_set_image(self):
         data = _get_jpeg()
@@ -480,16 +480,16 @@ class TVCCoverMixin:
         image = EmbeddedImage(fileobj, "image/jpeg", 10, 10, 8)
 
         song = self.QLType(self.filename)
-        self.assertTrue(song.has_images)
-        self.assertTrue(song.get_primary_image())
-        self.assertTrue(song.has_images)
+        assert song.has_images
+        assert song.get_primary_image()
+        assert song.has_images
         song.set_image(image)
-        self.assertTrue(song.has_images)
+        assert song.has_images
         self.assertEqual(song.get_primary_image().width, 10)
 
         song = self.MutagenType(self.filename)
-        self.assertTrue("coverart" not in song)
-        self.assertTrue("coverartmime" not in song)
+        assert "coverart" not in song
+        assert "coverartmime" not in song
 
 
 class TVCCoverOgg(TVCCover, TVCCoverMixin):
@@ -549,7 +549,7 @@ class TFlacPicture(TestCase):
         song.save()
 
         song = FLACFile(self.filename)
-        self.assertTrue(song("~picture"))
+        assert song("~picture")
         fn = song.get_primary_image().file
         self.assertEqual(fn.read(), pic.data)
 
@@ -562,18 +562,18 @@ class TFlacPicture(TestCase):
         song.save()
 
         song = FLACFile(self.filename)
-        self.assertTrue(song.get_primary_image())
+        assert song.get_primary_image()
         song.clear_images()
         song.clear_images()
         song = FLACFile(self.filename)
-        self.assertFalse(song.get_primary_image())
+        assert not song.get_primary_image()
 
     def test_set_image(self):
         fileobj = BytesIO(b"foo")
         image = EmbeddedImage(fileobj, "image/jpeg", 10, 10, 8)
 
         song = FLACFile(self.filename)
-        self.assertFalse(song.get_primary_image())
+        assert not song.get_primary_image()
         song.set_image(image)
         self.assertEqual(song.get_primary_image().width, 10)
 
@@ -612,7 +612,7 @@ class TOggOpusFile(TVCFile, TVCFileMixin):
 
     def test_length(self):
         self.assertAlmostEqual(self.song("~#length"), 3.6847, 3)
-        self.assertTrue("opusenc" in self.song("encoder"))
+        assert "opusenc" in self.song("encoder")
 
     def test_channels(self):
         assert self.song("~#channels") == 2

--- a/tests/test_icons.py
+++ b/tests/test_icons.py
@@ -21,4 +21,4 @@ class TIconTheme(TestCase):
             "io.github.quodlibet.ExFalso",
             "quodlibet-missing-cover"
         ]:
-            self.assertTrue(theme.has_icon(i))
+            assert theme.has_icon(i)

--- a/tests/test_library_album.py
+++ b/tests/test_library_album.py
@@ -56,14 +56,14 @@ class TAlbumLibrary(TestCase):
         self.assertEqual(self.library[key].key, key)
 
     def test_keys(self):
-        self.assertTrue(len(self.library.keys()), 3)
+        assert len(self.library.keys()), 3
 
     def test_has_key(self):
         key = self.underlying.get("file_1.mp3").album_key
-        self.assertTrue(self.library.has_key(key))
+        assert self.library.has_key(key)
 
     def test_misc_collection(self):
-        self.assertTrue(self.library.values())
+        assert self.library.values()
 
     def test_items(self):
         self.assertEqual(len(self.library.items()), 3)
@@ -96,7 +96,7 @@ class TAlbumLibrary(TestCase):
 
     def test_misc(self):
         # It shouldn't implement FileLibrary etc
-        self.assertFalse(getattr(self.library, "filename", None))
+        assert not getattr(self.library, "filename", None)
 
 
 class TAlbumLibrarySignals(TestCase):

--- a/tests/test_library_file.py
+++ b/tests/test_library_file.py
@@ -29,50 +29,50 @@ class TFileLibrary(TLibrary):
     def test_mask_invalid_mount_point(self):
         new = self.Fake(1)
         self.library.add([new])
-        self.assertFalse(self.library.masked_mount_points)
-        self.assertTrue(len(self.library))
+        assert not self.library.masked_mount_points
+        assert len(self.library)
         self.library.mask("/adsadsafaf")
-        self.assertFalse(self.library.masked_mount_points)
+        assert not self.library.masked_mount_points
         self.library.unmask("/adsadsafaf")
-        self.assertFalse(self.library.masked_mount_points)
-        self.assertTrue(len(self.library))
+        assert not self.library.masked_mount_points
+        assert len(self.library)
 
     def test_mask_basic(self):
         new = self.Fake(1)
         self.library.add([new])
-        self.assertFalse(self.library.masked_mount_points)
+        assert not self.library.masked_mount_points
         self.library.mask(new.mountpoint)
         self.assertEqual(self.library.masked_mount_points,
                              [new.mountpoint])
-        self.assertFalse(len(self.library))
+        assert not len(self.library)
         self.assertEqual(self.library.get_masked(new.mountpoint), [new])
-        self.assertTrue(self.library.masked(new))
+        assert self.library.masked(new)
         self.library.unmask(new.mountpoint)
-        self.assertTrue(len(self.library))
+        assert len(self.library)
         self.assertEqual(self.library.get_masked(new.mountpoint), [])
 
     def test_remove_masked(self):
         new = self.Fake(1)
         self.library.add([new])
         self.library.mask(new.mountpoint)
-        self.assertTrue(self.library.masked_mount_points)
+        assert self.library.masked_mount_points
         self.library.remove_masked(new.mountpoint)
-        self.assertFalse(self.library.masked_mount_points)
+        assert not self.library.masked_mount_points
 
     def test_content_masked(self):
         new = self.Fake(100)
         new._mounted = False
-        self.assertFalse(self.library.get_content())
+        assert not self.library.get_content()
         self.library._load_init([new])
-        self.assertTrue(self.library.masked(new))
-        self.assertTrue(self.library.get_content())
+        assert self.library.masked(new)
+        assert self.library.get_content()
 
     def test_init_masked(self):
         new = self.Fake(100)
         new._mounted = False
         self.library._load_init([new])
-        self.assertFalse(self.library.items())
-        self.assertTrue(self.library.masked(new))
+        assert not self.library.items()
+        assert self.library.masked(new)
 
     def test_load_init_nonmasked(self):
         new = self.Fake(200)
@@ -86,8 +86,8 @@ class TFileLibrary(TLibrary):
         changed = set()
         removed = set()
         self.library.reload(new, changed=changed, removed=removed)
-        self.assertTrue(new in changed)
-        self.assertFalse(removed)
+        assert new in changed
+        assert not removed
 
     def test_move_root(self):
         # TODO: mountpoint tests too

--- a/tests/test_library_librarians.py
+++ b/tests/test_library_librarians.py
@@ -45,8 +45,8 @@ class TLibrarian(TestCase):
 
     def test_libraries(self):
         self.assertEqual(len(self.librarian.libraries), 2)
-        self.assertTrue(self.lib1 in self.librarian.libraries.values())
-        self.assertTrue(self.lib2 in self.librarian.libraries.values())
+        assert self.lib1 in self.librarian.libraries.values()
+        assert self.lib2 in self.librarian.libraries.values()
 
     def test_register_at_instantiation(self):
         try:
@@ -70,8 +70,8 @@ class TLibrarian(TestCase):
     def test_unregister(self):
         self.lib2.destroy()
         self.assertEqual(len(self.librarian.libraries), 1)
-        self.assertTrue(self.lib1 in self.librarian.libraries.values())
-        self.assertFalse(self.lib2 in self.librarian.libraries.values())
+        assert self.lib1 in self.librarian.libraries.values()
+        assert self.lib2 not in self.librarian.libraries.values()
         self.lib1.destroy()
         self.assertEqual(len(self.librarian.libraries), 0)
 
@@ -119,9 +119,9 @@ class TLibrarian(TestCase):
         new.key = 200
         self.lib1.add([new])
         for value in [1, 2, 15, 22, 200, new]:
-            self.assertTrue(value in self.librarian, "didn't find %d" % value)
+            assert value in self.librarian, "didn't find %d" % value
         for value in [-1, 25, 50, 100]:
-            self.assertFalse(value in self.librarian, "found %d" % value)
+            assert value not in self.librarian, "found %d" % value
 
     def tearDown(self):
         self.Library.librarian = None
@@ -143,7 +143,7 @@ class TSongLibrarian(TLibrarian):
         self.assertEqual(
             sorted(self.librarian.tag_values(20)), list(range(20)))
         self.assertEqual(sorted(self.librarian.tag_values(0)), [])
-        self.assertFalse(self.changed or self.added or self.removed)
+        assert not self.changed or self.added or self.removed
 
     def test_rename(self):
         new = self.Fake(10)
@@ -153,13 +153,13 @@ class TSongLibrarian(TLibrarian):
         self.librarian.rename(new, 20)
         run_gtk_loop()
         self.assertEqual(new.key, 20)
-        self.assertTrue(new in self.lib1)
-        self.assertTrue(new in self.lib2)
-        self.assertTrue(new.key in self.lib1)
-        self.assertTrue(new.key in self.lib2)
+        assert new in self.lib1
+        assert new in self.lib2
+        assert new.key in self.lib1
+        assert new.key in self.lib2
         self.assertEqual(self.changed_1, [new])
         self.assertEqual(self.changed_2, [new])
-        self.assertTrue(new in self.changed)
+        assert new in self.changed
 
     def test_rename_changed(self):
         new = self.Fake(10)
@@ -167,7 +167,7 @@ class TSongLibrarian(TLibrarian):
         changed = set()
         self.librarian.rename(new, 20, changed=changed)
         self.assertEqual(len(changed), 1)
-        self.assertTrue(new in changed)
+        assert new in changed
 
     def test_reload(self):
         new = self.Fake(10)
@@ -176,5 +176,5 @@ class TSongLibrarian(TLibrarian):
         removed = set()
 
         self.librarian.reload(new, changed=changed, removed=removed)
-        self.assertTrue(new in changed)
-        self.assertFalse(removed)
+        assert new in changed
+        assert not removed

--- a/tests/test_library_libraries.py
+++ b/tests/test_library_libraries.py
@@ -117,17 +117,17 @@ class TLibrary(TestCase):
 
     def test_remove(self):
         self.library.add(self.Frange(10))
-        self.assertTrue(self.library.remove(self.Frange(3, 6)))
+        assert self.library.remove(self.Frange(3, 6))
         self.assertEqual(self.removed, self.Frange(3, 6))
 
         # Neither the objects nor their keys should be present.
-        self.assertFalse(self.Fake(3) in self.library)
-        self.assertTrue(self.Fake(6) in self.library)
-        self.assertFalse(3 in self.library)
-        self.assertTrue(6 in self.library)
+        assert self.Fake(3) not in self.library
+        assert self.Fake(6) in self.library
+        assert 3 not in self.library
+        assert 6 in self.library
 
     def test_remove_when_not_present(self):
-        self.assertFalse(self.library.remove([self.Fake(12)]))
+        assert not self.library.remove([self.Fake(12)])
 
     def test_changed(self):
         self.library.add(self.Frange(10))
@@ -150,7 +150,7 @@ class TLibrary(TestCase):
         self.assertEqual(sorted(self.library), self.Frange(10))
 
     def test___iter___empty(self):
-        self.assertFalse(list(self.library))
+        assert not list(self.library)
 
     def test___len__(self):
         self.assertEqual(len(self.library), 0)
@@ -166,7 +166,7 @@ class TLibrary(TestCase):
         new.key = 100
         self.library.add([new])
         self.assertEqual(self.library[100], new)
-        self.assertFalse(12 in self.library)
+        assert 12 not in self.library
 
     def test___getitem___not_present(self):
         self.library.add(self.Frange(10))
@@ -181,21 +181,21 @@ class TLibrary(TestCase):
             # 0, 1, 2, 6, 9: all added by self.Frange
             # 100: key for new
             # new: is itself present
-            self.assertTrue(value in self.library, "didn't find %s" % value)
+            assert value in self.library, "didn't find %s" % value
 
         for value in [-1, 10, 12, 101]:
             # -1, 10, 101: boundary values
             # 12: equal but non-key-equal to new
-            self.assertFalse(value in self.library, "found %d" % value)
+            assert value not in self.library, "found %d" % value
 
     def test_get(self):
-        self.assertTrue(self.library.get(12) is None)
-        self.assertTrue(self.library.get(12, "foo") == "foo")
+        assert self.library.get(12) is None
+        assert self.library.get(12, "foo") == "foo"
         new = self.Fake(12)
         new.key = 100
         self.library.add([new])
-        self.assertTrue(self.library.get(12) is None)
-        self.assertTrue(self.library.get(100) is new)
+        assert self.library.get(12) is None
+        assert self.library.get(100) is new
 
     def test_keys(self):
         items = []
@@ -224,12 +224,12 @@ class TLibrary(TestCase):
         self.assertEqual(sorted(self.library.items()), expected)
 
     def test_has_key(self):
-        self.assertFalse(self.library.has_key(10))
+        assert not self.library.has_key(10)
         new = self.Fake(10)
         new.key = 20
         self.library.add([new])
-        self.assertFalse(self.library.has_key(10))
-        self.assertTrue(self.library.has_key(20))
+        assert not self.library.has_key(10)
+        assert self.library.has_key(20)
 
     def tearDown(self):
         self.library.destroy()

--- a/tests/test_library_playlist.py
+++ b/tests/test_library_playlist.py
@@ -140,7 +140,7 @@ class TPlaylistLibrary(TestCase):
         assert self.library.has_key(PL_NAME)
 
     def test_misc_collection(self):
-        self.assertTrue(self.library.values())
+        assert self.library.values()
 
     def test_items(self):
         assert self.library.items() == [(PL_NAME, self.pl)]
@@ -155,7 +155,7 @@ class TPlaylistLibrary(TestCase):
 
     def test_misc(self):
         # It shouldn't implement FileLibrary etc
-        self.assertFalse(getattr(self.library, "filename", None))
+        assert not getattr(self.library, "filename", None)
 
 
 class TPlaylistLibrarySignals(TestCase):

--- a/tests/test_library_song.py
+++ b/tests/test_library_song.py
@@ -23,19 +23,19 @@ class TSongLibrary(TLibrary):
         self.library.dirty = False
         song = self.Fake(10)
         self.library.add([song])
-        self.assertTrue(self.library.dirty)
+        assert self.library.dirty
         self.library.dirty = False
         self.library.rename(song, 20)
-        self.assertTrue(self.library.dirty)
+        assert self.library.dirty
 
     def test_rename(self):
         song = self.Fake(10)
         self.library.add([song])
         self.library.rename(song, 20)
         run_gtk_loop()
-        self.assertTrue(song in self.changed)
-        self.assertTrue(song in self.library)
-        self.assertTrue(song.key in self.library)
+        assert song in self.changed
+        assert song in self.library
+        assert song.key in self.library
         self.assertEqual(song.key, 20)
 
     def test_rename_changed(self):
@@ -44,7 +44,7 @@ class TSongLibrary(TLibrary):
         changed = set()
         self.library.rename(song, 20, changed=changed)
         self.assertEqual(len(changed), 1)
-        self.assertTrue(song in changed)
+        assert song in changed
 
     def test_tag_values(self):
         self.library.add(self.Frange(30))
@@ -52,7 +52,7 @@ class TSongLibrary(TLibrary):
         self.assertEqual(
             sorted(self.library.tag_values(10)), list(range(10)))
         self.assertEqual(sorted(self.library.tag_values(0)), [])
-        self.assertFalse(self.changed or self.added or self.removed)
+        assert not self.changed or self.added or self.removed
 
 
 class TSongFileLibrary(TSongLibrary):
@@ -64,20 +64,20 @@ class TSongFileLibrary(TSongLibrary):
         new = self.Fake(100)
         new._valid = False
         changed, removed = self.library._load_item(new)
-        self.assertFalse(removed)
-        self.assertTrue(changed)
-        self.assertTrue(new._valid)
-        self.assertTrue(new in self.library)
+        assert not removed
+        assert changed
+        assert new._valid
+        assert new in self.library
 
     def test__load_not_exists(self):
         new = self.Fake(100)
         new._valid = False
         new._exists = False
         changed, removed = self.library._load_item(new)
-        self.assertFalse(removed)
-        self.assertFalse(changed)
-        self.assertFalse(new._valid)
-        self.assertFalse(new in self.library)
+        assert not removed
+        assert not changed
+        assert not new._valid
+        assert new not in self.library
 
     def test__load_error_during_reload(self):
         try:
@@ -92,10 +92,10 @@ class TSongFileLibrary(TSongLibrary):
             new.reload = error
             new._valid = False
             changed, removed = self.library._load_item(new)
-            self.assertTrue(removed)
-            self.assertFalse(changed)
-            self.assertFalse(new._valid)
-            self.assertFalse(new in self.library)
+            assert removed
+            assert not changed
+            assert not new._valid
+            assert new not in self.library
         finally:
             util.print_exc = print_exc
 
@@ -105,11 +105,11 @@ class TSongFileLibrary(TSongLibrary):
         new._exists = False
         new._mounted = False
         changed, removed = self.library._load_item(new)
-        self.assertFalse(removed)
-        self.assertFalse(changed)
-        self.assertFalse(new._valid)
-        self.assertFalse(new in self.library)
-        self.assertTrue(self.library.masked(new))
+        assert not removed
+        assert not changed
+        assert not new._valid
+        assert new not in self.library
+        assert self.library.masked(new)
 
     def __get_file(self):
         return get_temp_copy(get_data_path("empty.flac"))
@@ -119,28 +119,28 @@ class TSongFileLibrary(TSongLibrary):
         try:
             filename = self.__get_file()
             ret = self.library.add_filename(filename)
-            self.assertTrue(ret)
+            assert ret
             self.assertEqual(len(self.library), 1)
             self.assertEqual(len(self.added), 1)
             ret = self.library.add_filename(filename)
-            self.assertTrue(ret)
+            assert ret
             self.assertEqual(len(self.added), 1)
             os.unlink(filename)
 
             filename = self.__get_file()
             ret = self.library.add_filename(filename, add=False)
-            self.assertTrue(ret)
-            self.assertFalse(ret in self.library)
+            assert ret
+            assert ret not in self.library
             self.assertEqual(len(self.added), 1)
             self.library.add([ret])
-            self.assertTrue(ret in self.library)
+            assert ret in self.library
             self.assertEqual(len(self.added), 2)
             self.assertEqual(2, len(self.library))
             os.unlink(filename)
 
             with capture_output():
                 ret = self.library.add_filename("")
-            self.assertFalse(ret)
+            assert not ret
             self.assertEqual(len(self.added), 2)
             self.assertEqual(len(self.library), 2)
 
@@ -173,7 +173,7 @@ class TSongFileLibrary(TSongLibrary):
 
         song = self.library.add_filename(filename)
         other_song = self.library.add_filename(other)
-        self.assertTrue(song is other_song)
+        assert song is other_song
         os.unlink(filename)
         config.quit()
 

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -45,16 +45,16 @@ class _TestMetaDataMixin:
         self.assertEqual(self.song["title"], "Silence")
 
     def test_mutability(self):
-        self.assertFalse(self.song.can_change("=foo"))
-        self.assertFalse(self.song.can_change("foo~bar"))
-        self.assertTrue(self.song.can_change("artist"))
-        self.assertTrue(self.song.can_change("title"))
-        self.assertTrue(self.song.can_change("tracknumber"))
-        self.assertTrue(self.song.can_change("somebadtag"))
-        self.assertTrue(self.song.can_change("some%punctuated:tag."))
+        assert not self.song.can_change("=foo")
+        assert not self.song.can_change("foo~bar")
+        assert self.song.can_change("artist")
+        assert self.song.can_change("title")
+        assert self.song.can_change("tracknumber")
+        assert self.song.can_change("somebadtag")
+        assert self.song.can_change("some%punctuated:tag.")
 
     def _test_tag(self, tag, values, remove=True):
-        self.assertTrue(self.song.can_change(tag))
+        assert self.song.can_change(tag)
         for value in values:
             self.song[tag] = value
             self.song.write()
@@ -64,7 +64,7 @@ class _TestMetaDataMixin:
                 del self.song[tag]
                 self.song.write()
                 deleted = formats.MusicFile(self.filename)
-                self.assertFalse(tag in deleted)
+                assert tag not in deleted
 
     def test_artist(self): # a normalish tag
         self._test_tag("artist", ["me", "you\nme",

--- a/tests/test_operon.py
+++ b/tests/test_operon.py
@@ -150,7 +150,7 @@ class TOperonPrint(TOperonBase):
         # the failed ones, the patterns for the working ones and return
         # an error status
         o, e = self.check_false(["print", self.f3, self.f2], True, True)
-        self.assertTrue("Quod Libet Test Data" in o)
+        assert "Quod Libet Test Data" in o
 
     @skipIf(is_windows(), "doesn't prevent reading under wine...")
     def test_permissions(self):
@@ -201,7 +201,7 @@ class TOperonRemove(TOperonBase):
         self.check_true(["-v", "remove", "test", "-e", ".*", self.f],
                         False, True)
         self.s.reload()
-        self.assertFalse(self.s.list("test"))
+        assert not self.s.list("test")
 
 
 class TOperonClear(TOperonBase):
@@ -219,12 +219,12 @@ class TOperonClear(TOperonBase):
     def _test_all(self):
         self.check(["clear", "-a", self.f], True, output=False)
         self.s.reload()
-        self.assertFalse(self.s.realkeys())
+        assert not self.s.realkeys()
         self.check(["clear", "-a", self.f, self.f], True, output=False)
 
     def _test_all_dry_run(self):
         old_len = len(self.s.realkeys())
-        self.assertTrue(old_len)
+        assert old_len
         self.check(["clear", "-a", "--dry-run", self.f], True)
         self.s.reload()
         self.assertEqual(len(self.s.realkeys()), old_len)
@@ -293,10 +293,10 @@ class TOperonCopy(TOperonBase):
             del self.s2[key]
         self.s2.write()
         self.s2.reload()
-        self.assertFalse(self.s2.realkeys())
+        assert not self.s2.realkeys()
         self.check_true(["copy", self.f, self.f2], False, False)
         self.s2.reload()
-        self.assertTrue(self.s2.realkeys())
+        assert self.s2.realkeys()
 
     def test_not_changable(self):
         self.s2["rating"] = "foo"
@@ -318,7 +318,7 @@ class TOperonCopy(TOperonBase):
         self.s2.reload()
         self.check_true(["copy", "--dry-run", self.f, self.f2], False, True)
         self.s2.reload()
-        self.assertFalse(self.s2.realkeys())
+        assert not self.s2.realkeys()
 
 
 class TOperonEdit(TOperonBase):
@@ -333,7 +333,7 @@ class TOperonEdit(TOperonBase):
         editor = fsnative("/this/path/does/not/exist/hopefully")
         os.environ["VISUAL"] = editor
         e = self.check_false(["edit", self.f], False, True)[1]
-        self.assertTrue(editor in e)
+        assert editor in e
 
     def test_no_edit(self):
         if os.name == "nt":
@@ -370,7 +370,7 @@ class TOperonEdit(TOperonBase):
 
         # log all removals
         for key in self.s.realkeys():
-            self.assertTrue(key in e)
+            assert key in e
 
         # nothing should have changed
         self.s.reload()
@@ -397,9 +397,9 @@ class TOperonEdit(TOperonBase):
 
         # all should be gone on both files
         self.s.reload()
-        self.assertFalse(self.s.realkeys())
+        assert not self.s.realkeys()
         self.s2.reload()
-        self.assertFalse(self.s2.realkeys())
+        assert not self.s2.realkeys()
 
     def test_multi_edit(self):
         if os.name == "nt" or sys.platform == "darwin":
@@ -470,7 +470,7 @@ class TOperonList(TOperonBase):
         self.s.write()
         d = self.check_true(["list", "-t", "-cvalue", self.f], True, False)[0]
         lines = d.splitlines()
-        self.assertTrue("a\\:bc\\\\\\:" in lines)
+        assert "a\\:bc\\\\\\:" in lines
 
 
 class TOperonTags(TOperonBase):
@@ -539,7 +539,7 @@ class TOperonImageExtract(TOperonBase):
         expected = f"{name}-00.{image.extensions[0]}"
         expected_path = os.path.join(target_dir, expected)
 
-        self.assertTrue(os.path.exists(expected_path))
+        assert os.path.exists(expected_path)
 
         with open(expected_path, "rb") as h:
             self.assertEqual(h.read(), image.read())
@@ -558,7 +558,7 @@ class TOperonImageExtract(TOperonBase):
         expected = f"{name}.{image.extensions[0]}"
         expected_path = os.path.join(target_dir, expected)
 
-        self.assertTrue(os.path.exists(expected_path))
+        assert os.path.exists(expected_path)
 
         with open(expected_path, "rb") as h:
             self.assertEqual(h.read(), image.read())
@@ -597,7 +597,7 @@ class TOperonImageSet(TOperonBase):
         path = get_data_path("test.mid")
         out, err = self.check_false(
             ["image-set", self.filename, path], False, True)
-        self.assertTrue("supported" in err)
+        assert "supported" in err
 
     def test_set(self):
         self.check_true(["image-set", self.filename, self.fcover],
@@ -646,7 +646,7 @@ class TOperonImageClear(TOperonBase):
     def test_not_supported(self):
         path = get_data_path("test.mid")
         out, err = self.check_false(["image-clear", path], False, True)
-        self.assertTrue("supported" in err)
+        assert "supported" in err
 
     def test_clear(self):
         images = self.cover.get_images()
@@ -685,13 +685,13 @@ class TOperonFill(TOperonBase):
         o, e = self.check_true(
             ["fill", "--dry-run", "<title>", self.f], True, False)
 
-        self.assertTrue("title" in o)
-        self.assertTrue(self.s("~basename") in o)
+        assert "title" in o
+        assert self.s("~basename") in o
 
     def test_preview_no_match(self):
         o, e = self.check_true(
             ["fill", "--dry-run", "<tracknumber>. <title>", self.f],
             True, False)
 
-        self.assertTrue("title" in o)
-        self.assertTrue(self.s("~basename") in o)
+        assert "title" in o
+        assert self.s("~basename") in o

--- a/tests/test_order.py
+++ b/tests/test_order.py
@@ -31,9 +31,9 @@ class TOrderWeighted(TestCase):
             for j in range(3, -1, -1):
                 cur = order.next_explicit(pl, cur)
                 scores[pl[cur][0]] += j
-        self.assertTrue(scores[r1] > scores[r0])
-        self.assertTrue(scores[r2] > scores[r1])
-        self.assertTrue(scores[r3] > scores[r2])
+        assert scores[r1] > scores[r0]
+        assert scores[r2] > scores[r1]
+        assert scores[r3] > scores[r2]
 
 
 class TOrderShuffle(TestCase):

--- a/tests/test_pattern.py
+++ b/tests/test_pattern.py
@@ -278,13 +278,13 @@ class _TFileFromPattern(_TPattern):
 
     def test_escape_slash(self):
         fpat = self._create("<~filename>")
-        self.assertTrue(fpat.format(self.a).endswith("_path_to_a.mp3"))
+        assert fpat.format(self.a).endswith("_path_to_a.mp3")
 
         pat = Pattern("<~filename>")
         if os.name != "nt":
-            self.assertTrue(pat.format(self.a).startswith("/path/to/a"))
+            assert pat.format(self.a).startswith("/path/to/a")
         else:
-            self.assertTrue(pat.format(self.a).startswith("C:\\path\\to\\a"))
+            assert pat.format(self.a).startswith("C:\\path\\to\\a")
 
         if os.name != "nt":
             wpat = self._create(r'\\<artist>\\ "<title>')
@@ -308,30 +308,30 @@ class _TFileFromPattern(_TPattern):
     def test_backslash_conversion_win32(self):
         if os.name == "nt":
             pat = self._create(r"Z:\<artist>\<title>")
-            self.assertTrue(pat.format(self.a).startswith(r"Z:\Artist\Title5"))
+            assert pat.format(self.a).startswith(r"Z:\Artist\Title5")
 
     def test_raw_slash_preservation(self):
         if os.name == "nt":
             pat = self._create("C:\\a\\b\\<genre>")
-            self.assertTrue(pat.format(self.a).startswith("C:\\a\\b\\"))
-            self.assertTrue(pat.format(self.b).startswith("C:\\a\\b\\"))
-            self.assertTrue(pat.format(self.c).startswith("C:\\a\\b\\_, _"))
+            assert pat.format(self.a).startswith("C:\\a\\b\\")
+            assert pat.format(self.b).startswith("C:\\a\\b\\")
+            assert pat.format(self.c).startswith("C:\\a\\b\\_, _")
 
         else:
             pat = self._create("/a/b/<genre>")
-            self.assertTrue(pat.format(self.a).startswith("/a/b/"))
-            self.assertTrue(pat.format(self.b).startswith("/a/b/"))
-            self.assertTrue(pat.format(self.c).startswith("/a/b/_, _"))
+            assert pat.format(self.a).startswith("/a/b/")
+            assert pat.format(self.b).startswith("/a/b/")
+            assert pat.format(self.c).startswith("/a/b/_, _")
 
     def test_specialcase_anti_ext(self):
         p1 = self._create("<~filename>")
         p2 = self._create("<~dirname>_<~basename>")
         self.assertEqual(p1.format(self.a), p2.format(self.a))
-        self.assertTrue(p1.format(self.a).endswith("_path_to_a.mp3"))
+        assert p1.format(self.a).endswith("_path_to_a.mp3")
         self.assertEqual(p1.format(self.b), p2.format(self.b))
-        self.assertTrue(p1.format(self.b).endswith("_path_to_b.ogg"))
+        assert p1.format(self.b).endswith("_path_to_b.ogg")
         self.assertEqual(p1.format(self.c), p2.format(self.c))
-        self.assertTrue(p1.format(self.c).endswith("_one_more_a.flac"))
+        assert p1.format(self.c).endswith("_one_more_a.flac")
 
     def test_long_filename(self):
         if os.name == "nt":
@@ -358,9 +358,9 @@ class TFileFromPattern(_TFileFromPattern):
 
     def test_type(self):
         pat = self._create("")
-        self.assertTrue(isinstance(pat.format(self.a), fsnative))
+        assert isinstance(pat.format(self.a), fsnative)
         pat = self._create("<title>")
-        self.assertTrue(isinstance(pat.format(self.a), fsnative))
+        assert isinstance(pat.format(self.a), fsnative)
 
     def test_number_dot_title_dot(self):
         pat = self._create("<tracknumber>. <title>.")

--- a/tests/test_player.py
+++ b/tests/test_player.py
@@ -71,8 +71,8 @@ class TPlayer(TestCase):
             if type_ == "started":
                 stack.append(song)
             elif type_ == "ended":
-                self.assertTrue(stack.pop(-1) is song, msg=old)
-        self.assertFalse(stack, msg=old)
+                assert stack.pop(-1) is song, old
+        assert not stack, old
 
     def tearDown(self):
         self.player.destroy()
@@ -141,14 +141,14 @@ class TPlayerMixin:
         assert self.player.get_position() == 100
 
     def test_song_start(self):
-        self.assertFalse(self.player.song)
-        self.assertFalse(self.player.info)
+        assert not self.player.song
+        assert not self.player.info
 
     def test_paused(self):
-        self.assertTrue(self.player.paused)
+        assert self.player.paused
         self.player.paused = False
-        self.assertFalse(self.player.paused)
-        self.assertTrue(self.signals, ["unpaused"])
+        assert not self.player.paused
+        assert self.signals, ["unpaused"]
 
     def test_volume(self):
         self.assertEqual(self.player.volume, 1.0)
@@ -177,13 +177,13 @@ class TPlayerMixin:
         self.assertEqual(self.player.song, FILES[1])
 
     def test_next(self):
-        self.assertFalse(self.player.song)
+        assert not self.player.song
         self.player.next()
         self.assertEqual(self.player.song, FILES[0])
         self.player.next()
         self.assertEqual(self.player.song, FILES[1])
         self.player.next()
-        self.assertFalse(self.player.song)
+        assert not self.player.song
 
     def test_previous(self):
         self.player.next()
@@ -193,18 +193,18 @@ class TPlayerMixin:
         self.assertEqual(self.player.song, FILES[0])
 
     def test_goto(self):
-        self.assertTrue(self.player.paused)
+        assert self.player.paused
         self.player.go_to(FILES[1])
         self.assertEqual(self.player.song, FILES[1])
-        self.assertTrue(self.player.paused)
+        assert self.player.paused
         self.player.go_to(FILES[0], explicit=True)
         self.assertEqual(self.player.song, FILES[0])
 
     def test_goto_unknown(self):
-        self.assertTrue(self.player.paused)
+        assert self.player.paused
         self.player.go_to(UNKNOWN_FILE, True)
         self.assertIs(self.player.song, UNKNOWN_FILE)
-        self.assertTrue(self.player.paused)
+        assert self.player.paused
         self.player.go_to(None)
         self.assertIs(self.player.song, None)
 
@@ -227,9 +227,9 @@ class TPlayerMixin:
         self.player.go_to(None)
         self.player.paused = False
         self.player.next()
-        self.assertTrue(self.signals, ["unpaused"])
+        assert self.signals, ["unpaused"]
         self.player.go_to(None)
-        self.assertTrue(self.signals, ["unpaused", "paused"])
+        assert self.signals, ["unpaused", "paused"]
 
     def test_replaygain(self):
         self.player.replaygain_profiles[0] = "track"
@@ -243,9 +243,9 @@ class TPlayerMixin:
         self.assertEqual(self.player.calc_replaygain_volume(1.0), 1.0)
 
     def test_seekable(self):
-        self.assertFalse(self.player.seekable)
+        assert not self.player.seekable
         self.player.next()
-        self.assertTrue(self.player.seekable)
+        assert self.player.seekable
 
         calls = []
 
@@ -254,8 +254,8 @@ class TPlayerMixin:
 
         self.player.connect("notify::seekable", on_change)
         self.player.go_to(None)
-        self.assertTrue(calls)
-        self.assertFalse(self.player.seekable)
+        assert calls
+        assert not self.player.seekable
 
     def test_pause_on_goto_none(self):
         # When we got to None, pause after song-started
@@ -274,9 +274,9 @@ class TPlayerMixin:
         assert event[0] == (None, False)
 
     def test_mute(self):
-        self.assertFalse(self.player.mute)
+        assert not self.player.mute
         self.player.next()
-        self.assertFalse(self.player.mute)
+        assert not self.player.mute
         # backend don't have to support it, but shouldn't fail on set/get
         self.player.mute = not self.player.mute
 
@@ -350,9 +350,9 @@ class TNullPlayer(TPlayer, TPlayerMixin):
         self.assertEqual(self.player.get_position(), 0)
 
     def test_can_play_uri_null(self):
-        self.assertTrue(self.player.can_play_uri(""))
-        self.assertTrue(self.player.can_play_uri("file://"))
-        self.assertTrue(self.player.can_play_uri("fake://"))
+        assert self.player.can_play_uri("")
+        assert self.player.can_play_uri("file://")
+        assert self.player.can_play_uri("fake://")
 
 
 has_xine = True
@@ -367,9 +367,9 @@ class TXinePlayer(TPlayer, TPlayerMixin):
     NAME = "xinebe"
 
     def test_can_play_uri_xine(self):
-        self.assertFalse(self.player.can_play_uri(""))
-        self.assertTrue(self.player.can_play_uri("file://"))
-        self.assertFalse(self.player.can_play_uri("fake://"))
+        assert not self.player.can_play_uri("")
+        assert self.player.can_play_uri("file://")
+        assert not self.player.can_play_uri("fake://")
 
 
 has_gstbe = True
@@ -384,9 +384,9 @@ class TGstPlayer(TPlayer, TPlayerMixin):
     NAME = "gstbe"
 
     def test_can_play_uri_gst(self):
-        self.assertFalse(self.player.can_play_uri(""))
-        self.assertTrue(self.player.can_play_uri("file://"))
-        self.assertFalse(self.player.can_play_uri("fake://"))
+        assert not self.player.can_play_uri("")
+        assert self.player.can_play_uri("file://")
+        assert not self.player.can_play_uri("fake://")
 
 
 class TVolume(TestCase):

--- a/tests/test_player_gst.py
+++ b/tests/test_player_gst.py
@@ -56,7 +56,7 @@ class TGStreamerSink(TestCase):
         sinks = ["gconfaudiosink", "alsasink"]
         for n in filter(Gst.ElementFactory.find, sinks):
             obj, name = gstreamer_sink(n)
-            self.assertTrue(obj)
+            assert obj
             self.assertEqual(name, n)
 
     def test_invalid(self):
@@ -65,7 +65,7 @@ class TGStreamerSink(TestCase):
 
     def test_fallback(self):
         obj, name = gstreamer_sink("")
-        self.assertTrue(obj)
+        assert obj
         if os.name == "nt":
             self.assertEqual(name, "directsoundsink")
         else:
@@ -73,7 +73,7 @@ class TGStreamerSink(TestCase):
 
     def test_append_sink(self):
         obj, name = gstreamer_sink("volume")
-        self.assertTrue(obj)
+        assert obj
         self.assertEqual(name.split("!")[-1].strip(), gstreamer_sink("")[1])
 
 
@@ -84,11 +84,11 @@ class TGstreamerTagList(TestCase):
 
         l = {}
         l["extended-comment"] = "foo=bar"
-        self.assertTrue("foo" in parse_gstreamer_taglist(l))
+        assert "foo" in parse_gstreamer_taglist(l)
 
         l["extended-comment"] = ["foo=bar", "bar=foo", "bar=foo2"]
-        self.assertTrue("foo" in parse_gstreamer_taglist(l))
-        self.assertTrue("bar" in parse_gstreamer_taglist(l))
+        assert "foo" in parse_gstreamer_taglist(l)
+        assert "bar" in parse_gstreamer_taglist(l)
         self.assertEqual(parse_gstreamer_taglist(l)["bar"], "foo\nfoo2")
 
         # date is abstract, so define our own
@@ -104,13 +104,13 @@ class TGstreamerTagList(TestCase):
 
         l["foo"] = "äöü"
         parsed = parse_gstreamer_taglist(l)
-        self.assertTrue(isinstance(parsed["foo"], str))
-        self.assertTrue("äöü" in parsed["foo"].split("\n"))
+        assert isinstance(parsed["foo"], str)
+        assert "äöü" in parsed["foo"].split("\n")
 
         l["foo"] = "äöü".encode()
         parsed = parse_gstreamer_taglist(l)
-        self.assertTrue(isinstance(parsed["foo"], str))
-        self.assertTrue("äöü" in parsed["foo"].split("\n"))
+        assert isinstance(parsed["foo"], str)
+        assert "äöü" in parsed["foo"].split("\n")
 
         l["bar"] = 1.2
         self.assertEqual(parse_gstreamer_taglist(l)["bar"], 1.2)
@@ -121,11 +121,11 @@ class TGstreamerTagList(TestCase):
         l["bar"] = Gst.TagList() # some random gst instance
         self.assertTrue(
             isinstance(parse_gstreamer_taglist(l)["bar"], str))
-        self.assertTrue("GstTagList" in parse_gstreamer_taglist(l)["bar"])
+        assert "GstTagList" in parse_gstreamer_taglist(l)["bar"]
 
     def test_sanitize(self):
         l = sanitize_tags({"location": "http://foo"})
-        self.assertTrue("website" in l)
+        assert "website" in l
 
         l = sanitize_tags({"channel-mode": "joint-stereo"})
         self.assertEqual(l["channel-mode"], "stereo")
@@ -144,12 +144,12 @@ class TGstreamerTagList(TestCase):
 
         l = {"a": "http://www.shoutcast.com", "b": "default genre"}
         l = sanitize_tags(l)
-        self.assertFalse(l)
+        assert not l
 
         l = sanitize_tags({"duration": 1000 * 42}, stream=True)
         self.assertEqual(l["~#length"], 42)
         l = sanitize_tags({"duration": 1000 * 42})
-        self.assertFalse(l)
+        assert not l
 
         l = sanitize_tags({"duration": "bla"}, stream=True)
         self.assertEqual(l["duration"], "bla")
@@ -157,7 +157,7 @@ class TGstreamerTagList(TestCase):
         l = sanitize_tags({"bitrate": 1000 * 42}, stream=True)
         self.assertEqual(l["~#bitrate"], 42)
         l = sanitize_tags({"bitrate": 1000 * 42})
-        self.assertFalse(l)
+        assert not l
 
         l = sanitize_tags({"bitrate": "bla"})
         self.assertEqual(l["bitrate"], "bla")
@@ -165,35 +165,35 @@ class TGstreamerTagList(TestCase):
         l = sanitize_tags({"nominal-bitrate": 1000 * 42})
         self.assertEqual(l["~#bitrate"], 42)
         l = sanitize_tags({"nominal-bitrate": 1000 * 42}, stream=True)
-        self.assertFalse(l)
+        assert not l
 
         l = sanitize_tags({"nominal-bitrate": "bla"})
         self.assertEqual(l["nominal-bitrate"], "bla")
 
         l = {"emphasis": "something"}
-        self.assertFalse(sanitize_tags(l))
-        self.assertFalse(sanitize_tags(l))
+        assert not sanitize_tags(l)
+        assert not sanitize_tags(l)
 
         l = {"title": "something"}
-        self.assertFalse(sanitize_tags(l))
-        self.assertTrue(sanitize_tags(l, stream=True))
+        assert not sanitize_tags(l)
+        assert sanitize_tags(l, stream=True)
 
         l = {"artist": "something"}
-        self.assertFalse(sanitize_tags(l))
-        self.assertTrue(sanitize_tags(l, stream=True))
+        assert not sanitize_tags(l)
+        assert sanitize_tags(l, stream=True)
 
         l = {"~#foo": 42, "bar": 42, "~#bla": "42"}
-        self.assertTrue("~#foo" in sanitize_tags(l))
-        self.assertTrue("~#bar" in sanitize_tags(l))
-        self.assertTrue("bla" in sanitize_tags(l))
+        assert "~#foo" in sanitize_tags(l)
+        assert "~#bar" in sanitize_tags(l)
+        assert "bla" in sanitize_tags(l)
 
         l = {}
         l["extended-comment"] = ["location=1", "website=2", "website=3"]
         l = parse_gstreamer_taglist(l)
         l = sanitize_tags(l)["website"].split("\n")
-        self.assertTrue("1" in l)
-        self.assertTrue("2" in l)
-        self.assertTrue("3" in l)
+        assert "1" in l
+        assert "2" in l
+        assert "3" in l
 
 
 @skipUnless(Gst, "GStreamer missing")

--- a/tests/test_plugins___init__.py
+++ b/tests/test_plugins___init__.py
@@ -47,19 +47,19 @@ class TSongWrapper(TestCase):
         self.assertEqual([s("~#track") for s in songs], list(range(10)))
 
     def test_needs_write_yes(self):
-        self.assertFalse(self.wrap._needs_write)
+        assert not self.wrap._needs_write
         self.wrap["woo"] = "bar"
-        self.assertTrue(self.wrap._needs_write)
+        assert self.wrap._needs_write
 
     def test_needs_write_no(self):
-        self.assertFalse(self.wrap._needs_write)
+        assert not self.wrap._needs_write
         self.wrap["~woo"] = "bar"
-        self.assertFalse(self.wrap._needs_write)
+        assert not self.wrap._needs_write
 
     def test_pop(self):
-        self.assertFalse(self.wrap._needs_write)
+        assert not self.wrap._needs_write
         self.wrap.pop("artist", None)
-        self.assertTrue(self.wrap._needs_write)
+        assert self.wrap._needs_write
 
     def test_getitem(self):
         self.assertEqual(self.wrap["title"], "woo")
@@ -70,10 +70,10 @@ class TSongWrapper(TestCase):
         self.assertEqual(self.wrap.get("dne", "huh"), "huh")
 
     def test_delitem(self):
-        self.assertTrue("title" in self.wrap)
+        assert "title" in self.wrap
         del(self.wrap["title"])
-        self.assertFalse("title" in self.wrap)
-        self.assertTrue(self.wrap._needs_write)
+        assert "title" not in self.wrap
+        assert self.wrap._needs_write
 
     def test_realkeys(self):
         self.assertEqual(self.pwrap.realkeys(), self.psong.realkeys())
@@ -99,28 +99,28 @@ class TSongWrapper(TestCase):
 
     def test_mtime(self):
         self.wrap._song.sanitize()
-        self.assertTrue(self.wrap.valid())
+        assert self.wrap.valid()
         self.wrap["~#mtime"] = os.path.getmtime(self.filename) - 2
         self.wrap._updated = False
-        self.assertFalse(self.wrap.valid())
+        assert not self.wrap.valid()
 
     def test_setitem(self):
-        self.assertFalse(self.wrap._was_updated())
+        assert not self.wrap._was_updated()
         self.wrap["title"] = "bar"
-        self.assertTrue(self.wrap._was_updated())
+        assert self.wrap._was_updated()
         self.assertEqual(self.wrap["title"], "bar")
 
     def test_not_really_updated(self):
-        self.assertFalse(self.wrap._was_updated())
+        assert not self.wrap._was_updated()
         self.wrap["title"] = "woo"
-        self.assertFalse(self.wrap._was_updated())
+        assert not self.wrap._was_updated()
         self.wrap["title"] = "quux"
-        self.assertTrue(self.wrap._was_updated())
+        assert self.wrap._was_updated()
 
     def test_new_tag(self):
-        self.assertFalse(self.wrap._was_updated())
+        assert not self.wrap._was_updated()
         self.wrap["version"] = "bar"
-        self.assertTrue(self.wrap._was_updated())
+        assert self.wrap._was_updated()
 
     def test_bookmark(self):
         self.assertEqual(self.psong.bookmarks, self.pwrap.bookmarks)
@@ -136,12 +136,12 @@ class TListWrapper(TestCase):
 
     def test_empty_song(self):
         wrapped = list_wrapper([{}])
-        self.assertTrue(len(wrapped) == 1)
-        self.assertFalse(isinstance(wrapped[0], dict))
+        assert len(wrapped) == 1
+        assert not isinstance(wrapped[0], dict)
 
     def test_none(self):
         wrapped = list_wrapper([None, None])
-        self.assertTrue(len(wrapped) == 2)
+        assert len(wrapped) == 2
         self.assertEqual(wrapped, [None, None])
 
 

--- a/tests/test_plugins_cover.py
+++ b/tests/test_plugins_cover.py
@@ -141,17 +141,17 @@ class TCoverManager(TestCase):
             result.append(_result)
         manager.acquire_cover(done, None, None)
         run_gtk_loop()
-        self.assertFalse(found[0])
+        assert not found[0]
         handler.plugin_enable(dummy_sources[1])
         manager.acquire_cover(done, None, None)
         run_gtk_loop()
-        self.assertTrue(found[1])
+        assert found[1]
         self.assertIs(result[1], DUMMY_COVER)
         handler.plugin_disable(dummy_sources[1])
         handler.plugin_enable(dummy_sources[2])
         manager.acquire_cover(done, None, None)
         run_gtk_loop()
-        self.assertTrue(found[2])
+        assert found[2]
         self.assertIs(result[2], DUMMY_COVER)
 
     def test_acquire_cover_calls(self):
@@ -175,28 +175,28 @@ class TCoverManager(TestCase):
             result.append(_result)
         manager.acquire_cover(done, None, None)
         run_gtk_loop()
-        self.assertTrue(found[0])
+        assert found[0]
         self.assertIs(result[0], DUMMY_COVER)
-        self.assertTrue(dummy_sources[0].cls.cover_call)
-        self.assertTrue(dummy_sources[1].cls.cover_call)
-        self.assertFalse(dummy_sources[2].cls.cover_call)
-        self.assertFalse(dummy_sources[0].cls.fetch_call)
-        self.assertFalse(dummy_sources[1].cls.fetch_call)
-        self.assertFalse(dummy_sources[2].cls.fetch_call)
+        assert dummy_sources[0].cls.cover_call
+        assert dummy_sources[1].cls.cover_call
+        assert not dummy_sources[2].cls.cover_call
+        assert not dummy_sources[0].cls.fetch_call
+        assert not dummy_sources[1].cls.fetch_call
+        assert not dummy_sources[2].cls.fetch_call
         for source in dummy_sources:
             source.cls.cover_call = False
             source.cls.fetch_call = False
         handler.plugin_disable(dummy_sources[1])
         manager.acquire_cover(done, None, None)
         run_gtk_loop()
-        self.assertTrue(found[1])
+        assert found[1]
         self.assertIs(result[1], DUMMY_COVER)
-        self.assertTrue(dummy_sources[0].cls.cover_call)
-        self.assertFalse(dummy_sources[1].cls.cover_call)
-        self.assertTrue(dummy_sources[2].cls.cover_call)
-        self.assertFalse(dummy_sources[0].cls.fetch_call)
-        self.assertFalse(dummy_sources[1].cls.fetch_call)
-        self.assertTrue(dummy_sources[2].cls.fetch_call)
+        assert dummy_sources[0].cls.cover_call
+        assert not dummy_sources[1].cls.cover_call
+        assert dummy_sources[2].cls.cover_call
+        assert not dummy_sources[0].cls.fetch_call
+        assert not dummy_sources[1].cls.fetch_call
+        assert dummy_sources[2].cls.fetch_call
 
     def test_search(self):
         manager = CoverManager(use_built_in=False)
@@ -216,7 +216,7 @@ class TCoverManager(TestCase):
         results = []
 
         def done(manager, provider, result):
-            self.assertTrue(result, msg="Shouldn't succeed with no results")
+            assert result, "Shouldn't succeed with no results"
             results.append(result)
 
         def finished(manager, songs):
@@ -276,8 +276,8 @@ class TCoverManagerBuiltin(TestCase):
         self.assertEqual(called_with, [self.manager, [obj]])
 
     def test_get_primary_image(self):
-        self.assertFalse(MP3File(self.file1).has_images)
-        self.assertFalse(MP3File(self.file1).has_images)
+        assert not MP3File(self.file1).has_images
+        assert not MP3File(self.file1).has_images
 
     def test_manager(self):
         self.assertEqual(len(list(self.manager.sources)), 2)
@@ -299,18 +299,18 @@ class TCoverManagerBuiltin(TestCase):
         song2 = MP3File(self.file2)
 
         # each should find a cover
-        self.assertTrue(self.is_embedded(self.manager.get_cover(song1)))
-        self.assertFalse(self.is_embedded(self.manager.get_cover(song2)))
+        assert self.is_embedded(self.manager.get_cover(song1))
+        assert not self.is_embedded(self.manager.get_cover(song2))
 
         cover_for = self.manager.get_cover_many
         # both settings should search both songs before giving up
         config.set("albumart", "prefer_embedded", True)
-        self.assertTrue(self.is_embedded(cover_for([song1, song2])))
-        self.assertTrue(self.is_embedded(cover_for([song2, song1])))
+        assert self.is_embedded(cover_for([song1, song2]))
+        assert self.is_embedded(cover_for([song2, song1]))
 
         config.set("albumart", "prefer_embedded", False)
-        self.assertFalse(self.is_embedded(cover_for([song1, song2])))
-        self.assertFalse(self.is_embedded(cover_for([song2, song1])))
+        assert not self.is_embedded(cover_for([song1, song2]))
+        assert not self.is_embedded(cover_for([song2, song1]))
 
     def is_embedded(self, fileobj):
         return not path_equal(fileobj.name, self.external_cover, True)
@@ -340,10 +340,8 @@ class TCoverManagerBuiltin(TestCase):
 
         config.set("albumart", "prefer_embedded", True)
         acquire(both_song)
-        self.assertTrue(result_was_embedded(),
-                        "Embedded image expected due to prefs")
+        assert result_was_embedded(), "Embedded image expected due to prefs"
 
         config.set("albumart", "prefer_embedded", False)
         acquire(both_song)
-        self.assertFalse(result_was_embedded(),
-                    "Got an embedded image despite prefs")
+        assert not result_was_embedded(), "Got an embedded image despite prefs"

--- a/tests/test_plugins_playlist.py
+++ b/tests/test_plugins_playlist.py
@@ -117,16 +117,16 @@ class TPlaylistPlugins(TestCase):
     def test_disables_plugin(self):
         self.create_plugin(name="Name", desc="Desc", funcs=["plugin_playlist"])
         self.pm.rescan()
-        self.assertFalse(self.pm.enabled(self.pm.plugins[0]))
+        assert not self.pm.enabled(self.pm.plugins[0])
 
     def test_enabledisable_plugin(self):
         self.create_plugin(name="Name", desc="Desc", funcs=["plugin_playlist"])
         self.pm.rescan()
         plug = self.pm.plugins[0]
         self.pm.enable(plug, True)
-        self.assertTrue(self.pm.enabled(plug))
+        assert self.pm.enabled(plug)
         self.pm.enable(plug, False)
-        self.assertFalse(self.pm.enabled(plug))
+        assert not self.pm.enabled(plug)
 
     def test_ignores_broken_plugin(self):
         self.create_plugin(name="Broken", desc="Desc",

--- a/tests/test_plugins_songsmenu.py
+++ b/tests/test_plugins_songsmenu.py
@@ -95,16 +95,16 @@ class TSongsMenuPlugins(TestCase):
     def test_disables_plugin(self):
         self.create_plugin(name="Name", desc="Desc", funcs=["plugin_song"])
         self.pm.rescan()
-        self.assertFalse(self.pm.enabled(self.pm.plugins[0]))
+        assert not self.pm.enabled(self.pm.plugins[0])
 
     def test_enabledisable_plugin(self):
         self.create_plugin(name="Name", desc="Desc", funcs=["plugin_song"])
         self.pm.rescan()
         plug = self.pm.plugins[0]
         self.pm.enable(plug, True)
-        self.assertTrue(self.pm.enabled(plug))
+        assert self.pm.enabled(plug)
         self.pm.enable(plug, False)
-        self.assertFalse(self.pm.enabled(plug))
+        assert not self.pm.enabled(plug)
 
     def test_ignores_broken_plugin(self):
         self.create_plugin(name="Broken", desc="Desc",
@@ -114,7 +114,7 @@ class TSongsMenuPlugins(TestCase):
         self.pm.enable(plug, True)
         with capture_output():
             menu = self.handler.menu(None, [AudioFile()])
-        self.assertFalse(menu and menu.get_children())
+        assert not (menu and menu.get_children())
 
     def test_Menu(self):
         self.create_plugin(name="Name", desc="Desc", funcs=["plugin_song"])
@@ -156,26 +156,26 @@ class Tsongsmenu(TestCase):
     def test_any_song(self):
         FakeSongsMenuPlugin.plugin_handles = any_song(even)
         p = FakeSongsMenuPlugin(self.songs, None)
-        self.assertTrue(p.plugin_handles(self.songs))
-        self.assertFalse(p.plugin_handles(self.songs[:1]))
+        assert p.plugin_handles(self.songs)
+        assert not p.plugin_handles(self.songs[:1])
 
     def test_any_song_multiple(self):
         FakeSongsMenuPlugin.plugin_handles = any_song(even, never)
         p = FakeSongsMenuPlugin(self.songs, None)
-        self.assertFalse(p.plugin_handles(self.songs))
-        self.assertFalse(p.plugin_handles(self.songs[:1]))
+        assert not p.plugin_handles(self.songs)
+        assert not p.plugin_handles(self.songs[:1])
 
     def test_each_song(self):
         FakeSongsMenuPlugin.plugin_handles = each_song(even)
         p = FakeSongsMenuPlugin(self.songs, None)
-        self.assertFalse(p.plugin_handles(self.songs))
-        self.assertTrue(p.plugin_handles(self.songs[1:]))
+        assert not p.plugin_handles(self.songs)
+        assert p.plugin_handles(self.songs[1:])
 
     def test_each_song_multiple(self):
         FakeSongsMenuPlugin.plugin_handles = each_song(even, never)
         p = FakeSongsMenuPlugin(self.songs, None)
-        self.assertFalse(p.plugin_handles(self.songs))
-        self.assertFalse(p.plugin_handles(self.songs[:1]))
+        assert not p.plugin_handles(self.songs)
+        assert not p.plugin_handles(self.songs[:1])
 
 
 class FakeSongsMenuPlugin(SongsMenuPlugin):

--- a/tests/test_qltk___init__.py
+++ b/tests/test_qltk___init__.py
@@ -25,7 +25,7 @@ def test_is_instance_of_gtype_name():
 
 class TQltk(TestCase):
     def test_none(self):
-        self.assertTrue(qltk.get_top_parent(None) is None)
+        assert qltk.get_top_parent(None) is None
 
     def test_get_fg_highlight_color(self):
         widget = Gtk.Button()
@@ -52,19 +52,19 @@ class TQltk(TestCase):
 
     def test_is_accel(self):
         e = Gdk.Event.new(Gdk.EventType.KEY_RELEASE)
-        self.assertFalse(qltk.is_accel(e, "a"))
+        assert not qltk.is_accel(e, "a")
 
         e = Gdk.Event.new(Gdk.EventType.KEY_PRESS)
         e.keyval = Gdk.KEY_Return
         e.state = Gdk.ModifierType.CONTROL_MASK
-        self.assertTrue(qltk.is_accel(e, "<ctrl>Return"))
+        assert qltk.is_accel(e, "<ctrl>Return")
 
         e = Gdk.Event.new(Gdk.EventType.KEY_PRESS)
         e.keyval = Gdk.KEY_Return
         e.state = Gdk.ModifierType.CONTROL_MASK
-        self.assertTrue(qltk.is_accel(e, "a", "<ctrl>Return"))
-        self.assertTrue(qltk.is_accel(e, "<ctrl>Return", "b"))
-        self.assertFalse(qltk.is_accel(e, "a", "b"))
+        assert qltk.is_accel(e, "a", "<ctrl>Return")
+        assert qltk.is_accel(e, "<ctrl>Return", "b")
+        assert not qltk.is_accel(e, "a", "b")
 
     def test_is_accel_invalid(self):
         e = Gdk.Event.new(Gdk.EventType.KEY_PRESS)
@@ -76,7 +76,7 @@ class TQltk(TestCase):
         e.keyval = Gdk.KEY_Return
         e.state = Gdk.ModifierType.CONTROL_MASK
         if not util.is_osx():
-            self.assertTrue(qltk.is_accel(e, "<Primary>Return"))
+            assert qltk.is_accel(e, "<Primary>Return")
 
     def test_popup_menu_under_widget(self):
         w = Gtk.Window()
@@ -116,7 +116,7 @@ class TQltk(TestCase):
         item = Gtk.MenuItem()
         menu = Gtk.Menu()
         menu.append(item)
-        self.assertTrue(qltk.get_menu_item_top_parent(item) is None)
+        assert qltk.get_menu_item_top_parent(item) is None
 
     def test_show_uri_with_existing_window(self):
         PluginManager.instance = PluginManager()

--- a/tests/test_qltk_browser.py
+++ b/tests/test_qltk_browser.py
@@ -30,8 +30,8 @@ class TLibraryBrowser(TestCase):
     def test_open(self):
         self.library.librarian = SongLibrarian()
         widget = LibraryBrowser.open(TrackList, self.library, NullPlayer())
-        self.assertTrue(widget)
-        self.assertTrue(widget.get_visible())
+        assert widget
+        assert widget.get_visible()
         widget.destroy()
 
     def test_popup_menu(self):

--- a/tests/test_qltk_cbes.py
+++ b/tests/test_qltk_cbes.py
@@ -107,7 +107,7 @@ class TStandaloneEditor(TestCase):
         self.sae = StandaloneEditor(self.fname, "test", None, None)
 
     def test_constructor(self):
-        self.assertTrue(self.sae.model)
+        assert self.sae.model
         data = [(row[1], row[0]) for row in self.sae.model]
         self.assertEqual(data, self.TEST_KV_DATA)
 

--- a/tests/test_qltk_ccb.py
+++ b/tests/test_qltk_ccb.py
@@ -20,22 +20,22 @@ class TConfigCheckButton(TestCase):
         config.set("memory", "bar", "on")
         c = ConfigCheckButton("dummy", "memory", "bar")
         c.set_active(True)
-        self.assertTrue(config.getboolean("memory", "bar") and c.get_active())
+        assert config.getboolean("memory", "bar") and c.get_active()
         c.set_active(False)
         run_gtk_loop()
-        self.assertFalse(config.getboolean("memory", "bar") or c.get_active())
+        assert not config.getboolean("memory", "bar") or c.get_active()
 
     def test_populate(self):
         # Assert that active state works
         config.set("memory", "bar", "on")
         c = ConfigCheckButton("dummy", "memory", "bar", populate=True)
         run_gtk_loop()
-        self.assertTrue(c.get_active())
+        assert c.get_active()
         # ...and inactive
         config.set("memory", "bar", "off")
         c = ConfigCheckButton("dummy", "memory", "bar", populate=True)
         run_gtk_loop()
-        self.assertFalse(c.get_active())
+        assert not c.get_active()
 
 
 class TConfigCheckMenuItem(TestCase):
@@ -49,19 +49,19 @@ class TConfigCheckMenuItem(TestCase):
         config.set("memory", "bar", "on")
         c = ConfigCheckMenuItem("dummy", "memory", "bar")
         c.set_active(True)
-        self.assertTrue(config.getboolean("memory", "bar") and c.get_active())
+        assert config.getboolean("memory", "bar") and c.get_active()
         c.set_active(False)
         run_gtk_loop()
-        self.assertFalse(config.getboolean("memory", "bar") or c.get_active())
+        assert not config.getboolean("memory", "bar") or c.get_active()
 
     def test_populate(self):
         # Assert that active state works
         config.set("memory", "bar", "on")
         c = ConfigCheckMenuItem("dummy", "memory", "bar", populate=True)
         run_gtk_loop()
-        self.assertTrue(c.get_active())
+        assert c.get_active()
         # ...and inactive
         config.set("memory", "bar", "off")
         c = ConfigCheckMenuItem("dummy", "memory", "bar", populate=True)
         run_gtk_loop()
-        self.assertFalse(c.get_active())
+        assert not c.get_active()

--- a/tests/test_qltk_edittags.py
+++ b/tests/test_qltk_edittags.py
@@ -102,32 +102,32 @@ class TAudioFileGroup(TestCase):
 
     def test_multiple_values(self):
         group = AudioFileGroup([GroupSong(True), GroupSong(True)])
-        self.assertTrue(group.can_multiple_values() is True)
-        self.assertTrue(group.can_multiple_values("foo") is True)
+        assert group.can_multiple_values() is True
+        assert group.can_multiple_values("foo") is True
 
         group = AudioFileGroup([GroupSong(["ha"]), GroupSong(True)])
         self.assertEqual(group.can_multiple_values(), {"ha"})
-        self.assertFalse(group.can_multiple_values("foo"))
-        self.assertTrue(group.can_multiple_values("ha"))
+        assert not group.can_multiple_values("foo")
+        assert group.can_multiple_values("ha")
 
         group = AudioFileGroup([GroupSong(["foo", "ha"]), GroupSong(["ha"])])
         self.assertEqual(group.can_multiple_values(), {"ha"})
-        self.assertFalse(group.can_multiple_values("foo"))
-        self.assertTrue(group.can_multiple_values("ha"))
+        assert not group.can_multiple_values("foo")
+        assert group.can_multiple_values("ha")
 
     def test_can_change(self):
         group = AudioFileGroup(
             [GroupSong(can_change=True), GroupSong(can_change=True)])
-        self.assertTrue(group.can_change() is True)
-        self.assertTrue(group.can_change("foo") is True)
+        assert group.can_change() is True
+        assert group.can_change("foo") is True
 
         group = AudioFileGroup(
             [GroupSong(can_change=["foo", "ha"]),
              GroupSong(can_change=["ha"])])
         self.assertEqual(group.can_change(), {"ha"})
-        self.assertFalse(group.can_change("foo"))
-        self.assertTrue(group.can_change("ha"))
+        assert not group.can_change("foo")
+        assert group.can_change("ha")
 
         group = AudioFileGroup([GroupSong(), GroupSong(cant_change=["baz"])])
-        self.assertTrue(group.can_change())
-        self.assertFalse(group.can_change("baz"))
+        assert group.can_change()
+        assert not group.can_change("baz")

--- a/tests/test_qltk_entry.py
+++ b/tests/test_qltk_entry.py
@@ -19,7 +19,7 @@ class TEntry(TestCase):
             nat1 = e.get_preferred_width()[1]
             e.set_max_width_chars(40)
             nat2 = e.get_preferred_width()[1]
-            self.assertTrue(nat1 < nat2)
+            assert nat1 < nat2
 
 
 class TValidatingEntry(TestCase):
@@ -46,7 +46,7 @@ class TValidatingEntry(TestCase):
         entry = ValidatingEntry(valid)
         entry.set_text("foo")
         self.assertEqual(x, ["foo"])
-        self.assertTrue(isinstance(x[0], str))
+        assert isinstance(x[0], str)
 
     def tearDown(self):
         self.entry.destroy()

--- a/tests/test_qltk_exfalso.py
+++ b/tests/test_qltk_exfalso.py
@@ -17,7 +17,7 @@ class TExFalsoWindow(TestCase):
         self.ef = ExFalsoWindow(SongLibrary())
 
     def test_nothing(self):
-        self.assertTrue(self.ef.get_child())
+        assert self.ef.get_child()
 
     def tearDown(self):
         self.ef.destroy()

--- a/tests/test_qltk_filesel.py
+++ b/tests/test_qltk_filesel.py
@@ -70,7 +70,7 @@ class TDirectoryTree(TestCase):
             dirlist.destroy()
             # select the last valid parent directory
             self.assertEqual(len(selected), 1)
-            self.assertTrue(selected[0].startswith(path))
+            assert selected[0].startswith(path)
 
     def test_bad_go_to(self):
         newpath = fsnative("/woooooo/bar/fun/broken")
@@ -83,14 +83,14 @@ class TDirectoryTree(TestCase):
         if os.name == "nt":
             folders = ["C:\\"]
         main = MainDirectoryTree(folders=folders)
-        self.assertTrue(len(main.get_model()))
+        assert len(main.get_model())
 
         main = MainDirectoryTree()
-        self.assertTrue(len(main.get_model()))
+        assert len(main.get_model())
 
     def test_get_drives(self):
         for path in get_drives():
-            self.assertTrue(isinstance(path, fsnative))
+            assert isinstance(path, fsnative)
 
     def test_popup(self):
         dt = DirectoryTree(None, folders=self.ROOTS)
@@ -100,7 +100,7 @@ class TDirectoryTree(TestCase):
         self.assertEqual(len(children), 4)
         delete = children[1]
         self.assertEqual(delete.get_label(), __("_Delete"))
-        self.assertTrue(delete.get_sensitive())
+        assert delete.get_sensitive()
 
     def test_multiple_selections(self):
         dt = DirectoryTree(None, folders=self.ROOTS)
@@ -108,18 +108,16 @@ class TDirectoryTree(TestCase):
         dt._popup_menu(menu)
         children = menu.get_children()
         select_sub = children[3]
-        self.assertTrue("sub-folders" in select_sub.get_label().lower())
-        self.assertTrue(select_sub.get_sensitive())
+        assert "sub-folders" in select_sub.get_label().lower()
+        assert select_sub.get_sensitive()
         sel = dt.get_selection()
         model = dt.get_model()
         for it, _pth in model.iterrows(None):
             sel.select_iter(it)
-        self.assertTrue(select_sub.get_sensitive(),
-                        msg="Select All should work for multiple")
-        self.assertFalse(children[0].get_sensitive(),
-                    msg="New Folder should be disabled for multiple")
-        self.assertTrue(children[3].get_sensitive(),
-                        msg="Refresh should be enabled for multiple")
+        assert select_sub.get_sensitive(), "Select All should work for multiple"
+        msg = "New Folder should be disabled for multiple"
+        assert not children[0].get_sensitive(), msg
+        assert children[3].get_sensitive(), "Refresh should be enabled for multiple"
 
 
 class TFileSelector(TestCase):

--- a/tests/test_qltk_image.py
+++ b/tests/test_qltk_image.py
@@ -27,7 +27,7 @@ class TImageUtils(TestCase):
         rgb = GdkPixbuf.Colorspace.RGB
         newpb = GdkPixbuf.Pixbuf.new(rgb, True, 8, 10, 10)
         surface = get_surface_for_pixbuf(w, newpb)
-        self.assertTrue(isinstance(surface, cairo.Surface))
+        assert isinstance(surface, cairo.Surface)
 
     def test_scale(self):
         nw = scale(self.wide, (50, 30))

--- a/tests/test_qltk_information.py
+++ b/tests/test_qltk_information.py
@@ -80,7 +80,7 @@ class TInformation(TestCase):
         self.library.remove([f])
 
     def assert_child_is(self, cls):
-        self.assertTrue(isinstance(self.inf.get_child(), cls))
+        assert isinstance(self.inf.get_child(), cls)
 
 
 class TUtils(TestCase):

--- a/tests/test_qltk_lyrics.py
+++ b/tests/test_qltk_lyrics.py
@@ -60,10 +60,10 @@ class TLyricsPane(TestCase):
         os.makedirs(os.path.dirname(lf_name))
         with open(lf_name, "wb") as f:
             f.write(LYRICS.encode("utf-8"))
-        self.assertTrue(os.path.exists(lf_name))
+        assert os.path.exists(lf_name)
         self.pane = LyricsPane(af)
         self.pane._save_lyrics(af, LYRICS)
-        self.assertFalse(os.path.exists(lf_name))
+        assert not os.path.exists(lf_name)
 
     def temp_mp3(self):
         name = get_temp_copy(get_data_path("silence-44-s.mp3"))

--- a/tests/test_qltk_models.py
+++ b/tests/test_qltk_models.py
@@ -69,11 +69,11 @@ class _TObjectStoreMixin:
     def test_allow_nonatomic(self):
         m = self.Store()
         m.ATOMIC = False
-        self.assertTrue(m.insert(0))
-        self.assertTrue(m.prepend())
-        self.assertTrue(m.append())
-        self.assertTrue(m.insert_before(None))
-        self.assertTrue(m.insert_after(None))
+        assert m.insert(0)
+        assert m.prepend()
+        assert m.append()
+        assert m.insert_before(None)
+        assert m.insert_after(None)
 
 
 class TOrigObjectStore(TestCase, _TObjectStoreMixin):
@@ -184,11 +184,11 @@ class TObjectStore(TestCase, _TObjectStoreMixin):
 
     def test_is_empty(self):
         m = ObjectStore()
-        self.assertTrue(m.is_empty())
+        assert m.is_empty()
         iter_ = m.append(row=[1])
-        self.assertFalse(m.is_empty())
+        assert not m.is_empty()
         m.remove(iter_)
-        self.assertTrue(m.is_empty())
+        assert m.is_empty()
 
     def test_nonatomic(self):
         m = ObjectStore()
@@ -300,11 +300,11 @@ class _TObjectTreeStoreMixin:
     def test_allow_nonatomic(self):
         m = self.Store()
         m.ATOMIC = False
-        self.assertTrue(m.insert(None, 0))
-        self.assertTrue(m.prepend(None))
-        self.assertTrue(m.append(None))
-        self.assertTrue(m.insert_before(None, None))
-        self.assertTrue(m.insert_after(None, None))
+        assert m.insert(None, 0)
+        assert m.prepend(None)
+        assert m.append(None)
+        assert m.insert_before(None, None)
+        assert m.insert_after(None, None)
 
 
 class TOrigTreeStore(TestCase, _TObjectTreeStoreMixin):

--- a/tests/test_qltk_paned.py
+++ b/tests/test_qltk_paned.py
@@ -76,7 +76,7 @@ class TConfigRPaned(TestCase):
         config.quit()
 
     def test_basic(self):
-        self.assertTrue(config.get("memory", "foobar", None) is None)
+        assert config.get("memory", "foobar", None) is None
 
         p = ConfigRVPaned("memory", "foobar", 0.75)
         p.pack1(Gtk.Button())
@@ -176,7 +176,7 @@ class TConfigMultiRPaned:
         config.quit()
 
     def test_basic(self):
-        self.assertTrue(config.get("memory", "pane_widths", None) is None)
+        assert config.get("memory", "pane_widths", None) is None
 
         p = self.Kind("memory", "pane_widths")
         sws = [Gtk.ScrolledWindow() for _ in range(3)]

--- a/tests/test_qltk_playorder.py
+++ b/tests/test_qltk_playorder.py
@@ -29,10 +29,10 @@ class TPlayOrderWidget(TestCase):
         quodlibet.config.quit()
 
     def test_initial(self):
-        self.assertFalse(self.po.repeated)
-        self.assertFalse(self.po.shuffled)
-        self.assertTrue(isinstance(self.po.order, OrderInOrder))
-        self.assertTrue(self.replaygain_profiles[2], ["album", "track"])
+        assert not self.po.repeated
+        assert not self.po.shuffled
+        assert isinstance(self.po.order, OrderInOrder)
+        assert self.replaygain_profiles[2], ["album", "track"]
 
     def test_replay_gain(self):
         self.po.shuffled = True
@@ -48,11 +48,11 @@ class TPlayOrderWidget(TestCase):
             self.assertEqual(self.po.shuffler, order)
 
     def test_shuffle(self):
-        self.assertFalse(self.po.repeated)
+        assert not self.po.repeated
         self.po.shuffled = True
-        self.assertTrue(self.po.shuffled)
+        assert self.po.shuffled
         self.assertEqual(self.po.shuffler, OrderShuffle)
-        self.assertTrue(isinstance(self.order, OrderShuffle))
+        assert isinstance(self.order, OrderShuffle)
 
     def test_shuffle_defaults_to_inorder(self):
         self.po.shuffler = OrderWeighted
@@ -80,13 +80,13 @@ class TToggledPlayOrderMenu(TestCase):
         self.tpom.destroy()
 
     def test_enabled_initially(self):
-        self.assertTrue(self.tpom.enabled)
+        assert self.tpom.enabled
 
     def test_setting_enabled(self):
         self.tpom.enabled = False
-        self.assertFalse(self.tpom.enabled)
+        assert not self.tpom.enabled
         self.tpom.enabled = True
-        self.assertTrue(self.tpom.enabled)
+        assert self.tpom.enabled
 
     def test_initial(self):
         self.assertEqual(self.tpom.current, OrderShuffle)
@@ -105,8 +105,8 @@ class TToggledPlayOrderMenu(TestCase):
 
     def test_set_orders(self):
         self.tpom.set_orders([])
-        self.assertFalse(self.tpom.current)
+        assert not self.tpom.current
 
     def test_playorder_disables_when_order_disappears(self):
         self.tpom.orders = Orders([OrderWeighted, FakeOrder])
-        self.assertFalse(self.tpom.enabled)
+        assert not self.tpom.enabled

--- a/tests/test_qltk_queue.py
+++ b/tests/test_qltk_queue.py
@@ -86,11 +86,11 @@ class TQueueExpander(TestCase):
         widget.pause()
 
     def test_random_at_startup(self):
-        self.assertFalse(isinstance(self.queue.model.order, OrderShuffle))
+        assert not isinstance(self.queue.model.order, OrderShuffle)
         quodlibet.config.set("memory", "shufflequeue", True)
         self.queue = self.queue = QueueExpander(SongLibrary(), NullPlayer())
         # See issue #2411
-        self.assertTrue(isinstance(self.queue.model.order, OrderShuffle))
+        assert isinstance(self.queue.model.order, OrderShuffle)
 
     def tearDown(self):
         self.queue.destroy()

--- a/tests/test_qltk_ratingsmenu.py
+++ b/tests/test_qltk_ratingsmenu.py
@@ -51,7 +51,7 @@ class TRatingsMenuItem(TestCase):
 
     def test_set_remove_rating(self):
         self.rmi.set_rating(0.5, [self.af], self.library)
-        self.assertTrue(self.af.has_rating)
+        assert self.af.has_rating
         self.assertEqual(self.af("~#rating"), 0.5)
         self.rmi.remove_rating([self.af], self.library)
-        self.assertFalse(self.af.has_rating)
+        assert not self.af.has_rating

--- a/tests/test_qltk_renamefiles.py
+++ b/tests/test_qltk_renamefiles.py
@@ -34,7 +34,7 @@ class TFilterMixin:
         empty = fsnative("")
         v = self.c.filter(empty, "")
         self.assertEqual(v, "")
-        self.assertTrue(isinstance(v, str))
+        assert isinstance(v, str)
 
     def test_mix_safe(self):
         empty = fsnative("")
@@ -62,13 +62,13 @@ class TStripWindowsIncompat(TFilter, TFilterMixin):
 
     def test_type(self):
         empty = fsnative("")
-        self.assertTrue(isinstance(self.c.filter(empty, empty), fsnative))
+        assert isinstance(self.c.filter(empty, empty), fsnative)
 
     def test_ends_with_dots_or_spaces(self):
         empty = fsnative("")
         v = self.c.filter(empty, fsnative("foo. . "))
         self.assertEqual(v, fsnative("foo. ._"))
-        self.assertTrue(isinstance(v, fsnative))
+        assert isinstance(v, fsnative)
 
         if os.name == "nt":
             self.assertEqual(
@@ -102,7 +102,7 @@ class TReplaceColons(TFilter, TFilterMixin):
 
     def test_type(self):
         empty = fsnative("")
-        self.assertTrue(isinstance(self.c.filter(empty, empty), fsnative))
+        assert isinstance(self.c.filter(empty, empty), fsnative)
 
     def conv(self, s: str):
         return self.c.filter(fsnative(""), s)
@@ -120,7 +120,7 @@ class TStripDiacriticals(TFilter, TFilterMixin):
         out = "A test"
         v = self.c.filter(empty, test)
         self.assertEqual(v, out)
-        self.assertTrue(isinstance(v, str))
+        assert isinstance(v, str)
 
 
 class TStripNonASCII(TFilter, TFilterMixin):
@@ -132,7 +132,7 @@ class TStripNonASCII(TFilter, TFilterMixin):
         out = "foo _ _"
         v = self.c.filter(empty, in_)
         self.assertEqual(v, out)
-        self.assertTrue(isinstance(v, str))
+        assert isinstance(v, str)
 
 
 class TLowercase(TFilter, TFilterMixin):
@@ -143,11 +143,11 @@ class TLowercase(TFilter, TFilterMixin):
 
         v = self.c.filter(empty, fsnative("foobar baz"))
         self.assertEqual(v, fsnative("foobar baz"))
-        self.assertTrue(isinstance(v, fsnative))
+        assert isinstance(v, fsnative)
 
         v = self.c.filter(empty, fsnative("Foobar.BAZ"))
         self.assertEqual(v, fsnative("foobar.baz"))
-        self.assertTrue(isinstance(v, fsnative))
+        assert isinstance(v, fsnative)
 
 
 class Renamer(Gtk.EventBox):

--- a/tests/test_qltk_searchbar.py
+++ b/tests/test_qltk_searchbar.py
@@ -13,7 +13,7 @@ class TSearchBarBox(TestCase):
 
     def test_get_query(self):
         sbb = SearchBarBox()
-        self.assertFalse(sbb.get_query(None))
+        assert not sbb.get_query(None)
         a_star = ["artist", "date", "custom"]
         sbb.set_text("foobar")
         expected = Query("foobar", star=a_star)

--- a/tests/test_qltk_songlist.py
+++ b/tests/test_qltk_songlist.py
@@ -97,9 +97,9 @@ class TSongList(TestCase):
         s = self.songlist
         s.set_column_headers(["foo"])
         s.toggle_column_sort(s.get_columns()[0], replace=True)
-        self.assertTrue(s.get_sort_orders())
+        assert s.get_sort_orders()
         s.clear_sort()
-        self.assertFalse(s.get_sort_orders())
+        assert not s.get_sort_orders()
 
     def test_not_sortable(self):
         config.set("song_list", "always_allow_sorting", False)
@@ -123,13 +123,13 @@ class TSongList(TestCase):
 
     def test_find_default_sort_column(self):
         s = self.songlist
-        self.assertTrue(s.find_default_sort_column() is None)
+        assert s.find_default_sort_column() is None
         s.set_column_headers(["~#track"])
-        self.assertTrue(s.find_default_sort_column())
+        assert s.find_default_sort_column()
 
     def test_inline_search_state(self):
         self.assertEqual(self.songlist.get_search_column(), 0)
-        self.assertTrue(self.songlist.get_enable_search())
+        assert self.songlist.get_enable_search()
 
     def test_set_songs(self):
         self.songlist.set_songs([], sorted=True)
@@ -216,31 +216,31 @@ class TSongList(TestCase):
 
         self.songlist.set_column_headers(["foo"])
 
-        self.assertFalse(self.songlist.menu("foo", browser, library))
+        assert not self.songlist.menu("foo", browser, library)
         sel = self.songlist.get_selection()
         sel.select_all()
-        self.assertTrue(self.songlist.menu("foo", browser, library))
+        assert self.songlist.menu("foo", browser, library)
         librarian.destroy()
         self.lib.librarian = None
 
     def test_get_columns_migrated(self):
-        self.assertFalse(config.get("settings", "headers", None))
+        assert not config.get("settings", "headers", None)
         columns = "~album,~#replaygain_track_gain,foobar"
         config.set("settings", "columns", columns)
         self.assertEqual(get_columns(),
                              ["~album", "~#replaygain_track_gain", "foobar"])
-        self.assertFalse(config.get("settings", "headers", None))
+        assert not config.get("settings", "headers", None)
 
     def test_get_set_columns(self):
-        self.assertFalse(config.get("settings", "headers", None))
-        self.assertFalse(config.get("settings", "columns", None))
+        assert not config.get("settings", "headers", None)
+        assert not config.get("settings", "columns", None)
         columns = ["first", "won't", "two words", "4"]
         set_columns(columns)
         self.assertEqual(columns, get_columns())
         columns += ["~~another~one"]
         set_columns(columns)
         self.assertEqual(columns, get_columns())
-        self.assertFalse(config.get("settings", "headers", None))
+        assert not config.get("settings", "headers", None)
 
     def test_header_tag_split(self):
         self.assertEqual(header_tag_split("foo"), ["foo"])

--- a/tests/test_qltk_songmodel.py
+++ b/tests/test_qltk_songmodel.py
@@ -26,16 +26,16 @@ class TPlaylistModel(TestCase):
         self.pl = PlaylistModel()
         self.pl.set(range(10))
         do_events()
-        self.assertTrue(self.pl.current is None)
+        assert self.pl.current is None
 
     def test_current_recover(self):
         self.pl.set(range(10))
         self.pl.next()
         self.assertEqual(self.pl.current, 0)
         self.pl.set(range(20, 30))
-        self.assertTrue(self.pl.current is None)
+        assert self.pl.current is None
         self.pl.current_iter = self.pl.current_iter
-        self.assertTrue(self.pl.current is None)
+        assert self.pl.current is None
         self.pl.set(range(10))
         self.assertEqual(self.pl.current, 0)
 
@@ -48,9 +48,9 @@ class TPlaylistModel(TestCase):
         self.assertEqual(self.pl.current, 4)
 
     def test_isempty(self):
-        self.assertFalse(self.pl.is_empty())
+        assert not self.pl.is_empty()
         self.pl.clear()
-        self.assertTrue(self.pl.is_empty())
+        assert self.pl.is_empty()
 
     def test_get(self):
         self.assertEqual(self.pl.get(), list(range(10)))
@@ -66,13 +66,13 @@ class TPlaylistModel(TestCase):
         self.pl.go_to(9)
         self.assertEqual(self.pl.current, 9)
         self.pl.next()
-        self.assertTrue(self.pl.current is None)
+        assert self.pl.current is None
 
     def test_find(self):
         self.assertEqual(self.pl[self.pl.find(8)][0], 8)
 
     def test_find_not_there(self):
-        self.assertTrue(self.pl.find(22) is None)
+        assert self.pl.find(22) is None
 
     def test_find_all(self):
         to_find = [1, 4, 5, 8, 9]
@@ -82,10 +82,10 @@ class TPlaylistModel(TestCase):
 
     def test_find_all_duplicates(self):
         # ignore duplicates in parameters
-        self.assertTrue(len(self.pl.find_all([1, 1])), 1)
+        assert len(self.pl.find_all([1, 1])), 1
         # but find duplicates
         self.pl.set([1, 1])
-        self.assertTrue(len(self.pl.find_all([1])), 2)
+        assert len(self.pl.find_all([1])), 2
 
     def test_find_all_some_missing(self):
         to_find = [1, 4, 18, 5, 8, 9, -1]
@@ -101,9 +101,9 @@ class TPlaylistModel(TestCase):
         self.assertEqual(iters, [])
 
     def test_contains(self):
-        self.assertTrue(1 in self.pl)
-        self.assertTrue(8 in self.pl)
-        self.assertFalse(22 in self.pl)
+        assert 1 in self.pl
+        assert 8 in self.pl
+        assert 22 not in self.pl
 
     def test_removal(self):
         self.pl.go_to(8)
@@ -284,7 +284,7 @@ class TPlaylistMux(TestCase):
         self.p = NullPlayer()
         self.mux = PlaylistMux(self.p, self.q, self.pl)
         self.p.setup(self.mux, None, 0)
-        self.assertTrue(self.pl.current is None)
+        assert self.pl.current is None
         quodlibet.config.init()
 
     def test_destroy(self):
@@ -293,35 +293,35 @@ class TPlaylistMux(TestCase):
     def test_only_pl(self):
         self.pl.set(range(10))
         do_events()
-        self.assertTrue(self.mux.current is None)
+        assert self.mux.current is None
         songs = [self.next() for i in range(10)]
         self.assertEqual(songs, list(range(10)))
         self.next()
-        self.assertTrue(self.mux.current is None)
+        assert self.mux.current is None
 
     def test_only_q(self):
         self.q.set(range(10))
         do_events()
-        self.assertTrue(self.mux.current is None)
+        assert self.mux.current is None
         songs = [self.next() for i in range(10)]
         self.assertEqual(songs, list(range(10)))
         self.next()
-        self.assertTrue(self.mux.current is None)
+        assert self.mux.current is None
 
     def test_mixed(self):
         self.q.set(range(5))
         self.pl.set(range(5, 10))
         do_events()
-        self.assertTrue(self.mux.current is None)
+        assert self.mux.current is None
         songs = [self.next() for i in range(10)]
         self.assertEqual(songs, list(range(10)))
         self.next()
-        self.assertTrue(self.mux.current is None)
+        assert self.mux.current is None
 
     def test_newplaylist(self):
         self.pl.set(range(5, 10))
         do_events()
-        self.assertTrue(self.mux.current is None)
+        assert self.mux.current is None
         self.mux.go_to(7)
         self.assertEqual(self.mux.current, 7)
         self.pl.set([3, 5, 12, 11])
@@ -338,7 +338,7 @@ class TPlaylistMux(TestCase):
     def test_halfway(self):
         self.pl.set(range(10))
         do_events()
-        self.assertTrue(self.mux.current is None)
+        assert self.mux.current is None
         songs = [self.next() for i in range(5)]
         self.q.set(range(100, 105))
         do_events()
@@ -346,7 +346,7 @@ class TPlaylistMux(TestCase):
         self.assertEqual(
             songs, [0, 1, 2, 3, 4, 100, 101, 102, 103, 104, 5, 6, 7, 8, 9])
         self.next()
-        self.assertTrue(self.mux.current is None)
+        assert self.mux.current is None
 
     def test_removal(self):
         self.pl.set(range(0, 5))
@@ -391,7 +391,7 @@ class TPlaylistMux(TestCase):
         self.pl.set(range(10))
         self.q.set(range(10, 20))
         do_events()
-        self.assertTrue(self.mux.current is None)
+        assert self.mux.current is None
         self.mux.go_to(5)
         self.assertEqual(self.mux.current, 5)
         self.mux.go_to(2)
@@ -406,9 +406,9 @@ class TPlaylistMux(TestCase):
             self.mux.go_to(None)
             self.pl.set([1])
             do_events()
-            self.assertTrue(self.mux.current is None)
+            assert self.mux.current is None
             self.q.order = OrderShuffle()
-            self.assertTrue(self.next() == 1)
+            assert self.next() == 1
             self.q.set([10, 11])
             do_events()
             value = self.next()
@@ -424,15 +424,15 @@ class TPlaylistMux(TestCase):
         self.pl.set(range(10))
         self.q.set(range(10))
         self.mux.go_to(None)
-        self.assertTrue(self.pl.sourced)
+        assert self.pl.sourced
         self.q.go_to(1)
         self.p.next()
-        self.assertFalse(self.pl.sourced)
+        assert not self.pl.sourced
 
     def test_unqueue(self):
         self.q.set(range(100))
         self.mux.unqueue(range(100))
-        self.assertFalse(len(self.q))
+        assert not len(self.q)
 
     def test_queue(self):
         self.mux.enqueue(range(40))
@@ -450,7 +450,7 @@ class TPlaylistMux(TestCase):
         self.pl.set(range(20, 30))
         self.q.set(range(10))
         self.mux.go_to(self.q[-1].iter, source=self.q)
-        self.assertTrue(self.q.sourced)
+        assert self.q.sourced
         self.assertEqual(self.mux.current, self.q[-1][0])
 
     def test_queue_disable(self):
@@ -461,13 +461,13 @@ class TPlaylistMux(TestCase):
         self.next()
         self.assertEqual(len(self.pl.get()), len(range(10)))
         self.assertEqual(len(self.q.get()), len(range(10)))
-        self.assertTrue(self.pl.sourced)
+        assert self.pl.sourced
 
         quodlibet.config.set("memory", "queue_disable", False)
         self.next()
         self.assertEqual(len(self.pl.get()), len(range(10)))
         self.assertEqual(len(self.q.get()), len(range(10)) - 1)
-        self.assertTrue(self.q.sourced)
+        assert self.q.sourced
 
     def test_queue_disable_next(self):
         self.pl.set(range(10))
@@ -476,7 +476,7 @@ class TPlaylistMux(TestCase):
         self.mux.go_to(self.q[0].iter, source=self.q)
         quodlibet.config.set("memory", "queue_disable", True)
         self.next()
-        self.assertTrue(self.pl.sourced)
+        assert self.pl.sourced
 
     def test_queue_disable_prev(self):
         self.pl.set(range(10))
@@ -485,7 +485,7 @@ class TPlaylistMux(TestCase):
         self.mux.go_to(self.q[0].iter, source=self.q)
         quodlibet.config.set("memory", "queue_disable", True)
         self.previous()
-        self.assertTrue(self.pl.sourced)
+        assert self.pl.sourced
 
     def test_queue_keep_songs(self):
         self.q.set(range(10))
@@ -503,7 +503,7 @@ class TPlaylistMux(TestCase):
         quodlibet.config.set("memory", "queue_keep_songs", False)
         self.next()
         self.assertEqual(len(self.q.get()), len(range(10)) - 1)
-        self.assertTrue(self.q.current is None)
+        assert self.q.current is None
 
     def test_queue_disable_and_keep_songs(self):
         self.pl.set(range(10))
@@ -514,7 +514,7 @@ class TPlaylistMux(TestCase):
         quodlibet.config.set("memory", "queue_keep_songs", True)
 
         self.next()
-        self.assertTrue(self.pl.sourced)
+        assert self.pl.sourced
 
     def test_queue_preserved_when_setexplicit_rejected(self):
         class TestOrder(Order):
@@ -525,9 +525,9 @@ class TPlaylistMux(TestCase):
         self.pl.order = TestOrder()
         self.q.set(range(10))
         self.mux.go_to(self.q[0].iter, source=self.q)
-        self.assertTrue(self.q.sourced)
+        assert self.q.sourced
         self.mux.go_to(self.pl[0].iter, explicit=True, source=self.pl)
-        self.assertTrue(self.q.sourced)
+        assert self.q.sourced
         self.assertEqual(self.mux.current, self.q[0][0])
 
     def tearDown(self):

--- a/tests/test_qltk_songsmenu.py
+++ b/tests/test_qltk_songsmenu.py
@@ -42,7 +42,7 @@ class TSongsMenu(TestCase):
 
     def test_empty(self):
         self.menu = self.empty_menu_with()
-        self.assertFalse(len(self.menu))
+        assert not len(self.menu)
 
     def test_simple(self):
         self.menu = SongsMenu(self.library, self.songs, plugins=False)
@@ -50,58 +50,58 @@ class TSongsMenu(TestCase):
     def test_playlists(self):
         self.menu = self.empty_menu_with(playlists=True)
         self.assertEqual(len(self.menu), 1)
-        self.assertTrue(self.menu.get_children()[0].props.sensitive)
+        assert self.menu.get_children()[0].props.sensitive
 
         self.songs[0].can_add = False
         self.menu = self.empty_menu_with(playlists=True)
         self.assertEqual(len(self.menu), 1)
-        self.assertFalse(self.menu.get_children()[0].props.sensitive)
+        assert not self.menu.get_children()[0].props.sensitive
 
     def test_queue(self):
         self.menu = self.empty_menu_with(queue=True)
         self.assertEqual(len(self.menu), 1)
-        self.assertTrue(self.menu.get_children()[0].props.sensitive)
+        assert self.menu.get_children()[0].props.sensitive
 
         self.songs[0].can_add = False
         self.menu = self.empty_menu_with(queue=True)
         self.assertEqual(len(self.menu), 1)
-        self.assertFalse(self.menu.get_children()[0].props.sensitive)
+        assert not self.menu.get_children()[0].props.sensitive
 
     def test_remove(self):
         self.menu = self.empty_menu_with(remove=True,
                                          removal_confirmer=self._confirmer)
         self.assertEqual(len(self.menu), 1)
         item = self.menu.get_children()[0]
-        self.assertFalse(item.props.sensitive)
+        assert not item.props.sensitive
         item.activate()
-        self.assertTrue(self.confirmed, "Should have confirmed song removal")
+        assert self.confirmed, "Should have confirmed song removal"
 
     def test_remove_sensitive(self):
         self.library.add(self.songs)
         self.menu = self.empty_menu_with(remove=True)
         self.assertEqual(len(self.menu), 1)
-        self.assertTrue(self.menu.get_children()[0].props.sensitive)
+        assert self.menu.get_children()[0].props.sensitive
 
     def test_delete(self):
         self.menu = self.empty_menu_with(delete=True)
         self.assertEqual(len(self.menu), 1)
-        self.assertTrue(self.menu.get_children()[0].props.sensitive)
+        assert self.menu.get_children()[0].props.sensitive
 
         self.songs[0].is_file = False
         self.menu = self.empty_menu_with(delete=True)
-        self.assertFalse(self.menu.get_children()[0].props.sensitive)
+        assert not self.menu.get_children()[0].props.sensitive
 
     def test_show_files(self):
         self.menu = self.empty_menu_with(show_files=True)
         self.assertEqual(len(self.menu), 1)
-        self.assertTrue(self.menu.get_children()[0].props.sensitive)
+        assert self.menu.get_children()[0].props.sensitive
         item = self.menu.get_children()[0]
-        self.assertTrue(item.props.sensitive)
+        assert item.props.sensitive
 
     def test_show_files_remote_songs(self):
         self.songs = self.library.songs = [an_rf(1)]
         self.menu = self.empty_menu_with(show_files=True)
-        self.assertFalse(len(self.menu))
+        assert not len(self.menu)
 
     def test_show_files_too_many_songs(self):
         self.songs = self.library.songs = [an_af(i) for i in range(50)]

--- a/tests/test_qltk_textedit.py
+++ b/tests/test_qltk_textedit.py
@@ -38,7 +38,7 @@ class TTextEditBox2(TestCase):
 
     def test_revert(self):
         self.foobar.revert.clicked()
-        self.assertTrue(self.foobar.text, "foobar")
+        assert self.foobar.text, "foobar"
 
     def tearDown(self):
         self.foobar.destroy()

--- a/tests/test_qltk_tracker.py
+++ b/tests/test_qltk_tracker.py
@@ -46,14 +46,14 @@ class TSongTracker(TestCase):
         t = time.time()
         self.assertEqual(self.s1["~#playcount"], 1)
         self.assertEqual(self.s1["~#skipcount"], 0)
-        self.assertTrue(t - self.s1["~#lastplayed"] <= 1)
+        assert t - self.s1["~#lastplayed"] <= 1
 
     def test_skip(self):
         self.p.emit("song-ended", self.s1, True)
         run_gtk_loop()
         self.assertEqual(self.s1["~#playcount"], 0)
         self.assertEqual(self.s1["~#skipcount"], 1)
-        self.assertTrue(self.s1["~#lastplayed"], 10)
+        assert self.s1["~#lastplayed"], 10
 
     def test_error(self):
         self.current = self.p.song = self.s1
@@ -61,7 +61,7 @@ class TSongTracker(TestCase):
         run_gtk_loop()
         self.assertEqual(self.s1["~#playcount"], 0)
         self.assertEqual(self.s1["~#skipcount"], 0)
-        self.assertTrue(self.s1["~#lastplayed"], 10)
+        assert self.s1["~#lastplayed"], 10
 
     def test_restart(self):
         self.current = self.s1
@@ -92,20 +92,20 @@ class TFSInterface(TestCase):
 
     def test_init(self):
         run_gtk_loop()
-        self.assertFalse(os.path.exists(self.filename))
+        assert not os.path.exists(self.filename)
 
     def test_start(self):
         self.p.emit("song_started", self.song)
         run_gtk_loop()
         with open(self.filename, "rb") as h:
-            self.assertTrue(b"title=bar\n" in h.read())
+            assert b"title=bar\n" in h.read()
 
     def test_song_ended(self):
         self.p.emit("song-started", self.song)
         run_gtk_loop()
         self.p.emit("song-ended", {}, False)
         run_gtk_loop()
-        self.assertFalse(os.path.exists(self.filename))
+        assert not os.path.exists(self.filename)
 
     def test_elapsed(self):
         self.p.seek(123456)

--- a/tests/test_qltk_views.py
+++ b/tests/test_qltk_views.py
@@ -38,7 +38,7 @@ class THintedTreeView(TestCase):
         self.c = AllTreeView()
 
     def test_exists(self):
-        self.assertTrue(self.c)
+        assert self.c
 
     def tearDown(self):
         self.c.destroy()
@@ -61,19 +61,19 @@ class TBaseView(TestCase):
         self.m.append(row=["foo"])
         self.c.get_selection().set_mode(Gtk.SelectionMode.MULTIPLE)
         self.c.get_selection().select_all()
-        self.assertTrue(events)
+        assert events
 
     def test_remove(self):
         self.m.append(row=["foo"])
         self.c.remove_iters([self.m[0].iter])
-        self.assertFalse(len(self.m))
+        assert not len(self.m)
 
         self.m.append(row=["foo"])
         self.c.remove_iters([])
-        self.assertTrue(len(self.m))
+        assert len(self.m)
 
         self.c.remove_paths([self.m[0].path])
-        self.assertFalse(len(self.m))
+        assert not len(self.m)
 
     def test_key_events(self):
         with visible(self.c):
@@ -83,33 +83,33 @@ class TBaseView(TestCase):
     def test_select_func(self):
         self.m.append(row=["foo"])
         self.m.append(row=["bar"])
-        self.assertTrue(self.c.select_by_func(lambda r: True))
-        self.assertFalse(self.c.select_by_func(lambda r: False))
+        assert self.c.select_by_func(lambda r: True)
+        assert not self.c.select_by_func(lambda r: False)
         self.c.select_by_func(lambda r: False, scroll=False, one=True)
 
     def test_iter_select_func(self):
         # empty
-        self.assertFalse(self.c.iter_select_by_func(lambda r: False))
-        self.assertFalse(self.c.iter_select_by_func(lambda r: True))
+        assert not self.c.iter_select_by_func(lambda r: False)
+        assert not self.c.iter_select_by_func(lambda r: True)
 
         self.m.append(row=["foo"])
         self.m.append(row=["bar"])
         self.m.append(row=["foo"])
         self.c.remove_selection()
-        self.assertTrue(self.c.iter_select_by_func(lambda r: r[0] == "foo"))
+        assert self.c.iter_select_by_func(lambda r: r[0] == "foo")
         selection = self.c.get_selection()
         model, iter_ = selection.get_selected()
         self.assertEqual(model.get_path(iter_)[:], [0])
-        self.assertTrue(self.c.iter_select_by_func(lambda r: r[0] == "foo"))
+        assert self.c.iter_select_by_func(lambda r: r[0] == "foo")
         model, iter_ = selection.get_selected()
         self.assertEqual(model.get_path(iter_)[:], [2])
-        self.assertTrue(self.c.iter_select_by_func(lambda r: r[0] == "foo"))
+        assert self.c.iter_select_by_func(lambda r: r[0] == "foo")
         model, iter_ = selection.get_selected()
         self.assertEqual(model.get_path(iter_)[:], [0])
-        self.assertTrue(self.c.iter_select_by_func(lambda r: r[0] == "bar"))
+        assert self.c.iter_select_by_func(lambda r: r[0] == "bar")
         model, iter_ = selection.get_selected()
         self.assertEqual(model.get_path(iter_)[:], [1])
-        self.assertFalse(self.c.iter_select_by_func(lambda r: r[0] == "bar"))
+        assert not self.c.iter_select_by_func(lambda r: r[0] == "bar")
 
     def test_remove_select_single(self):
         # empty
@@ -158,11 +158,11 @@ class TBaseView(TestCase):
 
         with self.c.without_model() as model:
             self.assertEqual(model, self.m)
-            self.assertTrue(self.c.get_model() is None)
+            assert self.c.get_model() is None
 
         self.assertEqual(self.c.get_search_column(), 0)
         column = self.c.get_columns()[0]
-        self.assertTrue(column.get_sort_indicator())
+        assert column.get_sort_indicator()
 
     def test_set_drag_dest(self):
         x, y = self.c.convert_bin_window_to_widget_coords(0, 0)
@@ -171,7 +171,7 @@ class TBaseView(TestCase):
         self.c.unset_rows_drag_dest()
         self.c.set_drag_dest(x, y)
         path, pos = self.c.get_drag_dest_row()
-        self.assertTrue(path is None)
+        assert path is None
 
         # filled model but not realized, fall back to last path
         model = _fill_view(self.c)
@@ -231,7 +231,7 @@ class TRCMTreeView(TestCase):
             # the popup only shows if the underlying row is selected,
             # so select all first
             selection.select_all()
-            self.assertTrue(self.c.popup_menu(menu, Gdk.BUTTON_SECONDARY, 0))
+            assert self.c.popup_menu(menu, Gdk.BUTTON_SECONDARY, 0)
 
 
 class TDragIconTreeView(TestCase):
@@ -244,10 +244,10 @@ class TDragIconTreeView(TestCase):
         model = self.c.get_model()
         all_paths = [row.path for row in model]
 
-        self.assertFalse(self.c.create_multi_row_drag_icon(all_paths, 1))
+        assert not self.c.create_multi_row_drag_icon(all_paths, 1)
         with visible(self.c):
-            self.assertTrue(self.c.create_multi_row_drag_icon(all_paths, 1))
-            self.assertFalse(self.c.create_multi_row_drag_icon([], 1))
+            assert self.c.create_multi_row_drag_icon(all_paths, 1)
+            assert not self.c.create_multi_row_drag_icon([], 1)
             self.assertTrue(
                 self.c.create_multi_row_drag_icon([all_paths[0]], 10))
 

--- a/tests/test_qltk_window.py
+++ b/tests/test_qltk_window.py
@@ -38,25 +38,25 @@ class TWindow(TestCase):
                 super().__init__()
                 self._register_instance()
 
-        self.assertFalse(SomeWindow.windows)
+        assert not SomeWindow.windows
         other = Window()
         a = SomeWindow()
-        self.assertTrue(a in SomeWindow.windows)
-        self.assertTrue(a in SomeWindow.instances())
+        assert a in SomeWindow.windows
+        assert a in SomeWindow.instances()
         a.destroy()
-        self.assertFalse(SomeWindow.instances())
-        self.assertTrue(SomeWindow.windows)
+        assert not SomeWindow.instances()
+        assert SomeWindow.windows
         other.destroy()
-        self.assertFalse(SomeWindow.windows)
+        assert not SomeWindow.windows
 
     def test_show_maybe(self):
         Window.prevent_inital_show(True)
         w = Window()
         w.show_maybe()
-        self.assertFalse(w.get_visible())
+        assert not w.get_visible()
         Window.prevent_inital_show(False)
         w.show_maybe()
-        self.assertTrue(w.get_visible())
+        assert w.get_visible()
         w.destroy()
 
     def test_use_header_bar(self):

--- a/tests/test_qltk_wlw.py
+++ b/tests/test_qltk_wlw.py
@@ -55,10 +55,10 @@ class TWaitLoadWindow(TestCase):
         self.assertEqual(self.wlw.count, 5)
 
     def test_step(self):
-        self.assertFalse(self.wlw.step())
+        assert not self.wlw.step()
         self.assertEqual(self.wlw.current, 1)
-        self.assertFalse(self.wlw.step())
-        self.assertFalse(self.wlw.step())
+        assert not self.wlw.step()
+        assert not self.wlw.step()
         self.assertEqual(self.wlw.current, 3)
 
     def test_destroy(self):

--- a/tests/test_qltk_x.py
+++ b/tests/test_qltk_x.py
@@ -25,7 +25,7 @@ class Notebook(TestCase):
         n = x.Notebook()
         c = Gtk.VBox()
         n.append_page(c, l)
-        self.assertTrue(l is n.get_tab_label(c))
+        assert l is n.get_tab_label(c)
         c.destroy()
 
     def test_widget_error(self):
@@ -44,12 +44,12 @@ class Frame(TestCase):
 
 class MenuItem(TestCase):
     def test_ctr(self):
-        self.assertTrue(x.MenuItem("foo", Icons.EDIT_FIND))
+        assert x.MenuItem("foo", Icons.EDIT_FIND)
 
 
 class Button(TestCase):
     def test_ctr(self):
-        self.assertTrue(x.Button("foo", Icons.EDIT_FIND))
+        assert x.Button("foo", Icons.EDIT_FIND)
 
 
 class TAlign(TestCase):
@@ -60,7 +60,7 @@ class TAlign(TestCase):
         self.assertEqual(a.get_margin_bottom(), 0)
         self.assertEqual(a.get_margin_left(), 4)
         self.assertEqual(a.get_margin_right(), 6)
-        self.assertTrue(a.get_child() is button)
+        assert a.get_child() is button
         a.destroy()
 
 

--- a/tests/test_soundcloud_file.py
+++ b/tests/test_soundcloud_file.py
@@ -44,12 +44,12 @@ class TSoundcloudFile(TestCase):
     def test_favoriting(self):
         client = self.client
         song = SoundcloudFile("http://uri", TRACK_ID, client, favorite=False)
-        self.assertFalse(song.has_rating)
+        assert not song.has_rating
         song["~#rating"] = 1.0
-        self.assertTrue(song.has_rating)
+        assert song.has_rating
         self.assertEqual(song("~#rating"), 1.0)
         song.write()
-        self.assertTrue(song.favorite)
+        assert song.favorite
         self.assertEqual(client.favoritings[TRACK_ID], 1)
         self.assertEqual(client.unfavoritings[TRACK_ID], 0)
         song.write()
@@ -58,11 +58,11 @@ class TSoundcloudFile(TestCase):
     def test_unfavoriting(self):
         client = self.client
         song = SoundcloudFile("http://uri", TRACK_ID, client, favorite=True)
-        self.assertTrue(song.has_rating)
+        assert song.has_rating
         self.assertEqual(song("~#rating"), 1.0)
         song["~#rating"] = 0.2
         song.write()
-        self.assertFalse(song.favorite)
+        assert not song.favorite
         self.assertEqual(client.unfavoritings[TRACK_ID], 1)
         self.assertEqual(client.favoritings[TRACK_ID], 0)
         song.write()

--- a/tests/test_unisearch.py
+++ b/tests/test_unisearch.py
@@ -28,7 +28,7 @@ class TUniSearch(TestCase):
 
     def test_re_replace(self):
         r = re_add_variants("aa")
-        self.assertTrue("[" in r and "]" in r and r.count("ä") == 2)
+        assert "[" in r and "]" in r and r.count("ä") == 2
 
     def test_re_replace_multi(self):
         r = re_add_variants("ae")

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -47,12 +47,12 @@ class Tmkdir(TestCase):
         self.assertRaises(OSError, mkdir, __file__)
 
     def test_manydeep(self):
-        self.assertTrue(not os.path.isdir("nonext"))
+        assert not os.path.isdir("nonext")
         t = tempfile.mkdtemp()
         path = os.path.join(t, "nonext", "test", "test2", "test3")
         mkdir(path)
         try:
-            self.assertTrue(os.path.isdir(path))
+            assert os.path.isdir(path)
         finally:
             os.rmdir(path)
             path = os.path.dirname(path)
@@ -67,7 +67,7 @@ class Tmkdir(TestCase):
 class Tgetcwd(TestCase):
 
     def test_getcwd(self):
-        self.assertTrue(isinstance(os.getcwd(), fsnative))
+        assert isinstance(os.getcwd(), fsnative)
 
 
 class Tmtime(TestCase):
@@ -75,7 +75,7 @@ class Tmtime(TestCase):
         self.assertEqual(mtime("."), os.path.getmtime("."))
 
     def test_bad(self):
-        self.assertFalse(os.path.exists("/dev/doesnotexist"))
+        assert not os.path.exists("/dev/doesnotexist")
         self.assertEqual(mtime("/dev/doesnotexist"), 0)
 
 
@@ -209,11 +209,11 @@ class Tpango(TestCase):
 class Tre_esc(TestCase):
     def test_empty(self):
         self.assertEqual(re_escape(b""), b"")
-        self.assertTrue(isinstance(re_escape(b""), bytes))
+        assert isinstance(re_escape(b""), bytes)
 
     def test_empty_unicode(self):
         self.assertEqual(re_escape(""), "")
-        self.assertTrue(isinstance(re_escape(""), str))
+        assert isinstance(re_escape(""), str)
 
     def test_safe(self):
         self.assertEqual(re_escape("fo o"), "fo o")
@@ -278,22 +278,22 @@ class Thuman_sort(TestCase):
 
         self.assertEqual(self.smaller("bbb", "zzz3"), True)
 
-        self.assertTrue(self.equal(" foo", "foo"))
-        self.assertTrue(self.equal(" ", ""))
-        self.assertTrue(self.smaller("", "."))
-        self.assertTrue(self.smaller("a", "b"))
-        self.assertTrue(self.smaller("A", "b"))
+        assert self.equal(" foo", "foo")
+        assert self.equal(" ", "")
+        assert self.smaller("", ".")
+        assert self.smaller("a", "b")
+        assert self.smaller("A", "b")
 
     def test_false(self):
         # album browser needs that to sort albums without artist/title
         # to the bottom
-        self.assertFalse(util.human_sort_key(""))
+        assert not util.human_sort_key("")
 
     def test_white(self):
         self.assertEqual(
             util.human_sort_key("  3foo    bar6 42.8"),
             util.human_sort_key("3 foo bar6  42.8  "))
-        self.assertTrue(64.0 in util.human_sort_key("64. 8"))
+        assert 64.0 in util.human_sort_key("64. 8")
 
 
 class Tformat_time(TestCase):
@@ -366,22 +366,22 @@ class Tdate_key(TestCase):
 
     def test_compare(self):
         date_key = util.date_key
-        self.assertTrue(date_key("2004") == date_key("2004-01-01"))
-        self.assertTrue(date_key("2004") == date_key("2004-01"))
-        self.assertTrue(date_key("2004") < date_key("2004-01-02"))
-        self.assertTrue(date_key("2099-02-02") < date_key("2099-03-30"))
+        assert date_key("2004") == date_key("2004-01-01")
+        assert date_key("2004") == date_key("2004-01")
+        assert date_key("2004") < date_key("2004-01-02")
+        assert date_key("2099-02-02") < date_key("2099-03-30")
 
-        self.assertTrue(date_key("2004-01-foo") == date_key("2004-01"))
+        assert date_key("2004-01-foo") == date_key("2004-01")
 
     def test_validate(self):
         validate = util.validate_query_date
 
         for valid in ["2004", "2005-01", "3000-3-4"]:
-            self.assertTrue(validate(valid))
+            assert validate(valid)
 
         for invalid in ["", "-", "3000-", "9-0", "8-1-0", "1-13-1", "1-1-32",
                         "1-1-1-1-1", "a", "1-a", "1-1-a"]:
-            self.assertFalse(validate(invalid))
+            assert not validate(invalid)
 
 
 class Tformat_size(TestCase):
@@ -607,7 +607,7 @@ class Tspawn(TestCase):
     def test_simple(self):
         if is_win:
             return
-        self.assertTrue(util.spawn(["ls", "."], stdout=True))
+        assert util.spawn(["ls", "."], stdout=True)
 
     def test_invalid(self):
         from gi.repository import GLib
@@ -649,24 +649,24 @@ class Txdg_dirs(TestCase):
     def test_parse_xdg_user_dirs(self):
         data = b'# foo\nBLA="$HOME/blah"\n'
         vars_ = parse_xdg_user_dirs(data)
-        self.assertTrue(b"BLA" in vars_)
+        assert b"BLA" in vars_
         expected = os.path.join(os.environ.get("HOME", ""), "blah")
         self.assertEqual(vars_[b"BLA"], expected)
 
         vars_ = parse_xdg_user_dirs(b'BLA="$HOME/"')
-        self.assertTrue(b"BLA" in vars_)
+        assert b"BLA" in vars_
         self.assertEqual(vars_[b"BLA"], os.environ.get("HOME", ""))
 
         # some invalid
-        self.assertFalse(parse_xdg_user_dirs(b"foo"))
-        self.assertFalse(parse_xdg_user_dirs(b"foo=foo bar"))
-        self.assertFalse(parse_xdg_user_dirs(b"foo='foo"))
+        assert not parse_xdg_user_dirs(b"foo")
+        assert not parse_xdg_user_dirs(b"foo=foo bar")
+        assert not parse_xdg_user_dirs(b"foo='foo")
 
     def test_on_windows(self):
-        self.assertTrue(xdg_get_system_data_dirs())
-        self.assertTrue(xdg_get_cache_home())
-        self.assertTrue(xdg_get_data_home())
-        self.assertTrue(xdg_get_config_home())
+        assert xdg_get_system_data_dirs()
+        assert xdg_get_cache_home()
+        assert xdg_get_data_home()
+        assert xdg_get_config_home()
 
 
 class Tlibrary(TestCase):
@@ -677,7 +677,7 @@ class Tlibrary(TestCase):
         config.quit()
 
     def test_basic(self):
-        self.assertFalse(get_scan_dirs())
+        assert not get_scan_dirs()
         if os.name == "nt":
             set_scan_dirs(["C:\\foo", "D:\\bar", ""])
             self.assertEqual(get_scan_dirs(), ["C:\\foo", "D:\\bar"])
@@ -752,17 +752,17 @@ class Tescape_filename(TestCase):
     def test_str(self):
         result = escape_filename("\x00\x01")
         self.assertEqual(result, "%00%01")
-        self.assertTrue(isinstance(result, fsnative))
+        assert isinstance(result, fsnative)
 
     def test_unicode(self):
         result = escape_filename("abc\xe4")
         self.assertEqual(result, "abc%C3%A4")
-        self.assertTrue(isinstance(result, fsnative))
+        assert isinstance(result, fsnative)
 
     def test_safe_chars(self):
         result = escape_filename("1, 2, and -3", safe=" -")
         self.assertEqual(result, "1%2C 2%2C and -3")
-        self.assertTrue(isinstance(result, fsnative))
+        assert isinstance(result, fsnative)
 
 
 @skipIf(is_win, "not on Windows")
@@ -777,10 +777,10 @@ class Tload_library(TestCase):
         self.assertEqual(name, "c")
 
         lib2, name = util.load_library(["c"])
-        self.assertTrue(lib is lib2)
+        assert lib is lib2
 
         lib3, name = util.load_library(["c"], shared=False)
-        self.assertTrue(lib2 is not lib3)
+        assert lib2 is not lib3
 
     def test_glib(self):
         if sys.platform == "darwin":
@@ -789,21 +789,21 @@ class Tload_library(TestCase):
             fn = "libglib-2.0.so.0"
         lib, name = util.load_library([fn])
         self.assertEqual(name, fn)
-        self.assertTrue(lib)
+        assert lib
 
 
 class Tstrip_win32_incompat_from_path(TestCase):
 
     def test_types(self):
         v = strip_win32_incompat_from_path(fsnative(""))
-        self.assertTrue(isinstance(v, fsnative))
+        assert isinstance(v, fsnative)
         v = strip_win32_incompat_from_path(fsnative("foo"))
-        self.assertTrue(isinstance(v, fsnative))
+        assert isinstance(v, fsnative)
 
         v = strip_win32_incompat_from_path("")
-        self.assertTrue(isinstance(v, str))
+        assert isinstance(v, str)
         v = strip_win32_incompat_from_path("foo")
-        self.assertTrue(isinstance(v, str))
+        assert isinstance(v, str)
 
     def test_basic(self):
         if is_win:
@@ -818,10 +818,10 @@ class TPathHandling(TestCase):
 
     def test_main(self):
         v = fsnative("foo")
-        self.assertTrue(isinstance(v, fsnative))
+        assert isinstance(v, fsnative)
 
         v3 = bytes2fsn(fsn2bytes(v, "utf-8"), "utf-8")
-        self.assertTrue(isinstance(v3, fsnative))
+        assert isinstance(v3, fsnative)
         self.assertEqual(v, v3)
 
 
@@ -830,7 +830,7 @@ class Tget_temp_cover_file(TestCase):
     def test_main(self):
         fobj = get_temp_cover_file(b"foobar")
         try:
-            self.assertTrue(isinstance(fobj.name, fsnative))
+            assert isinstance(fobj.name, fsnative)
         finally:
             fobj.close()
 
@@ -862,24 +862,24 @@ class Tsplit_escape(TestCase):
     def test_types(self):
         parts = split_escape(b"\xff:\xff", b":")
         self.assertEqual(parts, [b"\xff", b"\xff"])
-        self.assertTrue(isinstance(parts[0], bytes))
+        assert isinstance(parts[0], bytes)
 
         parts = split_escape("a:b", ":")
         self.assertEqual(parts, ["a", "b"])
-        self.assertTrue(all(isinstance(p, str) for p in parts))
+        assert all(isinstance(p, str) for p in parts)
 
         parts = split_escape("", ":")
         self.assertEqual(parts, [""])
-        self.assertTrue(all(isinstance(p, str) for p in parts))
+        assert all(isinstance(p, str) for p in parts)
 
         parts = split_escape(":", ":")
         self.assertEqual(parts, ["", ""])
-        self.assertTrue(all(isinstance(p, str) for p in parts))
+        assert all(isinstance(p, str) for p in parts)
 
     def test_join_escape_types(self):
         self.assertEqual(join_escape([], b":"), b"")
-        self.assertTrue(isinstance(join_escape([], b":"), bytes))
-        self.assertTrue(isinstance(join_escape([], ":"), str))
+        assert isinstance(join_escape([], b":"), bytes)
+        assert isinstance(join_escape([], ":"), str)
         self.assertEqual(join_escape([b"\xff", b"\xff"], b":"), b"\xff:\xff")
         self.assertEqual(join_escape(["\xe4", "\xe4"], ":"), "\xe4:\xe4")
 
@@ -968,7 +968,7 @@ class TMainRunner(TestCase):
         loop = GLib.MainLoop()
 
         def func(i):
-            self.assertTrue(util.is_main_thread())
+            assert util.is_main_thread()
             return i + 1
 
         def worker():
@@ -1028,9 +1028,9 @@ class Tcached_property(TestCase):
 
         a = A()
         first = a.foo
-        self.assertTrue(first is a.foo)
+        assert first is a.foo
         del a.__dict__["foo"]
-        self.assertFalse(first is a.foo)
+        assert first is not a.foo
 
     def test_dunder(self):
 
@@ -1060,15 +1060,15 @@ class Tenum(TestCase):
             FOO = 0
             BAR = 1
 
-        self.assertTrue(issubclass(IntFoo, int))
-        self.assertTrue(isinstance(IntFoo.BAR, IntFoo))
-        self.assertTrue(isinstance(IntFoo.FOO, IntFoo))
+        assert issubclass(IntFoo, int)
+        assert isinstance(IntFoo.BAR, IntFoo)
+        assert isinstance(IntFoo.FOO, IntFoo)
         self.assertEqual(IntFoo.FOO, 0)
         self.assertEqual(IntFoo.BAR, 1)
 
     def test_str(self):
-        self.assertTrue(issubclass(Foo, str))
-        self.assertTrue(isinstance(Foo.BAR, Foo))
+        assert issubclass(Foo, str)
+        assert isinstance(Foo.BAR, Foo)
         self.assertEqual(Foo.FOO, "blah")
         self.assertEqual(repr(Foo.BAR), "Foo.BAR")
 
@@ -1105,10 +1105,10 @@ class Treraise(TestCase):
             except Exception as e:
                 util.reraise(TypeError, e)
         except Exception as e:
-            self.assertTrue(isinstance(e, TypeError))
-            self.assertTrue("ValueError" in traceback.format_exc())
+            assert isinstance(e, TypeError)
+            assert "ValueError" in traceback.format_exc()
         else:
-            self.assertTrue(False)
+            raise AssertionError()
 
 
 class Tenviron(TestCase):
@@ -1116,22 +1116,22 @@ class Tenviron(TestCase):
     def test_main(self):
         for v in os.environ.values():
             if os.name == "nt":
-                self.assertTrue(isinstance(v, str))
+                assert isinstance(v, str)
             else:
-                self.assertTrue(isinstance(v, str))
+                assert isinstance(v, str)
 
 
 class Tget_module_dir(TestCase):
 
     def test_self(self):
         path = util.get_module_dir()
-        self.assertTrue(isinstance(path, fsnative))
-        self.assertTrue(os.path.exists(path))
+        assert isinstance(path, fsnative)
+        assert os.path.exists(path)
 
     def test_other(self):
         path = util.get_module_dir(util)
-        self.assertTrue(isinstance(path, fsnative))
-        self.assertTrue(os.path.exists(path))
+        assert isinstance(path, fsnative)
+        assert os.path.exists(path)
 
 
 class Tget_ca_file(TestCase):
@@ -1139,8 +1139,8 @@ class Tget_ca_file(TestCase):
     def test_main(self):
         path = util.get_ca_file()
         if path is not None:
-            self.assertTrue(isinstance(path, fsnative))
-            self.assertTrue(os.path.exists(path))
+            assert isinstance(path, fsnative)
+            assert os.path.exists(path)
 
 
 class Tprint_exc(TestCase):
@@ -1189,12 +1189,12 @@ class Textract_tb(TestCase):
             1 / 0  # noqa
         except Exception:
             result = extract_tb(sys.exc_info()[2])
-            self.assertTrue(isinstance(result, list))
+            assert isinstance(result, list)
             for fn, l, fu, text in result:
-                self.assertTrue(isinstance(fn, fsnative))
-                self.assertTrue(isinstance(l, int))
-                self.assertTrue(isinstance(fu, str))
-                self.assertTrue(isinstance(text, str))
+                assert isinstance(fn, fsnative)
+                assert isinstance(l, int)
+                assert isinstance(fu, str)
+                assert isinstance(text, str)
 
 
 def test_capture_output():

--- a/tests/test_util_atomic.py
+++ b/tests/test_util_atomic.py
@@ -35,7 +35,7 @@ class Tatomic_save(TestCase):
         with open(filename, "rb") as fobj:
             self.assertEqual(fobj.read(), b"foo")
 
-        self.assertFalse(os.path.exists(temp_name))
+        assert not os.path.exists(temp_name)
         self.assertEqual(os.listdir(self.dir), [os.path.basename(filename)])
 
     def test_non_exist(self):
@@ -48,7 +48,7 @@ class Tatomic_save(TestCase):
         with open(filename, "rb") as fobj:
             self.assertEqual(fobj.read(), b"foo")
 
-        self.assertFalse(os.path.exists(temp_name))
+        assert not os.path.exists(temp_name)
         self.assertEqual(os.listdir(self.dir), [os.path.basename(filename)])
 
     def test_readonly(self):
@@ -95,8 +95,8 @@ class Tatomic_save(TestCase):
         with open(filename, "rb") as fobj:
             self.assertEqual(fobj.read(), b"foo")
 
-        self.assertFalse(os.path.exists(temp_name))
+        assert not os.path.exists(temp_name)
         self.assertEqual(
             sorted(os.listdir(self.dir)),
             sorted([os.path.basename(filename), os.path.basename(symlink)]))
-        self.assertTrue(os.path.islink(symlink))
+        assert os.path.islink(symlink)

--- a/tests/test_util_collection.py
+++ b/tests/test_util_collection.py
@@ -415,30 +415,30 @@ class TPlaylist(TestCase):
             pl.append(AMAZING_SONG)
 
             new_rating = pl.get("~#filesize")
-            self.assertTrue(new_rating > old_rating)
+            assert new_rating > old_rating
 
     def test_updating_aggregates_clear(self):
         with self.wrap("playlist") as pl:
             pl.extend(NUMERIC_SONGS)
-            self.assertTrue(pl.get("~#length"))
+            assert pl.get("~#length")
 
             pl.clear()
-            self.assertFalse(pl.get("~#length"))
+            assert not pl.get("~#length")
 
     def test_updating_aggregates_remove_songs(self):
         with self.wrap("playlist") as pl:
             pl.extend(NUMERIC_SONGS)
-            self.assertTrue(pl.get("~#length"))
+            assert pl.get("~#length")
 
             pl.remove_songs(NUMERIC_SONGS)
-            self.assertFalse(pl.get("~#length"))
+            assert not pl.get("~#length")
 
     def test_listlike(self):
         with self.wrap("playlist") as pl:
             pl.extend(NUMERIC_SONGS)
             self.assertEqual(NUMERIC_SONGS[0], pl[0])
             self.assertEqual(NUMERIC_SONGS[1:2], pl[1:2])
-            self.assertTrue(NUMERIC_SONGS[1] in pl)
+            assert NUMERIC_SONGS[1] in pl
 
     def test_extend_signals(self):
         with self.wrap("playlist") as pl:
@@ -459,7 +459,7 @@ class TPlaylist(TestCase):
 
     def test_make(self):
         with self.wrap("Does not exist") as pl:
-            self.assertFalse(len(pl))
+            assert not len(pl)
             self.assertEqual(pl.name, "Does not exist")
 
     def test_rename_working(self):
@@ -468,7 +468,7 @@ class TPlaylist(TestCase):
             pl.rename("Foo Quuxly")
             assert pl.name == "Foo Quuxly"
             # Rename should not fire signals
-            self.assertFalse(self.FAKE_LIB.changed)
+            assert not self.FAKE_LIB.changed
 
     def test_rename_nothing(self):
         with self.wrap("Foobar") as pl:
@@ -482,9 +482,9 @@ class TPlaylist(TestCase):
     def test_duplicates_single_item(self):
         with self.wrap("playlist") as pl:
             pl.append(self.TWO_SONGS[0])
-            self.assertFalse(pl.has_duplicates)
+            assert not pl.has_duplicates
             pl.append(self.TWO_SONGS[0])
-            self.assertTrue(pl.has_duplicates)
+            assert pl.has_duplicates
 
     def test_duplicates(self):
         with self.wrap("playlist") as pl:
@@ -503,16 +503,16 @@ class TPlaylist(TestCase):
             self.assertEqual(len(self.FAKE_LIB.changed), 7)
             self.FAKE_LIB.reset()
             pl.remove_songs(self.TWO_SONGS, leave_dupes=True)
-            self.assertTrue(first in pl)
-            self.assertTrue(second in pl)
-            self.assertFalse(len(self.FAKE_LIB.changed))
+            assert first in pl
+            assert second in pl
+            assert not len(self.FAKE_LIB.changed)
 
     def test_remove_fully(self):
         with self.wrap("playlist") as pl:
             pl.extend(self.TWO_SONGS * 2)
             self.FAKE_LIB.reset()
             pl.remove_songs(self.TWO_SONGS, leave_dupes=False)
-            self.assertFalse(len(pl))
+            assert not len(pl)
             self.assertEqual(self.FAKE_LIB.changed, self.TWO_SONGS)
 
 
@@ -586,7 +586,7 @@ class TFileBackedPlaylist(TPlaylist):
         p1 = self.new_pl("Does not exist")
         p2 = self.new_pl("Does not exist")
         self.assertEqual(p1.name, "Does not exist")
-        self.assertTrue(p2.name.startswith("Does not exist"))
+        assert p2.name.startswith("Does not exist")
         self.assertNotEqual(p1.name, p2.name)
         p1.delete()
         p2.delete()
@@ -594,8 +594,8 @@ class TFileBackedPlaylist(TPlaylist):
     def test_rename_removes(self):
         with self.wrap("foo") as pl:
             pl.rename("bar")
-            self.assertTrue(exists(self.path_for("bar")))
-            self.assertFalse(exists(self.path_for("foo")))
+            assert exists(self.path_for("bar"))
+            assert not exists(self.path_for("foo"))
 
     def path_for(self, name: str):
         return os.path.join(self.temp, self.Playlist.filename_for(name))
@@ -621,7 +621,7 @@ class TFileBackedPlaylist(TPlaylist):
             lib.mask("/")
             pl.append(song)
             pl.remove_songs([song])
-            self.assertTrue("/fake" in pl)
+            assert "/fake" in pl
 
             pl.extend(self.TWO_SONGS)
 
@@ -631,7 +631,7 @@ class TFileBackedPlaylist(TPlaylist):
             # unmask and update
             lib.unmask("/")
             pl.add_songs(["/fake"], lib)
-            self.assertTrue(song in pl)
+            assert song in pl
 
             lib.destroy()
 

--- a/tests/test_util_collections.py
+++ b/tests/test_util_collections.py
@@ -20,10 +20,10 @@ class TDictMixin(TestCase):
         self.assertRaises(KeyError, self.fdict.__getitem__, "bar")
 
     def test_has_key_contains(self):
-        self.assertTrue("foo" in self.fdict)
-        self.assertFalse("bar" in self.fdict)
-        self.assertTrue(self.fdict.has_key("foo"))
-        self.assertFalse(self.fdict.has_key("bar"))
+        assert "foo" in self.fdict
+        assert "bar" not in self.fdict
+        assert self.fdict.has_key("foo")
+        assert not self.fdict.has_key("bar")
 
     def test_iter(self):
         self.assertEqual(list(iter(self.fdict)), ["foo"])
@@ -31,7 +31,7 @@ class TDictMixin(TestCase):
     def test_clear(self):
         self.fdict.clear()
         self.rdict.clear()
-        self.assertFalse(self.fdict)
+        assert not self.fdict
 
     def test_keys(self):
         self.assertEqual(list(self.fdict.keys()), list(self.rdict.keys()))
@@ -96,10 +96,10 @@ class TDictMixin(TestCase):
 class THashedList(TestCase):
     def test_init(self):
         l = HashedList([1, 2, 3])
-        self.assertTrue(1 in l)
+        assert 1 in l
 
         l = HashedList()
-        self.assertFalse(1 in l)
+        assert 1 not in l
 
     def test_length(self):
         l = HashedList([1, 2, 3, 3])
@@ -112,11 +112,11 @@ class THashedList(TestCase):
 
     def test_delete(self):
         l = HashedList([2, 2])
-        self.assertTrue(2 in l)
+        assert 2 in l
         del l[0]
-        self.assertTrue(2 in l)
+        assert 2 in l
         del l[0]
-        self.assertFalse(2 in l)
+        assert 2 not in l
 
     def test_iter(self):
         l = HashedList([1, 2, 3, 3])
@@ -127,27 +127,27 @@ class THashedList(TestCase):
         l = HashedList([1, 2, 3, 3])
         del l[1:3]
         self.assertEqual(len(l), 2)
-        self.assertTrue(1 in l)
-        self.assertTrue(3 in l)
-        self.assertFalse(2 in l)
+        assert 1 in l
+        assert 3 in l
+        assert 2 not in l
 
     def test_set_slice(self):
         l = HashedList([1, 2, 3, 3])
         l[:3] = [4]
-        self.assertTrue(4 in l)
-        self.assertTrue(3 in l)
-        self.assertFalse(2 in l)
+        assert 4 in l
+        assert 3 in l
+        assert 2 not in l
 
     def test_extend(self):
         l = HashedList()
         l.extend([1, 1, 2])
-        self.assertTrue(1 in l)
+        assert 1 in l
         self.assertEqual(len(l), 3)
 
     def test_duplicates(self):
         l = HashedList()
-        self.assertFalse(l.has_duplicates())
+        assert not l.has_duplicates()
         l = HashedList(range(10))
-        self.assertFalse(l.has_duplicates())
+        assert not l.has_duplicates()
         l.append(5)
-        self.assertTrue(l.has_duplicates())
+        assert l.has_duplicates()

--- a/tests/test_util_config.py
+++ b/tests/test_util_config.py
@@ -37,14 +37,14 @@ class TConfig(TestCase):
 
     def test_has_section(self):
         conf = Config()
-        self.assertFalse(conf.has_section("foo"))
+        assert not conf.has_section("foo")
         conf.defaults.add_section("foo")
-        self.assertTrue(conf.has_section("foo"))
+        assert conf.has_section("foo")
         conf.add_section("foo")
         conf.defaults.clear()
-        self.assertTrue(conf.has_section("foo"))
+        assert conf.has_section("foo")
         conf.clear()
-        self.assertFalse(conf.has_section("foo"))
+        assert not conf.has_section("foo")
 
     def test_read_garbage_file(self):
         conf = Config()
@@ -148,7 +148,7 @@ class TConfig(TestCase):
         conf = Config()
         conf.add_section("foo")
         conf.set("foo", "bla", "xx;,,;\n\n\naa")
-        self.assertTrue(conf.getboolean("foo", "bla", True))
+        assert conf.getboolean("foo", "bla", True)
         self.assertEqual(conf.getint("foo", "bla", 42), 42)
         self.assertEqual(conf.getfloat("foo", "bla", 1.5), 1.5)
         self.assertEqual(conf.getstringlist("foo", "bla", ["baz"]), ["baz"])
@@ -172,7 +172,7 @@ class TConfig(TestCase):
         conf = Config()
         conf.add_section("foo")
 
-        self.assertFalse(conf.get("foo", "bar", None))
+        assert not conf.get("foo", "bar", None)
         vals = ["one", "two", "three"]
         conf.setstringlist("foo", "bar", vals)
         self.assertEqual(conf.getstringlist("foo", "bar"), vals)
@@ -181,7 +181,7 @@ class TConfig(TestCase):
         conf = Config()
         conf.add_section("foo")
 
-        self.assertFalse(conf.get("foo", "bar", None))
+        assert not conf.get("foo", "bar", None)
         conf.setstringlist("foo", "bar", ["one", 2])
         self.assertEqual(conf.getstringlist("foo", "bar"), ["one", "2"])
 
@@ -189,7 +189,7 @@ class TConfig(TestCase):
         conf = Config()
         conf.add_section("foo")
 
-        self.assertFalse(conf.get("foo", "bar", None))
+        assert not conf.get("foo", "bar", None)
         vals = ["foo's gold", "bar, \"best\" 'ever'",
                 "le goût d'œufs à Noël"]
         conf.setstringlist("foo", "bar", vals)
@@ -288,7 +288,7 @@ class TConfig(TestCase):
         conf = Config(version=41)
 
         def func(*args):
-            self.assertTrue(False)
+            raise AssertionError()
         conf.register_upgrade_function(func)
         conf.read(filename)
 

--- a/tests/test_util_cover.py
+++ b/tests/test_util_cover.py
@@ -43,7 +43,7 @@ class TCoverManager(TestCase):
         self.song = self.an_album_song()
 
         # Safety check
-        self.assertFalse(glob.glob(os.path.join(self.dir + "*.jpg")))
+        assert not glob.glob(os.path.join(self.dir + "*.jpg"))
         files = [self.full_path("12345.jpg"), self.full_path("nothing.jpg")]
         for f in files:
             open(f, "w").close()
@@ -66,10 +66,10 @@ class TCoverManager(TestCase):
         return os.path.join(self.dir, path)
 
     def test_dir_not_exist(self):
-        self.assertFalse(self._find_cover(bar_2_1))
+        assert not self._find_cover(bar_2_1)
 
     def test_nothing(self):
-        self.assertFalse(self._find_cover(self.song))
+        assert not self._find_cover(self.song)
 
     def test_labelid(self):
         self.song["labelid"] = "12345"
@@ -88,7 +88,7 @@ class TCoverManager(TestCase):
 
     def test_file_encoding(self):
         f = self.add_file(fsnative("öäü - Quuxly - cover.jpg"))
-        self.assertTrue(isinstance(self.song("album"), str))
+        assert isinstance(self.song("album"), str)
         h = self._find_cover(self.song)
         assert h, "Nothing found"
         self.assertEqual(normalize_path(h.name), normalize_path(f))
@@ -208,14 +208,14 @@ class TCoverManager(TestCase):
                    "The Composer - The Conductor, The Performer - foobar.jpg"]:
             f = self.add_file(fn)
             cover = self._find_cover(song)
-            self.assertTrue(cover)
+            assert cover
             actual = os.path.abspath(cover.name)
             cover.close()
             assert path_equal(
                 actual, f, f'"{f}" should trump "{actual}"')
 
     def test_get_thumbnail(self):
-        self.assertTrue(self.manager.get_pixbuf(self.song, 10, 10) is None)
+        assert self.manager.get_pixbuf(self.song, 10, 10) is None
         self.assertTrue(
             self.manager.get_pixbuf_many([self.song], 10, 10) is None)
 

--- a/tests/test_util_dbusutils.py
+++ b/tests/test_util_dbusutils.py
@@ -41,33 +41,33 @@ class TDbusUtils(TestCase):
 
     def test_prop_sig(self):
         value = apply_signature(2, "u")
-        self.assertTrue(isinstance(value, dbus.UInt32))
+        assert isinstance(value, dbus.UInt32)
 
         value = apply_signature({"a": "b"}, "a{ss}")
         self.assertEqual(value.signature, "ss")
-        self.assertTrue(isinstance(value, dbus.Dictionary))
+        assert isinstance(value, dbus.Dictionary)
 
         value = apply_signature(("a",), "a(s)")
         self.assertEqual(value.signature, "s")
-        self.assertTrue(isinstance(value, dbus.Struct))
+        assert isinstance(value, dbus.Struct)
 
         value = apply_signature(("a", "b"), "as")
         self.assertEqual(value.signature, "s")
-        self.assertTrue(isinstance(value, dbus.Array))
+        assert isinstance(value, dbus.Array)
 
         self.assertRaises(TypeError, apply_signature, 2, "a(s)")
 
         text = b"\xc3\xb6\xc3\xa4\xc3\xbc"
         value = apply_signature(text, "s", utf8_strings=True)
-        self.assertTrue(isinstance(value, str))
+        assert isinstance(value, str)
         value = apply_signature(text, "s")
-        self.assertTrue(isinstance(value, str))
+        assert isinstance(value, str)
 
         text = "öäü"
         value = apply_signature(text, "s", utf8_strings=True)
-        self.assertTrue(isinstance(value, str))
+        assert isinstance(value, str)
         value = apply_signature(text, "s")
-        self.assertTrue(isinstance(value, str))
+        assert isinstance(value, str)
 
     def test_list_props(self):
         props = list_spec_properties(ANN1)
@@ -120,10 +120,10 @@ class TDbusUtils(TestCase):
         x.implement_interface("a1", "a2")
 
         props = x.get_properties("a1")
-        self.assertTrue(("a1", "Position") in props)
-        self.assertTrue(("a2", "XXX") in props)
+        assert ("a1", "Position") in props
+        assert ("a2", "XXX") in props
         props = x.get_properties("a2")
-        self.assertFalse(("a1", "Position") in props)
+        assert ("a1", "Position") not in props
 
         self.assertEqual(x.get_interface("a2", "XXX"), "a2")
         self.assertEqual(x.get_interface("a1", "XXX"), "a2")

--- a/tests/test_util_environment.py
+++ b/tests/test_util_environment.py
@@ -13,13 +13,13 @@ from quodlibet.util import is_unity, is_windows, is_osx
 class TUtilEnvironment(TestCase):
 
     def test_all(self):
-        self.assertTrue(isinstance(is_unity(), bool))
-        self.assertTrue(isinstance(is_windows(), bool))
-        self.assertTrue(isinstance(is_osx(), bool))
+        assert isinstance(is_unity(), bool)
+        assert isinstance(is_windows(), bool)
+        assert isinstance(is_osx(), bool)
 
     def test_constrains(self):
         if is_windows():
-            self.assertFalse(is_osx())
+            assert not is_osx()
 
         if is_osx():
-            self.assertFalse(is_windows())
+            assert not is_windows()

--- a/tests/test_util_fifo.py
+++ b/tests/test_util_fifo.py
@@ -56,9 +56,9 @@ class TFIFO(TestCase):
 
         with temp_filename() as fn:
             fifo = FIFO(fn, cb)
-            self.assertFalse(fifo_exists(fifo._path))
+            assert not fifo_exists(fifo._path)
             fifo.open()
-            self.assertTrue(fifo_exists(fifo._path))
+            assert fifo_exists(fifo._path)
         # Should *not* error if file is gone
         fifo.destroy()
 

--- a/tests/test_util_i18n.py
+++ b/tests/test_util_i18n.py
@@ -46,30 +46,30 @@ class TGlibTranslations(TestCase):
     def test_ugettext(self):
         t = self.t.ugettext("foo")
         self.assertEqual(t, "foo")
-        self.assertTrue(isinstance(t, str))
+        assert isinstance(t, str)
 
     def test_ungettext(self):
         t = self.t.ungettext("foo", "bar", 1)
         self.assertEqual(t, "foo")
-        self.assertTrue(isinstance(t, str))
+        assert isinstance(t, str)
 
         t = self.t.ungettext("foo", "bar", 2)
         self.assertEqual(t, "bar")
-        self.assertTrue(isinstance(t, str))
+        assert isinstance(t, str)
 
     def test_upgettext(self):
         t = self.t.upgettext("ctx", "foo")
         self.assertEqual(t, "foo")
-        self.assertTrue(isinstance(t, str))
+        assert isinstance(t, str)
 
     def test_unpgettext(self):
         t = self.t.unpgettext("ctx", "foo", "bar", 1)
         self.assertEqual(t, "foo")
-        self.assertTrue(isinstance(t, str))
+        assert isinstance(t, str)
 
         t = self.t.unpgettext("ctx", "foo", "bar", 2)
         self.assertEqual(t, "bar")
-        self.assertTrue(isinstance(t, str))
+        assert isinstance(t, str)
 
 
 class Tgettext(TestCase):

--- a/tests/test_util_massagers.py
+++ b/tests/test_util_massagers.py
@@ -13,13 +13,13 @@ class TMassagers(TestCase):
     def validate(self, key, values):
         massager = Massager.for_tag(key)
         for val in values:
-            self.assertTrue(massager.is_valid(val))
+            assert massager.is_valid(val)
             self.assertTrue(
                 isinstance(massager.validate(str(val)), str))
 
     def invalidate(self, key, values):
         for val in values:
-            self.assertFalse(Massager.for_tag(key).is_valid(val))
+            assert not Massager.for_tag(key).is_valid(val)
 
     def equivs(self, key, equivs):
         massager = Massager.for_tag(key)
@@ -34,17 +34,17 @@ class TMassagers(TestCase):
         self.assertEqual(validate("date", "2000"), "2000")
 
     def test_is_valid_helper(self):
-        self.assertTrue(is_valid("foo", "bar"))
-        self.assertFalse(is_valid("date", "bar"))
-        self.assertTrue(is_valid("date", "2000"))
+        assert is_valid("foo", "bar")
+        assert not is_valid("date", "bar")
+        assert is_valid("date", "2000")
 
     def test_error_message_helper(self):
-        self.assertFalse(error_message("foo", "bar"))
-        self.assertTrue(error_message("date", "2000"))
+        assert not error_message("foo", "bar")
+        assert error_message("date", "2000")
 
     def test_get_options_helper(self):
-        self.assertFalse(get_options("foo"))
-        self.assertTrue(get_options("language"))
+        assert not get_options("foo")
+        assert get_options("language")
 
     def test_date_valid(self):
         self.validate("date", ["2002-10-12", "2000", "1200-10", "0000-00-00",
@@ -118,4 +118,4 @@ class TMassagers(TestCase):
         for code in ["eng", "fra", "fre", "deu", "zho"]:
             self.assertTrue(code in mas.options,
                 "'%s' should be in languages options" % code)
-        self.assertFalse("" in mas.options)
+        assert "" not in mas.options

--- a/tests/test_util_modulescanner.py
+++ b/tests/test_util_modulescanner.py
@@ -90,9 +90,9 @@ class TModuleScanner(TestCase):
         self._create_mod("q1.py").close()
         self._create_mod("q2.py").close()
         s = ModuleScanner([self.d])
-        self.assertFalse(s.modules)
+        assert not s.modules
         removed, added = s.rescan()
-        self.assertFalse(removed)
+        assert not removed
         self.assertEqual(set(added), {"q1", "q2"})
         self.assertEqual(len(s.modules), 2)
         self.assertEqual(len(s.failures), 0)
@@ -100,10 +100,10 @@ class TModuleScanner(TestCase):
     def test_unimportable_package(self):
         self._create_pkg("_foobar").close()
         s = ModuleScanner([self.d])
-        self.assertFalse(s.modules)
+        assert not s.modules
         removed, added = s.rescan()
-        self.assertFalse(added)
-        self.assertFalse(removed)
+        assert not added
+        assert not removed
 
     def test_scanner_remove(self):
         h = self._create_mod("q3.py")
@@ -116,7 +116,7 @@ class TModuleScanner(TestCase):
         except OSError:
             pass
         removed, added = s.rescan()
-        self.assertFalse(added)
+        assert not added
         self.assertEqual(removed, ["q3"])
         self.assertEqual(len(s.modules), 0)
         self.assertEqual(len(s.failures), 0)
@@ -127,10 +127,10 @@ class TModuleScanner(TestCase):
         h.close()
         s = ModuleScanner([self.d])
         removed, added = s.rescan()
-        self.assertFalse(added)
-        self.assertFalse(removed)
+        assert not added
+        assert not removed
         self.assertEqual(len(s.failures), 1)
-        self.assertTrue("q4" in s.failures)
+        assert "q4" in s.failures
 
     def test_scanner_add_package(self):
         h = self._create_pkg("somepkg")

--- a/tests/test_util_path.py
+++ b/tests/test_util_path.py
@@ -46,11 +46,11 @@ class Turi(TestCase):
     def test_uri2fsn(self):
         if os.name != "nt":
             path = uri2fsn("file:///home/piman/cr%21azy")
-            self.assertTrue(isinstance(path, fsnative))
+            assert isinstance(path, fsnative)
             self.assertEqual(path, fsnative("/home/piman/cr!azy"))
         else:
             path = uri2fsn("file:///C:/foo")
-            self.assertTrue(isinstance(path, fsnative))
+            assert isinstance(path, fsnative)
             self.assertEqual(path, fsnative("C:\\foo"))
 
     def test_uri2fsn_invalid(self):
@@ -81,7 +81,7 @@ class Turi(TestCase):
 
         for source in paths:
             path = uri2fsn(fsn2uri(fsnative(source)))
-            self.assertTrue(isinstance(path, fsnative))
+            assert isinstance(path, fsnative)
             self.assertEqual(path, fsnative(source))
 
     def test_win_unc_path(self):
@@ -91,13 +91,13 @@ class Turi(TestCase):
                 "file://server/share/path")
 
     def test_uri_is_valid(self):
-        self.assertTrue(uri_is_valid("file:///foo"))
-        self.assertTrue(uri_is_valid("file:///C:/foo"))
-        self.assertTrue(uri_is_valid("http://www.example.com"))
+        assert uri_is_valid("file:///foo")
+        assert uri_is_valid("file:///C:/foo")
+        assert uri_is_valid("http://www.example.com")
 
-        self.assertFalse(uri_is_valid("/bla"))
-        self.assertFalse(uri_is_valid("test"))
-        self.assertFalse(uri_is_valid(""))
+        assert not uri_is_valid("/bla")
+        assert not uri_is_valid("test")
+        assert not uri_is_valid("")
 
         assert not uri_is_valid("file:///öäü")
         assert not uri_is_valid("file:///öäü".encode())
@@ -106,8 +106,8 @@ class Turi(TestCase):
 class Tget_x_dir(TestCase):
 
     def test_get_home_dir(self):
-        self.assertTrue(isinstance(get_home_dir(), fsnative))
-        self.assertTrue(os.path.isabs(get_home_dir()))
+        assert isinstance(get_home_dir(), fsnative)
+        assert os.path.isabs(get_home_dir())
 
 
 class Tlimit_path(TestCase):
@@ -124,16 +124,16 @@ class Tlimit_path(TestCase):
 
         path = fsnative("foo%s.ext" % ("x" * 300))
         new = limit_path(path, ellipsis=False)
-        self.assertTrue(isinstance(new, fsnative))
+        assert isinstance(new, fsnative)
         self.assertEqual(len(new), 255)
-        self.assertTrue(new.endswith(fsnative("xx.ext")))
+        assert new.endswith(fsnative("xx.ext"))
 
         new = limit_path(path)
-        self.assertTrue(isinstance(new, fsnative))
+        assert isinstance(new, fsnative)
         self.assertEqual(len(new), 255)
-        self.assertTrue(new.endswith(fsnative("...ext")))
+        assert new.endswith(fsnative("...ext"))
 
-        self.assertTrue(isinstance(limit_path(fsnative()), fsnative))
+        assert isinstance(limit_path(fsnative()), fsnative)
         self.assertEqual(limit_path(fsnative()), fsnative())
 
 
@@ -141,16 +141,16 @@ class Tiscommand(TestCase):
 
     @unittest.skipIf(is_win, "Unix only")
     def test_unix(self):
-        self.assertTrue(iscommand("ls"))
-        self.assertTrue(iscommand(shutil.which("ls")))
-        self.assertTrue(iscommand("whoami"))
+        assert iscommand("ls")
+        assert iscommand(shutil.which("ls"))
+        assert iscommand("whoami")
 
     def test_both(self):
-        self.assertFalse(iscommand("zzzzzzzzz"))
-        self.assertFalse(iscommand("/bin/zzzzzzzzz"))
-        self.assertFalse(iscommand(""))
-        self.assertFalse(iscommand("/bin"))
-        self.assertFalse(iscommand("X11"))
+        assert not iscommand("zzzzzzzzz")
+        assert not iscommand("/bin/zzzzzzzzz")
+        assert not iscommand("")
+        assert not iscommand("/bin")
+        assert not iscommand("X11")
 
     @unittest.skipUnless(path_set, "Can only test with a valid $PATH")
     @unittest.skipIf(is_win, "needs porting")
@@ -163,5 +163,5 @@ class Tiscommand(TestCase):
                     p = os.path.join(d, file_path)
                     if os.path.isfile(p) and os.access(p, os.X_OK):
                         print_d("Testing %s" % p)
-                        self.assertTrue(iscommand(p), msg=p)
+                        assert iscommand(p), p
                         return

--- a/tests/test_util_string.py
+++ b/tests/test_util_string.py
@@ -11,9 +11,9 @@ from quodlibet.util.string import isascii
 class Tisascii(TestCase):
 
     def test_main(self):
-        self.assertTrue(isascii(""))
-        self.assertTrue(isascii(""))
-        self.assertTrue(isascii("abc"))
-        self.assertTrue(isascii("abc"))
-        self.assertFalse(isascii("\xffbc"))
-        self.assertFalse(isascii("übc"))
+        assert isascii("")
+        assert isascii("")
+        assert isascii("abc")
+        assert isascii("abc")
+        assert not isascii("\xffbc")
+        assert not isascii("übc")

--- a/tests/test_util_tagsfrompath.py
+++ b/tests/test_util_tagsfrompath.py
@@ -54,8 +54,8 @@ class TTagsFromPattern(TestCase):
         song = pat.match({"~filename": self.f1})
         self.assertEqual(song.get("path"), "path")
         self.assertEqual(song.get("title"), "Title")
-        self.assertFalse(song.get("album"))
-        self.assertFalse(song.get("artist"))
+        assert not song.get("album")
+        assert not song.get("artist")
 
     def test_dict(self):
         tracktitle = {"tracknumber": "01", "title": "Title"}

--- a/tests/test_util_trash.py
+++ b/tests/test_util_trash.py
@@ -26,7 +26,7 @@ class Ttrash(TestCase):
         old_os_name = os.name
         try:
             os.name = "not posix"
-            self.assertFalse(use_trash())
+            assert not use_trash()
         finally:
             os.name = old_os_name
 
@@ -36,7 +36,7 @@ class Ttrash(TestCase):
         try:
             os.name = "posix"
             sys.platform = "darwin"
-            self.assertFalse(use_trash())
+            assert not use_trash()
         finally:
             os.name = old_os_name
             sys.platform = old_sys_platform
@@ -48,7 +48,7 @@ class Ttrash(TestCase):
             os.name = "posix"
             sys.platform = "linux"
             if not is_flatpak():
-                self.assertTrue(use_trash())
+                assert use_trash()
         finally:
             os.name = old_os_name
             sys.platform = old_sys_platform
@@ -60,7 +60,7 @@ class Ttrash(TestCase):
             config.set("settings", "bypass_trash", "true")
             os.name = "posix"
             sys.platform = "linux"
-            self.assertFalse(use_trash())
+            assert not use_trash()
         finally:
             os.name = old_os_name
             sys.platform = old_sys_platform
@@ -70,6 +70,6 @@ class Ttrash(TestCase):
         filename = mkstemp()[1]
         with open(filename, "w") as f:
             f.write("\n")
-        self.assertTrue(os.path.exists(filename))
+        assert os.path.exists(filename)
         trash(filename)
-        self.assertFalse(os.path.exists(filename))
+        assert not os.path.exists(filename)

--- a/tests/test_windows.py
+++ b/tests/test_windows.py
@@ -19,34 +19,34 @@ class TWindows(TestCase):
 
     def test_dir_funcs(self):
         d = windows.get_personal_dir()
-        self.assertTrue(d is None or isinstance(d, str))
+        assert d is None or isinstance(d, str)
 
         d = windows.get_appdata_dir()
-        self.assertTrue(d is None or isinstance(d, str))
+        assert d is None or isinstance(d, str)
 
         d = windows.get_desktop_dir()
-        self.assertTrue(d is None or isinstance(d, str))
+        assert d is None or isinstance(d, str)
 
         d = windows.get_music_dir()
-        self.assertTrue(d is None or isinstance(d, str))
+        assert d is None or isinstance(d, str)
 
         d = windows.get_profile_dir()
-        self.assertTrue(d is None or isinstance(d, str))
+        assert d is None or isinstance(d, str)
 
         d = windows.get_links_dir()
-        self.assertTrue(d is None or isinstance(d, str))
+        assert d is None or isinstance(d, str)
 
     def test_get_link_target(self):
         path = get_data_path("test.lnk")
         d = windows.get_link_target(path)
-        self.assertTrue(isinstance(d, str))
+        assert isinstance(d, str)
         self.assertEqual(
             normalize_path(d), normalize_path("C:\\Windows\\explorer.exe"))
 
     def test_get_link_target_unicode(self):
         path = get_data_path("test2.lnk")
         d = windows.get_link_target(path)
-        self.assertTrue(isinstance(d, str))
+        assert isinstance(d, str)
         if is_wine():
             # wine doesn't support unicode paths here..
             self.assertEqual(os.path.basename(d), "\xe1??.txt")


### PR DESCRIPTION
* Remove now unused proxied methods
* `self.assertTrue(foo)` -> `assert foo`
* `self.assertFalse(foo)` -> `assert not foo`
* Various `not foo in bar` -> `foo not in bar` fixups