### PR TITLE
Silence some new gettext warnings

### DIFF
--- a/quodlibet/errorreport/ui.py
+++ b/quodlibet/errorreport/ui.py
@@ -83,9 +83,9 @@ class SubmitErrorDialog(Gtk.MessageDialog):
         secondary_text = _(
             "Various details regarding the error and your system will be send "
             "to a third party online service "
-            "(<a href='https://www.sentry.io'>www.sentry.io</a>). You can "
+            "(<a href='{sentry_url}'>www.sentry.io</a>). You can "
             "review the data before sending it below."
-        )
+        ).format(sentry_url="https://www.sentry.io")
 
         secondary_text += "\n\n"
 

--- a/quodlibet/ext/events/mpris/__init__.py
+++ b/quodlibet/ext/events/mpris/__init__.py
@@ -39,10 +39,10 @@ class MPRIS(EventPlugin):
     PLUGIN_NAME = _("Linux Desktop Integration (MPRIS D-Bus)")
     PLUGIN_DESC_MARKUP = _(
         "⏯️ Allows control of Quod Libet using the "
-        '<a href="https://mpris2.readthedocs.io/en/latest/">MPRIS 2</a> '
+        '<a href="{mpris_url}">MPRIS 2</a> '
         "D-Bus Interface.\n"
         "This allows various Linux desktop integrations (e.g. multimedia keys)."
-    )
+    ).format(mpris_url="https://mpris2.readthedocs.io/en/latest/")
     PLUGIN_ICON = Icons.MEDIA_PLAYBACK_START
 
     def PluginPreferences(self, parent):

--- a/quodlibet/ext/songsmenu/ifp.py
+++ b/quodlibet/ext/songsmenu/ifp.py
@@ -33,8 +33,8 @@ class IFPUpload(SongsMenuPlugin):
                     "Unable to contact your iFP device. Check "
                     "that the device is powered on and plugged "
                     "in, and that you have ifp-line "
-                    "(http://ifp-driver.sf.net) installed."
-                ),
+                    "({ifp_url}) installed."
+                ).format(ifp_url="http://ifp-driver.sf.net"),
             ).run()
             return True
         self.__madedir = []

--- a/quodlibet/ext/songsmenu/replaygain.py
+++ b/quodlibet/ext/songsmenu/replaygain.py
@@ -580,7 +580,7 @@ class ReplayGain(SongsMenuPlugin, PluginConfigMixin):
     PLUGIN_DESC_MARKUP = _(
         'Analyzes and updates <a href="%(rg_link)s">ReplayGain</a> information, '
         "using GStreamer. Results are grouped by album."
-    ) % {"rg_link": _("https://en.wikipedia.org/wiki/ReplayGain")}
+    ) % {"rg_link": "https://wikipedia.org/wiki/ReplayGain"}
     PLUGIN_ICON = Icons.MULTIMEDIA_VOLUME_CONTROL
     CONFIG_SECTION = "replaygain"
 


### PR DESCRIPTION
it complains about URLs in translatable strings, so move them out
