### PR TITLE
Move show_all() call down in AlbumArtWindow::__init__()

### DIFF
--- a/quodlibet/ext/songsmenu/albumart.py
+++ b/quodlibet/ext/songsmenu/albumart.py
@@ -699,11 +699,11 @@ class AlbumArtWindow(qltk.Window, PersistentWindowMixin, PluginConfigMixin):
 
         self.add(hpaned)
 
-        self.show_all()
-
         left_vbox.pack_start(self.progress, False, True, 0)
 
         self.connect("destroy", self.__save_config)
+
+        self.show_all()
 
         song = songs[0]
         text = SEARCH_PATTERN.format(song)


### PR DESCRIPTION
Check-list
----------

 * [ ] There is a linked issue discussing the motivations for this feature or bugfix
 * [ ] Unit tests have been added where possible
 * [ ] I've added / updated documentation for any user-facing features.
 * [x] Performance seems to be comparable or better than current `main`


What this change is adding / fixing
-----------------------------------
Somehow this fixes Flatpak unit tests with runtime 49.


