### PR TITLE
🆕 Auto-enable more plugins:

### DIFF
--- a/quodlibet/config.py
+++ b/quodlibet/config.py
@@ -1,5 +1,5 @@
 # Copyright 2004-2008 Joe Wreschnig
-#           2009-2022 Nick Boultbee
+#           2009-2025 Nick Boultbee
 #           2011-2014 Christoph Reiter
 #           2018-2019 Peter Strulo
 #                2022 Jej@github
@@ -11,14 +11,20 @@
 
 import shutil
 
-from quodlibet.util import enum
+from quodlibet.util import enum, is_linux
 from . import const
 from quodlibet.util.config import Config, Error
 from quodlibet.util import print_d, print_w
 from quodlibet.util import is_osx, is_windows
 
 # Some plugins can be enabled on first install
-AUTO_ENABLED_PLUGINS = ["Shuffle Playlist", "Remove Playlist Duplicates"]
+AUTO_ENABLED_PLUGINS = [
+    "Shuffle Playlist",
+    "Remove Playlist Duplicates",
+    "WaveformSeekBar",
+]
+if is_linux():
+    AUTO_ENABLED_PLUGINS += ["mpris"]
 
 
 # this defines the initial and default values


### PR DESCRIPTION
* `mpris` (D-Bus) if on Linux - it's vital for so many Linux things
* `WaveformSeekBar` - stable for years, it's in every modern screenshot and there seems little reason to ship without it

Probably some more we could turn on...
