### PR TITLE
🔧 Fix cover failure handling in CoverManager & add tests

### DIFF
--- a/quodlibet/plugins/cover.py
+++ b/quodlibet/plugins/cover.py
@@ -10,7 +10,7 @@ import os.path
 from os import path, makedirs
 from hashlib import sha1
 
-from gi.repository import GObject, Soup
+from gi.repository import GObject
 
 from quodlibet import get_cache_dir
 from quodlibet.qltk import Icons
@@ -169,13 +169,14 @@ class CoverSourcePlugin(GObject.Object):
         """
         self.fail("This source is incapable of fetching covers", log=False)
 
-    def fail(self, message: Soup.Message, *, log: bool = True) -> None:
+    def fail(self, message: str, *, log: bool = True) -> None:
         """
         Shorthand method for emitting `fetch-failure` signals.
 
         Use:
             return self.fail("Transient failure message")
 
+        :param message: A string message to record about the failure
         :param log: Whether to log the failure message
         """
         self.emit("fetch-failure", message, log)

--- a/quodlibet/util/cover/manager.py
+++ b/quodlibet/util/cover/manager.py
@@ -102,7 +102,7 @@ class CoverManager(GObject.Object):
         sources = self.sources
 
         def success(source, result):
-            name = source.__class__.__name__
+            name = type(source).__name__
             print_d("Successfully got cover", context=name)
             source.disconnect_by_func(success)
             source.disconnect_by_func(failure)
@@ -110,7 +110,7 @@ class CoverManager(GObject.Object):
                 callback(True, result)
 
         def failure(source: GObject, msg: Soup.Message, log: bool = True) -> None:
-            name = source.__class__.__name__
+            name = type(source).__name__
             if log:
                 print_d(f"Didn't get cover: {msg}", context=name)
             source.disconnect_by_func(success)
@@ -126,7 +126,7 @@ class CoverManager(GObject.Object):
 
             cover = provider.cover
             if cover:
-                name = provider.__class__.__name__
+                name = type(provider).__name__
                 key = song.key if song else None
                 print_d(f"Found local cover for {key}", context=name)
                 callback(True, cover)
@@ -267,10 +267,11 @@ class CoverManager(GObject.Object):
                 self.emit("covers-found", provider, covers)
             provider.disconnect_by_func(search_complete)
 
-        def failure(provider, result):
+        def failure(provider: CoverManager, message: str, log: bool = True):
             finished(provider, False)
             name = provider.__class__.__name__
-            print_d(f"Failed to get cover from ({result})", context=name)
+            if log:
+                print_d(f"Failed to get cover ({message})", context=name)
             provider.disconnect_by_func(failure)
 
         def song_groups(songs, sources):

--- a/quodlibet/util/thumbnails.py
+++ b/quodlibet/util/thumbnails.py
@@ -145,7 +145,7 @@ def get_thumbnail(path: fsnative, boundary, ignore_temp=True) -> GdkPixbuf:
         pb = new_from_file_at_size(str(thumb_path), width, height)
     except GLib.GError:
         # in case it fails to load, we recreate it
-        print_w(f"Couldn't find thumbnail at {str(thumb_path)!r}, so recreating.")
+        print_d(f"Couldn't find thumbnail at {str(thumb_path)!r}, so recreating.")
     else:
         meta_mtime = pb.get_option("tEXt::Thumb::MTime")
         if meta_mtime is not None:

--- a/tests/test_plugins_cover.py
+++ b/tests/test_plugins_cover.py
@@ -26,6 +26,14 @@ from .helper import get_temp_copy
 
 DUMMY_COVER = io.StringIO()
 
+A_SONG = AudioFile(
+    {
+        "~filename": os.path.join("/tmp/asong.ogg"),
+        "album": "Abbey Road",
+        "artist": "The Beatles",
+    }
+)
+
 
 class DummyCoverSource1(CoverSourcePlugin):
     @staticmethod
@@ -71,9 +79,51 @@ class DummyCoverSource3(ApiCoverSourcePlugin):
         return self.emit("fetch-success", DUMMY_COVER)
 
 
+class FailingCoverSource(ApiCoverSourcePlugin):
+    PLUGIN_ID = "failing-fetcher"
+    PLUGIN_NAME = "Fetch Failer"
+
+    def search(self):
+        return self.fail("Never searches", log=False)
+
+    # For testing niceness
+    def __eq__(self, other):
+        return self.song == other.song
+
+    def __hash__(self):
+        return hash(self.song)
+
+
 dummy_sources = [
-    Plugin(s) for s in (DummyCoverSource1, DummyCoverSource2, DummyCoverSource3)
+    Plugin(s)
+    for s in (
+        DummyCoverSource1,
+        DummyCoverSource2,
+        DummyCoverSource3,
+        FailingCoverSource,
+    )
 ]
+
+
+class TCoverManagerFailures(TestCase):
+    def setUp(self):
+        self.manager = CoverManager(use_built_in=False)
+        self.handler = self.manager.plugin_handler
+        self.bad = dummy_sources[3]
+        self.manager.plugin_handler.plugin_enable(self.bad)
+
+    def test_failures(self):
+        def finished(manager, results):
+            assert manager == self.manager
+            cover_plugin = self.bad.cls(A_SONG)
+            assert results == {cover_plugin: False}
+
+        def done(manager, provider, result):
+            raise AssertionError("Shouldn't have found anything")
+
+        self.manager.connect("searches-complete", finished)
+        self.manager.connect("covers-found", done)
+        self.manager.search_cover(Cancellable(), [A_SONG])
 
 
 class TCoverManager(TestCase):
@@ -213,13 +263,7 @@ class TCoverManager(TestCase):
             source.cls.cover_call = False
             source.cls.fetch_call = False
 
-        song = AudioFile(
-            {
-                "~filename": os.path.join("/tmp/asong.ogg"),
-                "album": "Abbey Road",
-                "artist": "The Beatles",
-            }
-        )
+        song = A_SONG
         songs = [song]
         results = []
 


### PR DESCRIPTION
* Add missing bool to `CoverManager` callback, to stop failures from also failing (e.g. [these CI windows tests](https://github.com/quodlibet/quodlibet/actions/runs/20385179232/job/58584520247?pr=4823)).
* And actually only log at manager level if instructed.
* Fix some dodgy typing in 88bda15 - my bad
* Add unit test of failing manager
* Add live integration tests of real failures
* Also, mostly unrelated - reduce log level of cache recreation, doesn't seem warning at all.

