### PR TITLE
Support for 0-100 scale rating in vorbis comment

### DIFF
--- a/docs/development/formats.rst
+++ b/docs/development/formats.rst
@@ -129,8 +129,12 @@ is a string representation of a floating point number between 0.0 and 1.0,
 inclusive. This format is chosen so the application may decide what 
 precision it offers to the user, and how this information is presented. If 
 no value is present, the rating should be assumed to be 0.5.
+Starting from version 4.8, the de-facto standard for representing and 
+interpreting ratings in Vorbis comments uses a 0–100 integer scale, 
+ensuring consistent reading and writing of rating values across applications.
 
 Example: ``rating:quodlibet@sacredchao.net=0.67``
+         ``rating=67``
 
 **playcount**
 

--- a/quodlibet/formats/xiph.py
+++ b/quodlibet/formats/xiph.py
@@ -101,7 +101,10 @@ class MutagenVCFile(AudioFile):
                 key = f"{keyed_key}{subkey}"
                 if key in self:
                     try:
-                        self[f"~#{keyed_key}"] = func(self[key])
+                        if key == "rating":
+                            self[f"~#{keyed_key}"] = func(self[key]) / 100
+                        else:
+                            self[f"~#{keyed_key}"] = func(self[key])
                     except ValueError:
                         pass
                     del self[key]
@@ -272,6 +275,7 @@ class MutagenVCFile(AudioFile):
             email = email or const.EMAIL
             if self.has_rating:
                 comments[f"rating:{email}"] = str(self("~#rating"))
+                comments["rating"] = str(int(100 * self("~#rating")))
             playcount = self.get("~#playcount", 0)
             if playcount != 0:
                 comments[f"playcount:{email}"] = str(playcount)

--- a/tests/test_formats_xiph.py
+++ b/tests/test_formats_xiph.py
@@ -101,7 +101,8 @@ class TVCFileMixin:
         self.song.write()
         config.set("editing", "save_email", const.EMAIL)
         song = type(self.song)(self.filename)
-        self.assertEqual(song("~#rating"), RATINGS.default)
+        # expect custom rating because de-facto standard rating comment is always written
+        self.assertEqual(song("~#rating"), 0.2)
 
         song.write()
         config.set("editing", "save_email", "foo@Bar.org")

--- a/tests/test_formats_xiph.py
+++ b/tests/test_formats_xiph.py
@@ -101,7 +101,7 @@ class TVCFileMixin:
         self.song.write()
         config.set("editing", "save_email", const.EMAIL)
         song = type(self.song)(self.filename)
-        # expect custom rating because de-facto standard rating comment is always written
+        # expect custom rating because de-facto standard rating is always written
         self.assertEqual(song("~#rating"), 0.2)
 
         song.write()


### PR DESCRIPTION
Adds support for the de facto standard 0–100 scale rating in Vorbis comments.

- The 0–100 rating is now written alongside the Quod Libet–specific rating tags.
- When reading, the Quod Libet–specific rating takes precedence if both formats are present.
- As a side effect, ratings are now preserved when a custom e‑mail address is changed (uncertain if this behavior is desirable).
- Documentation about ratings in Vorbis comments has been updated.
- The test for modified custom e‑mails has been updated to reflect the new rating preservation behavior.

Resolves [#3812 ](https://github.com/quodlibet/quodlibet/issues/3812)
Resolves [#3533](https://github.com/quodlibet/quodlibet/issues/3533)