### PR TITLE
advanced prefs: add option to use playbin3 instead of playbin

### DIFF
--- a/quodlibet/config.py
+++ b/quodlibet/config.py
@@ -51,6 +51,7 @@ INITIAL: dict[str, dict[str, str]] = {
         # Consider a track as played after listening to
         # this proportion of its overall length
         "playcount_minimum_length_proportion": "0.5",
+        "gst_use_playbin3": "false",
     },
     "library": {
         "exclude": "",

--- a/quodlibet/player/gstbe/player.py
+++ b/quodlibet/player/gstbe/player.py
@@ -526,7 +526,10 @@ class GStreamerPlayer(BasePlayer, GStreamerPluginHandler):
         gpad = Gst.GhostPad.new("sink", pipeline[0].get_static_pad("sink"))
         bufbin.add_pad(gpad)
 
-        bin_ = self._make("playbin", None)
+        if config.getboolean("player", "gst_use_playbin3"):
+            bin_ = self._make("playbin3", None)
+        else:
+            bin_ = self._make("playbin", None)
         assert bin_
 
         self.bin = BufferingWrapper(bin_, self)

--- a/quodlibet/qltk/advanced_prefs.py
+++ b/quodlibet/qltk/advanced_prefs.py
@@ -289,6 +289,12 @@ class AdvancedPreferencesPane(Gtk.VBox):
                     "<~#bitrate>, etc. See tags documentation for details."
                 ),
             ),
+            boolean_config(
+                "player",
+                "gst_use_playbin3",
+                "Use GStreamer playbin3",
+                "Use GStreamer playbin3 instead of playbin for playback.",
+            ),
         ]
 
         # Tabulate all settings for neatness


### PR DESCRIPTION
Not quite if there is anything we need to change or can drop for playbin3, but the basics seem to work, so make it easier to test for starters
