### PR TITLE
Discord presence plugin: Add new Exception type emitted by pypresence

### DIFF
--- a/quodlibet/ext/events/discord_status.py
+++ b/quodlibet/ext/events/discord_status.py
@@ -2,6 +2,7 @@
 #
 # Copyright (c) 2022 Aditi K <105543244+teeleafs@users.noreply.github.com>
 #               2025 W. Connor Yates <self@wcyates.xyz>
+#               2026 Tobias Klausmann <klausman@schwarzvogel.de>
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -26,6 +27,7 @@ try:
         ActivityType,
         StatusDisplayType,
     )
+    from pypresence.exceptions import PipeClosed as discord_PipeClosed
 except ImportError as err:
     from quodlibet.plugins import MissingModulePluginError
 
@@ -138,7 +140,7 @@ class DiscordStatusMessage(EventPlugin):
                 large_image=QL_LOGO_IMAGE_URL,
                 large_text=app.name,
             )
-        except InvalidID:
+        except (InvalidID, discord_PipeClosed):
             # XXX Discord was closed?
             self.discordrp = None
 


### PR DESCRIPTION
More recent versions of pypresence emit a new exception type. This usually fires if Discord was running at some point (and we had an open pipe to it), but has since closed. When we then emit another song change/status update, the exception `pypresence.exceptions.PipeClosed` is thrown. Since there is not much we can do except ignore it, we do just that. If Discord comes back, the client will automatically recover and status updates will happen again.

Check-list
----------

 * [x] There is a linked issue discussing the motivations for this feature or bugfix: #4641

What this change is adding / fixing
-----------------------------------
<!-- A high-level description of the changes.
Hopefully the commits are atomic and well described, but this is the overall
summary of the change, to other developers / maintainers, plus any TODOs. -->

Fixes new spurious error messages due to pypresence using a new/different exception type, see issue #4641