### PR TITLE
Update _id3.py to use album artist for TPE2

### DIFF
--- a/quodlibet/formats/_id3.py
+++ b/quodlibet/formats/_id3.py
@@ -42,7 +42,7 @@ class ID3File(AudioFile):
         "TIT2": "title",
         "TIT3": "version",
         "TPE1": "artist",
-        "TPE2": "performer",
+        "TPE2": "albumartist",
         "TPE3": "conductor",
         "TPE4": "arranger",
         "TEXT": "lyricist",


### PR DESCRIPTION
Use 'albumartist' for TPE2 instead of 'performer' to maintain consistency with other music players and tagging for other file formats.

Closes #1179
Closes #3810

Check-list
----------

 * [x] There is a linked issue discussing the motivations for this feature or bugfix
 * [x] Unit tests have been added where possible
 * [x] I've added / updated documentation for any user-facing features.
 * [x] Performance seems to be comparable or better than current `main`


What this change is adding / fixing
-----------------------------------
<!-- A high-level description of the changes.
Hopefully the commits are atomic and well described, but this is the overall
summary of the change, to other developers / maintainers, plus any TODOs. -->

Change: Modified _id3.py to make TPE2 map to albumartist.
Reason: This is how other music players and tag editors handle the tag.  It also brings mp3 tagging in line with other file formats that have an albumartist tag so that tracks in collections with multiple formats can be handled the same way (e.g. allows using albumartist tag consistently for both mp3 and flac in searches or in Paned Browser and Album Collection views).