### PR TITLE
Use non-capturing group in PatternLexer

### DIFF
--- a/quodlibet/pattern/_pattern.py
+++ b/quodlibet/pattern/_pattern.py
@@ -73,7 +73,7 @@ class PatternLexer(Scanner):
         Scanner.__init__(
             self,
             [
-                (r"([^<>|\\]|\\.)+", self.text),
+                (r"(?:[^<>|\\]|\\.)+", self.text),
                 (r"\|\||[<>|]", self.table),
             ],
         )


### PR DESCRIPTION
Check-list
----------

 * [ ] There is a linked issue discussing the motivations for this feature or bugfix
 * [ ] Unit tests have been added where possible
 * [ ] I've added / updated documentation for any user-facing features.
 * [x] Performance seems to be comparable or better than current `main`


What this change is adding / fixing
-----------------------------------
Required as of Python 3.15.

See: https://github.com/python/cpython/pull/140944