### PR TITLE
Update MacOS build to harfbuzz 10.1.0.

### DIFF
--- a/dev-utils/osx_bundle/bootstrap.sh
+++ b/dev-utils/osx_bundle/bootstrap.sh
@@ -19,7 +19,7 @@ rustup install "$RUST_REVISION"
 
 # Clone and install JHBuild.  Specify "--simple-install" so that we get the same
 # behavior regardless of whether autotools is installed or not.
-mkdir -p "$QL_OSXBUNDLE_JHBUILD_DEST" "$QL_OSXBUNDLE_BUNDLER_DEST" "$QL_OSXBUNDLE_BUNDLE_DEST"
+mkdir -p "$HOME" "$QL_OSXBUNDLE_JHBUILD_DEST" "$QL_OSXBUNDLE_BUNDLER_DEST" "$QL_OSXBUNDLE_BUNDLE_DEST"
 git clone https://gitlab.gnome.org/GNOME/jhbuild.git "$QL_OSXBUNDLE_JHBUILD_DEST"
 (cd "$QL_OSXBUNDLE_JHBUILD_DEST" && git checkout "$JHBUILD_REVISION" && ./autogen.sh --simple-install && make -f Makefile.plain DISABLE_GETTEXT=1 install >/dev/null)
 cp misc/gtk-osx-jhbuildrc "$HOME/.jhbuildrc"

--- a/dev-utils/osx_bundle/bootstrap.sh
+++ b/dev-utils/osx_bundle/bootstrap.sh
@@ -2,6 +2,9 @@
 
 set -e
 
+JHBUILD_REVISION="3.38.0"
+RUST_REVISION="1.69.0"
+
 # shellcheck source-path=SCRIPTDIR
 source env.sh
 
@@ -12,14 +15,16 @@ source clean.sh
 # Cargo and Rust must be installed in the user's home directory.
 # They cannot be run successfully from JHBuild's prefix or home
 # directory.
-rustup install 1.69.0
+rustup install "$RUST_REVISION"
 
-JHBUILD_REVISION="3.38.0"
-
-mkdir -p "$HOME"
+# Clone and install JHBuild.  Specify "--simple-install" so that we get the same
+# behavior regardless of whether autotools is installed or not.
+mkdir -p "$QL_OSXBUNDLE_JHBUILD_DEST" "$QL_OSXBUNDLE_BUNDLER_DEST" "$QL_OSXBUNDLE_BUNDLE_DEST"
 git clone https://gitlab.gnome.org/GNOME/jhbuild.git "$QL_OSXBUNDLE_JHBUILD_DEST"
-(cd "$QL_OSXBUNDLE_JHBUILD_DEST" && git checkout "$JHBUILD_REVISION" && ./autogen.sh && make -f Makefile.plain DISABLE_GETTEXT=1 install >/dev/null)
+(cd "$QL_OSXBUNDLE_JHBUILD_DEST" && git checkout "$JHBUILD_REVISION" && ./autogen.sh --simple-install && make -f Makefile.plain DISABLE_GETTEXT=1 install >/dev/null)
 cp misc/gtk-osx-jhbuildrc "$HOME/.jhbuildrc"
 cp misc/quodlibet-jhbuildrc-custom "$HOME/.jhbuildrc-custom"
+
+# Clone and install the GNOME Mac bundler.
 git clone https://gitlab.gnome.org/GNOME/gtk-mac-bundler.git "$QL_OSXBUNDLE_BUNDLER_DEST"
 (cd "$QL_OSXBUNDLE_BUNDLER_DEST" && make install)

--- a/dev-utils/osx_bundle/modulesets/quodlibet.modules
+++ b/dev-utils/osx_bundle/modulesets/quodlibet.modules
@@ -335,9 +335,9 @@
 
   <meson id="harfbuzz" mesonargs="-Ddocs=disabled -Dcoretext=enabled -Dgobject=enabled -Dintrospection=enabled">
     <branch repo="github-tar"
-            version="5.3.1"
+            version="10.1.0"
             module="harfbuzz/harfbuzz/releases/download/${version}/harfbuzz-${version}.tar.xz"
-            hash="sha256:4a6ce097b75a8121facc4ba83b5b083bfec657f45b003cd5a3424f2ae6b4434d">
+            hash="sha256:6ce3520f2d089a33cef0fc48321334b8e0b72141f6a763719aaaecd2779ecb82">
     </branch>
     <dependencies>
       <dep package="freetype-no-harfbuzz"/>


### PR DESCRIPTION
We were using a very old version of harfbuzz that triggered large numbers of fatal compile warnings.

Also install JHBuild the same regardless of whether autotools are installed, to reduce developer confusion.

Fixes #4638.

Check-list
----------

 * [X ] There is a linked issue discussing the motivations for this feature or bugfix
 * [ ] Unit tests have been added where possible
 * [ ] I've added / updated documentation for any user-facing features.
 * [ ] Performance seems to be comparable or better than current `main`


What this change is adding / fixing
-----------------------------------
Update MacOS build scripts to work with latest XCode release.
