### PR TITLE
test_formats_xiph: Make _get_jpeg() read file from disk instead of fd

### DIFF
--- a/tests/test_formats_xiph.py
+++ b/tests/test_formats_xiph.py
@@ -25,10 +25,11 @@ from .helper import get_temp_copy
 def _get_jpeg(size=5):
     from gi.repository import GdkPixbuf
 
-    pb = GdkPixbuf.Pixbuf.new(GdkPixbuf.Colorspace.RGB, False, 8, size, size)
     fd, fn = mkstemp()
+    os.close(fd)
+    pb = GdkPixbuf.Pixbuf.new(GdkPixbuf.Colorspace.RGB, False, 8, size, size)
     pb.savev(fn, "jpeg", [], [])
-    with os.fdopen(fd, "rb") as h:
+    with open(fn, "rb") as h:
         data = h.read()
     os.unlink(fn)
     return data


### PR DESCRIPTION
Check-list
----------

 * [ ] There is a linked issue discussing the motivations for this feature or bugfix
 * [ ] Unit tests have been added where possible
 * [ ] I've added / updated documentation for any user-facing features.
 * [x] Performance seems to be comparable or better than current `main`


What this change is adding / fixing
-----------------------------------
It seems like some Gdk behavior got changed and now h.read() returns empty list when trying to read back the JPEG image.

This incidentally makes code match TCoverManagerBuiltin::setUp(), so I guess it's ok anyway.
