### PR TITLE
Add PositionColumn to display row position in song lists

### DIFF
--- a/quodlibet/qltk/songlistcolumns.py
+++ b/quodlibet/qltk/songlistcolumns.py
@@ -35,6 +35,8 @@ def create_songlist_column(model: Gtk.TreeModel, t):
         return FilesizeColumn()
     if t in ["~rating"]:
         return RatingColumn()
+    if t == "~#position":
+        return PositionColumn()
     if t.startswith("~#"):
         return NumericColumn(t)
     if t in FILESYSTEM_TAGS:
@@ -460,6 +462,34 @@ class FilesizeColumn(NumericColumn):
         text = util.format_size(value)
         cell.set_property("text", text)
         self._recalc_width(model.get_path(iter_), text)
+
+
+class PositionColumn(TextColumn):
+    """Displays the row position (1, 2, 3...) in the current view.
+
+    This shows the track's position within the current list/playlist,
+    not the track number from album metadata.
+    """
+
+    def __init__(self):
+        super().__init__("~#position")
+        self._render.set_property("xalign", 1.0)
+        self.set_alignment(1.0)
+        self.set_expand(False)
+        self.set_resizable(False)
+
+    def _format_title(self, tag):
+        return "#"
+
+    def _get_min_width(self):
+        return self._cell_width("9999")
+
+    def _fetch_value(self, model, iter_):
+        path = model.get_path(iter_)
+        return path[0] + 1 if path else 0
+
+    def _apply_value(self, model, iter_, cell, value):
+        cell.set_property("text", str(value))
 
 
 class CurrentColumn(SongListColumn):


### PR DESCRIPTION
Adds a new column type `~#position` that displays the track's position (1, 2, 3...) within the current view. This shows the row number in whatever list/playlist is currently displayed, not the track number from album metadata.

This is useful for playlists where users want to see sequential numbering regardless of the original album track numbers.

Usage: Add `~#position` to the columns via Preferences > Song List >
Edit (under "Others"), then Update Columns.

Closes #3271

Check-list
----------

 * [ ] There is a linked issue discussing the motivations for this feature or bugfix
 * [ ] Unit tests have been added where possible
 * [ ] I've added / updated documentation for any user-facing features.
 * [ ] Performance seems to be comparable or better than current `main`


What this change is adding / fixing
-----------------------------------
<!-- A high-level description of the changes.
Hopefully the commits are atomic and well described, but this is the overall
summary of the change, to other developers / maintainers, plus any TODOs. -->

<img width="2024" height="1112" alt="Screenshot from 2026-01-05 23-25-34" src="https://github.com/user-attachments/assets/9ce71c08-68a4-4265-a9c5-f1a7a068e8d4" />

