### PR TITLE
fix: synchronizedLyrics trackname checking for illegal chars

### DIFF
--- a/quodlibet/ext/events/synchronizedlyrics.py
+++ b/quodlibet/ext/events/synchronizedlyrics.py
@@ -212,7 +212,7 @@ class SynchronizedLyrics(EventPlugin, PluginConfigMixin):
                 except FileNotFoundError:
                     continue
                 except OSError as e:
-                    print_w(f"Failed to write file {filename!r} (e!r)")
+                    print_w(f"Failed to write file {filename!r} ({e!r})")
                     continue
                 return self._parse_lrc(contents)
             print_d(f"No lyrics found for {track_name!r}")


### PR DESCRIPTION
Hello,

The `synchronizedLyrics` plugin was unable to set it's text and background colors and causing errors when the metadata contains illegal characters such as `?` on Windows.

~~These changes _should_ fix the issues, however I couldn't verify it as I don't have the necessary build environment yet.~~