### PR TITLE
Fix sre_parse/sre_constants imports on Python 3.15

### DIFF
--- a/quodlibet/unisearch/parser.py
+++ b/quodlibet/unisearch/parser.py
@@ -7,9 +7,14 @@
 
 from collections.abc import Callable
 import re
-import sre_parse
-import sre_constants
 import unicodedata
+
+try:
+    from re import _parser as sre_parse  # type: ignore
+    from re import _constants as sre_constants  # type: ignore
+except ImportError:
+    import sre_parse
+    import sre_constants
 
 from quodlibet import print_d
 from quodlibet.util import re_escape


### PR DESCRIPTION
Check-list
----------

 * [ ] There is a linked issue discussing the motivations for this feature or bugfix
 * [ ] Unit tests have been added where possible
 * [ ] I've added / updated documentation for any user-facing features.
 * [x] Performance seems to be comparable or better than current `main`


What this change is adding / fixing
-----------------------------------

sre_parse/sre_constants are removed from Python 3.15 and thus they fail to import.