### PR TITLE
Don't run tests while building cairo.

### DIFF
--- a/dev-utils/osx_bundle/modulesets/quodlibet.modules
+++ b/dev-utils/osx_bundle/modulesets/quodlibet.modules
@@ -235,7 +235,7 @@
     </branch>
   </autotools>
 
-  <meson id="cairo">
+  <meson id="cairo" mesonargs="-Dtests=disabled">
     <branch module="cairo-${version}.tar.xz"  version="1.17.8"
             repo="cairographics-snapshots"
             hash="sha256:5b10c8892d1b58d70d3f0ba5b47863a061262fa56b9dc7944161f8c8b783bc64">


### PR DESCRIPTION
This eliminates a dependency on fonttools and also saves time.  Fixes #4643.

Check-list
----------

 * [ X] There is a linked issue discussing the motivations for this feature or bugfix
 * [ ] Unit tests have been added where possible
 * [ ] I've added / updated documentation for any user-facing features.
 * [ X] Performance seems to be comparable or better than current `main`


What this change is adding / fixing
-----------------------------------
Another step in ensuring that QL can be built on a Mac other than mine. 

