### PR TITLE
Add SSL support to bundled Python for use by plugins.

### DIFF
--- a/dev-utils/osx_bundle/modulesets/patches/Python-use-ssl-from-bundle.patch
+++ b/dev-utils/osx_bundle/modulesets/patches/Python-use-ssl-from-bundle.patch
@@ -1,0 +1,9 @@
+diff -Nru Python-3.11.3-orig/Modules/Setup.local Python-3.11.3/Modules/Setup.local
+--- /dev/null	2025-01-21 13:18:12
++++ Python-3.11.3/Modules/Setup.local	2025-01-21 13:18:12
+@@ -0,0 +1,5 @@
++# Have _ssl built by Modules/Setup rather than the top-level setup.py
++# script, because the top-level script doesn't honor the top-level "--with-openssl"
++# configure parameter, and we need that to find the openssl implementation in our
++# bundle.
++_ssl _ssl.c $(OPENSSL_INCLUDES) $(OPENSSL_LDFLAGS) $(OPENSSL_LIBS)

--- a/dev-utils/osx_bundle/modulesets/quodlibet.modules
+++ b/dev-utils/osx_bundle/modulesets/quodlibet.modules
@@ -406,20 +406,19 @@
     </dependencies>
   </autotools>
 
-  <!-- INSTALL_PREFIX because it doesn't use DESTDIR and LIBS="" to skip installing static libs -->
   <autotools id="openssl" autogen-sh="Configure" autogenargs="shared zlib-dynamic"
              autogen-template="%(srcdir)s/%(autogen-sh)s --prefix=%(prefix)s --openssldir=%(prefix)s/etc/ssl %(autogenargs)s"
-             makeinstallargs="INSTALL_PREFIX=$JHBUILD_PREFIX/_jhbuild/root-openssl LIBS= install_sw"
              supports-non-srcdir-builds="no">
     <branch module="openssl-1.1.1t.tar.gz" version="1.1.1.t" repo="openssl"
             hash="sha256:8dee9b24bdb1dcbf0c3d1e9b02fb8f6bf22165e807f45adeb7c9677536859d3b"/>
   </autotools>
 
-  <autotools id="python" autogenargs="--enable-shared --without-ensurepip"
+  <autotools id="python" autogenargs="--enable-shared --without-ensurepip --with-openssl=$JHBUILD_PREFIX --with-openssl-rpath"
          autogen-sh="configure" supports-non-srcdir-builds="no">
     <branch repo="python"
         module="${version}/Python-${version}.tar.xz" version="3.11.3"
         hash="sha256:8a5db99c961a7ecf27c75956189c9602c968751f11dbeae2b900dbff1c085b5e">
+        <patch file="patches/Python-use-ssl-from-bundle.patch" strip="1"/>
     </branch>
     <dependencies>
       <dep package="gettext"/>


### PR DESCRIPTION
Correct build of bundled Python interpreter so that it includes the SSL module.  A bug in the 3.11.1 Python release (and others) caused the "--with-openssl" configure parameter to have no effect when the SSL module was built through setup.py.  Change the module build specification so that it is built through Modules/Setup, which correctly implements the relevant configure parameter.

Fixes #4648.

Check-list
----------

 * [X ] There is a linked issue discussing the motivations for this feature or bugfix
 * [ ] Unit tests have been added where possible
 * [ ] I've added / updated documentation for any user-facing features.
 * [X ] Performance seems to be comparable or better than current `main`


What this change is adding / fixing
-----------------------------------
The immediate cause of this is that the Python interpreter we include in the application bundle isn't being built with SSL support. (MusicBrainz requires https.) The root cause is a deficiency in the Python build scripts. The "--with-openssl" configure parameter is ignored when the "_ssl" module is built by the top-level setup.py script.

