### PR TITLE
Added --set-panes cli option, to be able to change currently visible panes from cli

### DIFF
--- a/docs/guide/commands/quodlibet.rst
+++ b/docs/guide/commands/quodlibet.rst
@@ -140,6 +140,9 @@ OPTIONS
 --set-browser=BrowserName
     Set the current browser
 
+--set-panes=<PanesConfig>
+    Set panes for current browser (config for each pane should be separated by \t)
+
 --show-window
     Show main window
 

--- a/quodlibet/browsers/paned/main.py
+++ b/quodlibet/browsers/paned/main.py
@@ -28,7 +28,7 @@ from quodlibet.util import connect_destroy
 from quodlibet.qltk.paned import ConfigMultiRHPaned
 
 from .prefs import PreferencesButton, ColumnMode
-from .util import get_headers
+from .util import get_headers, save_headers
 from .pane import Pane
 
 
@@ -321,3 +321,10 @@ class PanedBrowser(Browser, util.InstanceTracker):
 
     def fill(self, songs):
         GLib.idle_add(self.songs_selected, list(songs))
+
+    def set_panes_headers(self, new_headers):
+        new_headers = new_headers.split("\t")
+        if new_headers != get_headers():
+            save_headers(new_headers)
+            self.set_all_panes()
+            self.make_pane_widths_equal()

--- a/quodlibet/cli.py
+++ b/quodlibet/cli.py
@@ -110,6 +110,7 @@ def process_arguments(argv):
         "repeat-type",
         "shuffle-type",
         "add-location",
+        "set-panes",
     ]
 
     options = util.OptionParser(
@@ -183,6 +184,7 @@ def process_arguments(argv):
         ),
         ("add-location", _("Add a file or directory to the library"), _("location")),
         ("with-pattern", _("Set template for --print-* commands"), _("pattern")),
+        ("set-panes", _("Set paned browser panes"), _("set-panes")),
     ]:
         options.add(opt, help=help, arg=arg)
 

--- a/quodlibet/commands.py
+++ b/quodlibet/commands.py
@@ -17,6 +17,7 @@ from quodlibet.util.string import split_escape
 from quodlibet import browsers
 
 from quodlibet import util
+from quodlibet import _
 from quodlibet.util import print_d, print_e, copool
 
 from quodlibet.qltk.browser import LibraryBrowser
@@ -580,3 +581,9 @@ def _print_playing(app, fstring=None):
 def _uri_received(app, uri):
     uri = arg2text(uri)
     app.browser.emit("uri-received", uri)
+
+
+@registry.register("set-panes", args=1)
+def _set_panes(app, value):
+    if app.browser.name == _("Paned Browser"):
+        app.browser.set_panes_headers(value)


### PR DESCRIPTION
All is in the title, it's a direct implementation of the feature asked in #3109.

It's my first time contributing to quodlibet code, so I hope this PR is formed in an appropriate way. Also if there's anything missing to it let me know and I'll do my best to add the necessary.
I haven't added a test, but looking through them, I did not really know if it was necessary to add some for this. If necessary, let me know which test I should add where and I'll try my best to make one.

As mentioned in the issue, this is a small addition, but allow to add quite a bit of flexibility to quodlibet, making it relevant for many type of ways to organize at once. Hoping this is a welcome change :)

Check-list
----------

 * [x] There is a linked issue discussing the motivations for this feature or bugfix: #3109
 * [ ] Unit tests have been added where possible
 * [x] I've added / updated documentation for any user-facing features. — *hope I added it everywhere relevant, if desired I could also add a bit of documentation on how to use the feature*
 * [x] Performance seems to be comparable or better than current `main`


What this change is adding / fixing
-----------------------------------
Simply adds a `--set-panes` cli option.
This allows to run from cli for example `quodlibet --set-panes genre\tgrouping\tartist\t'<albumyear> - <album>'` to actually trigger the modification of panes, if current browser is paned, otherwise nothing is done.
