### PR TITLE
🔧 Fix Nix Flake for Poetry 2, and more

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,16 +20,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1733412085,
-        "narHash": "sha256-FillH0qdWDt/nlO6ED7h4cmN+G9uXwGjwmCnHs0QVYM=",
+        "lastModified": 1744098102,
+        "narHash": "sha256-tzCdyIJj9AjysC3OuKA+tMD/kDEDAF9mICPDU7ix0JA=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "4dc2fc4e62dbf62b84132fe526356fbac7b03541",
+        "rev": "c8cd81426f45942bb2906d5ed2fe21d2f19d95b7",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-24.11",
+        "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,8 @@
 {
   description = "Development Flake for Quod Libet";
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs/nixos-24.11";
+    # TODO: pin to 25.05 once available, but we need Poetry > 2.0 now
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
     flake-parts.url = "github:hercules-ci/flake-parts";
     treefmt-nix.url = "github:numtide/treefmt-nix";
   };
@@ -70,8 +71,10 @@
           };
           devShells.default =
             with pkgs;
-            pkgs.mkShell {
+            mkShell {
               POETRY_VIRTUALENV_CREATE = 1;
+              # Allow libpcre to... work
+              LD_LIBRARY_PATH="${glib.out}/lib";
               packages =
                 [
                   qlPoetry
@@ -85,21 +88,24 @@
                   glibcLocales
                   gobject-introspection
                   gtk3
-                  libcanberra-gtk3
+                  gtksourceview4
+                  kakasi
+                  keybinder3
                   libappindicator-gtk3
                   libmodplug
+                  libnotify
+                  librsvg
                   libsoup_3
+                  pcre2
                   shared-mime-info
-                  webkitgtk_4_0
                   xvfb-run
                 ]
                 ++ (with gst_all_1; [
                   gstreamer
                   gst-plugins-bad
+                  gst-plugins-base
                   gst-plugins-good
                   gst-plugins-ugly
-                  gst-plugins-base
-                  gstreamer
                   gst-libav
                 ]);
             };


### PR DESCRIPTION
* We need `unstable` until `25.05` comes out (with Poetry 2+)
* Take "inspiration" from nixpkgs packing (thanks!)
* Stick with Python 3.11 here
* Remove a few redundant things
* Hack LD_LIBRARY_PATH to get it to run for me :|

