### PR TITLE
Properly handle control-click on MacOS as a synonym for right-click.

### DIFF
--- a/dev-utils/osx_bundle/modulesets/patches/gtk+-pulldown-menu-modifier.patch
+++ b/dev-utils/osx_bundle/modulesets/patches/gtk+-pulldown-menu-modifier.patch
@@ -1,0 +1,40 @@
+# Patch gtk+ to recognize control-click as a way to activate pulldown menus.
+# This is documented gtk+ behavior but was broken some time before
+# 3.24.38 (see https://gitlab.gnome.org/GNOME/gtk/-/issues/6724).
+# It's fixed in GTK 4.16, but that's a really big jump from 3.24.38 for
+# one bug fix.
+# This fix is their commit 4b5d503c, backported to gtk+ 3.
+diff -ruw gtk+-3.24.38-orig/gdk/gdkevents.c gtk+-3.24.38/gdk/gdkevents.c
+--- gtk+-3.24.38-orig/gdk/gdkevents.c	2025-01-06 15:02:03
++++ gtk+-3.24.38/gdk/gdkevents.c	2025-01-06 15:03:46
+@@ -1883,8 +1883,6 @@
+   if (event->type == GDK_BUTTON_PRESS)
+     {
+       const GdkEventButton *bevent = (const GdkEventButton *) event;
+-      GdkDisplay *display;
+-      GdkModifierType modifier;
+ 
+       g_return_val_if_fail (GDK_IS_WINDOW (bevent->window), FALSE);
+ 
+@@ -1892,16 +1890,12 @@
+           ! (bevent->state & (GDK_BUTTON1_MASK | GDK_BUTTON2_MASK)))
+         return TRUE;
+ 
+-      display = gdk_window_get_display (bevent->window);
+-
+-      modifier = gdk_keymap_get_modifier_mask (gdk_keymap_get_for_display (display),
+-                                               GDK_MODIFIER_INTENT_CONTEXT_MENU);
+-
+-      if (modifier != 0 &&
+-          bevent->button == GDK_BUTTON_PRIMARY &&
+-          ! (bevent->state & (GDK_BUTTON2_MASK | GDK_BUTTON3_MASK)) &&
+-          (bevent->state & modifier))
++#ifdef __APPLE__
++      if (bevent->button == GDK_BUTTON_PRIMARY &&
++          (bevent->state & GDK_CONTROL_MASK) &&
++          ! (bevent->state & (GDK_BUTTON1_MASK | GDK_BUTTON2_MASK)))
+         return TRUE;
++#endif
+     }
+ 
+   return FALSE;

--- a/dev-utils/osx_bundle/modulesets/quodlibet.modules
+++ b/dev-utils/osx_bundle/modulesets/quodlibet.modules
@@ -515,6 +515,7 @@
   <meson id="gtk3" mesonargs="-Dexamples=false -Dtests=false -Dquartz_backend=true -Dx11_backend=false">
     <branch module="gtk+/3.24/gtk+-${version}.tar.xz"  version="3.24.38"
             hash="sha256:ce11decf018b25bdd8505544a4f87242854ec88be054d9ade5f3a20444dd8ee7">
+      <patch file="patches/gtk+-pulldown-menu-modifier.patch" strip="1"/>
     </branch>
     <dependencies>
         <dep package="glib2"/>

--- a/quodlibet/browsers/covergrid/widgets.py
+++ b/quodlibet/browsers/covergrid/widgets.py
@@ -138,7 +138,7 @@ class AlbumWidget(Gtk.FlowBoxChild):
         self.model.format_label(self.props.display_pattern)
 
     def __rightclick(self, widget, event):
-        if event.button == Gdk.BUTTON_SECONDARY:
+        if event.triggers_context_menu():
             self.emit("songs-menu")
 
     def __tooltip(self, widget, x, y, keyboard_tip, tooltip):

--- a/quodlibet/ext/events/equalizer.py
+++ b/quodlibet/ext/events/equalizer.py
@@ -573,5 +573,5 @@ class Equalizer(EventPlugin):
         return main_vbox
 
     def __rightclick(self, hs, event):
-        if event.button == Gdk.BUTTON_SECONDARY:
+        if event.triggers_context_menu():
             hs.set_value(0)

--- a/quodlibet/qltk/controls.py
+++ b/quodlibet/qltk/controls.py
@@ -62,7 +62,7 @@ class Volume(Gtk.VolumeButton):
         if event.type != Gdk.EventType.BUTTON_PRESS:
             return False
 
-        if event.button == Gdk.BUTTON_SECONDARY:
+        if event.triggers_context_menu():
             qltk.popup_menu_at_widget(menu, self, event.button, event.time)
             return True
         elif event.button == Gdk.BUTTON_MIDDLE:

--- a/quodlibet/qltk/info.py
+++ b/quodlibet/qltk/info.py
@@ -85,7 +85,7 @@ class SongInfo(Gtk.EventBox):
             player.playpause()
 
     def _on_button_press_event(self, widget, event, player, library):
-        if event.button == Gdk.BUTTON_SECONDARY:
+        if event.triggers_context_menu():
             menu = self._get_menu(player, library)
             menu.attach_to_widget(widget, None)
             menu.popup(None, None, None, None, event.button, event.time)

--- a/quodlibet/qltk/seekbutton.py
+++ b/quodlibet/qltk/seekbutton.py
@@ -274,7 +274,7 @@ class SeekButton(HSlider):
         if event.type != Gdk.EventType.BUTTON_PRESS:
             return
 
-        if event.button == Gdk.BUTTON_SECONDARY:
+        if event.triggers_context_menu():
             return self.__popup_menu(menu, player, event)
         elif event.button == Gdk.BUTTON_MIDDLE:
             remaining_item.set_active(not remaining_item.get_active())

--- a/quodlibet/qltk/songlist.py
+++ b/quodlibet/qltk/songlist.py
@@ -1298,7 +1298,7 @@ class SongList(AllTreeView, SongListDnDMixin, DragScroll, util.InstanceTracker):
     def __showmenu(self, column, event=None):
         time = event.time if event else Gtk.get_current_event_time()
 
-        if event is not None and event.button != Gdk.BUTTON_SECONDARY:
+        if event is not None and not event.triggers_context_menu():
             return False
 
         menu = self._menu(column)

--- a/quodlibet/qltk/views.py
+++ b/quodlibet/qltk/views.py
@@ -1040,7 +1040,7 @@ class RCMTreeView(BaseView):
         self.connect("button-press-event", self.__button_press)
 
     def __button_press(self, view, event):
-        if event.button == Gdk.BUTTON_SECONDARY:
+        if event.triggers_context_menu():
             return self.__check_popup(event)
 
     def __check_popup(self, event):


### PR DESCRIPTION
During builds for MacOS, patch gdk_event_triggers_context_menu() in gtk+ to recognize control-click as a way to activate pulldown menus. This is documented gtk+ behavior but was broken some time before 3.24.38 (see https://gitlab.gnome.org/GNOME/gtk/-/issues/6724). This patch is their commit 4b5d503c, backported to gtk+ 3.

Update QL to use the GTK Python binding for this API.

    Fixes #4640.

Check-list
----------

 * [ X] There is a linked issue discussing the motivations for this feature or bugfix
 * [ ] Unit tests have been added where possible
 * [ ] I've added / updated documentation for any user-facing features.
 * [X ] Performance seems to be comparable or better than current `main`


What this change is adding / fixing
-----------------------------------
Fix the handling of control-click on Macintosh to match the documented GTK behavior.

