### PR TITLE
🔧 Create Sort Tags plugin: never create empty tags

### DIFF
--- a/quodlibet/ext/songsmenu/makesorttags.py
+++ b/quodlibet/ext/songsmenu/makesorttags.py
@@ -1,15 +1,17 @@
 # Copyright 2008 Joe Wreschnig
-#           2016 Nick Boultbee
+#     2016, 2024 Nick Boultbee
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation; either version 2 of the License, or
 # (at your option) any later version.
+from typing import cast
 
 from quodlibet import _
 from quodlibet.plugins.songshelpers import any_song, is_finite, is_writable
 from quodlibet.plugins.songsmenu import SongsMenuPlugin
 from quodlibet.qltk import Icons
+from quodlibet.util.collection import PEOPLE
 
 
 def artist_to_sort(artist):
@@ -40,12 +42,8 @@ class MakeSortTags(SongsMenuPlugin):
     plugin_handles = any_song(is_writable, is_finite)
 
     def plugin_song(self, song):
-        for tag in ["album"]:
-            values = filter(None, map(album_to_sort, song.list(tag)))
-            if values and (tag + "sort") not in song:
-                song[tag + "sort"] = "\n".join(values)
-
-        for tag in ["artist", "albumartist", "performer"]:
-            values = filter(None, map(artist_to_sort, song.list(tag)))
+        for tag in ["album", "artist", "albumartist", "performer"]:
+            func = artist_to_sort if tag in PEOPLE else album_to_sort
+            values = cast(list[str], [v for tag in song.list(tag) if (v:=func(tag))])
             if values and (tag + "sort") not in song:
                 song[tag + "sort"] = "\n".join(values)

--- a/quodlibet/formats/_audio.py
+++ b/quodlibet/formats/_audio.py
@@ -750,7 +750,7 @@ class AudioFile(dict, ImageContainer, HasKey):
         else:
             return re.sub("\n+", ", ", v.strip())
 
-    def list(self, key):
+    def list(self, key) -> list[Any]:
         """Get all values of a tag, as a list. Synthetic tags are supported,
         but will be slower. Numeric tags will give their one value.
 

--- a/tests/plugin/test_makesorttags.py
+++ b/tests/plugin/test_makesorttags.py
@@ -1,0 +1,28 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+
+from quodlibet.ext.songsmenu.makesorttags import artist_to_sort, album_to_sort
+from quodlibet.formats import AudioFile
+from quodlibet.util.songwrapper import SongWrapper
+from tests.plugin import PluginTestCase
+
+
+class TMakeSortTags(PluginTestCase):
+    def setUp(self):
+        globals().update(vars(self.modules["SortTags"]))
+        self.kind = self.plugins["SortTags"].cls
+
+    def test_util_functions(self):
+        assert artist_to_sort("The Strokes") == "Strokes, The"
+        assert album_to_sort("The Very Greatest Hits") == "Very Greatest Hits, The"
+
+    def test_no_blanks(self):
+        s = AudioFile({"filename": "/dev/null", "artist": "The Beatles"})
+        sw = SongWrapper(s)
+        self.plugin = self.kind([sw], None).plugin_song(sw)
+        assert sw("artistsort") == "Beatles, The"
+        assert "performersort" not in sw._song
+        assert "albumartistsort" not in sw._song
+        assert "albumsort" not in sw._song


### PR DESCRIPTION
* Probably missed in the Python 3 migration (!!)
* But unify some code whilst there
* And add the important missing tests

Fixes #4629