### PR TITLE
Match desktop color scheme as it changes

### DIFF
--- a/quodlibet/ext/events/themeswitcher.py
+++ b/quodlibet/ext/events/themeswitcher.py
@@ -41,6 +41,11 @@ class ThemeSwitcher(EventPlugin):
         self.__default_theme = settings.get_property("gtk-theme-name")
         self.__default_dark = settings.get_property("gtk-application-prefer-dark-theme")
 
+        self.__desktop = Gio.Settings.new('org.gnome.desktop.interface')
+        def on_color_scheme(settings, value):
+            self.__set_dark(self.__get_dark())
+        self.__desktop.connect('changed::color-scheme', on_color_scheme)
+
     def PluginPreferences(self, *args):
         self.__init_defaults()
 
@@ -151,7 +156,8 @@ class ThemeSwitcher(EventPlugin):
         settings.set_property("gtk-application-prefer-dark-theme", value)
 
     def __get_dark(self):
-        return config.getboolean("plugins", self.CONFIG_DARK, self.__default_dark)
+        prefers_dark = self.__desktop.get_string('color-scheme') == 'prefer-dark'
+        return config.getboolean("plugins", self.CONFIG_DARK, prefers_dark)
 
     def enabled(self):
         self.__enabled = True


### PR DESCRIPTION
Check-list
----------

 * [x] There is a linked issue discussing the motivations for this feature or bugfix
 * [ ] Unit tests have been added where possible
 * [ ] I've added / updated documentation for any user-facing features.
 * [x] Performance seems to be comparable or better than current `main`


What this change is adding / fixing
-----------------------------------
Add light / dark mode detection #4011
Honestly I only tested with Gnome Shell on Arch Linux. It relies on Gnome specific settings so might conflict with other environments.
Also there's a slight bug where opening plugin preferences will preset the "Prefer dark theme version" checkbox even if the config value for it does not exist.
However this method does prove that automatic detection is possible.