### PR TITLE
gstreamer: default to wasapi2sink on Windows and support exclusive mode

### DIFF
--- a/quodlibet/config.py
+++ b/quodlibet/config.py
@@ -42,6 +42,8 @@ INITIAL: dict[str, dict[str, str]] = {
         "gst_buffer": "3",
         "gst_device": "",
         "gst_disable_gapless": "false",
+        # Use WASAPI exclusive mode on Windows
+        "gst_exclusive_mode": "false",
         # Use Jack sink (via Gstreamer) if available
         "gst_use_jack": "false",
         # Usually true is good here, but if you have patchbay configured maybe not...

--- a/quodlibet/player/gstbe/player.py
+++ b/quodlibet/player/gstbe/player.py
@@ -491,8 +491,23 @@ class GStreamerPlayer(BasePlayer, GStreamerPluginHandler):
         if isinstance(sink_element, Gst.Bin):
             sink_element = iter_to_list(sink_element.iterate_recurse)[-1]
 
+        sink_name = sink_element.get_factory().get_name()
+
+        exclusive_mode_active = False
+        if config.getboolean("player", "gst_exclusive_mode") and hasattr(
+            sink_element.props, "exclusive"
+        ):
+            sink_element.set_property("exclusive", True)
+            exclusive_mode_active = True
+
+        force_internal_volume = False
+        if sink_name == AudioSinks.WASAPI2.value and exclusive_mode_active:
+            # wasapi2sink volume doesn't work in exclusive mode,
+            # so force using our internal volume element in this case
+            force_internal_volume = True
+
         self._ext_vol_element = None
-        if hasattr(sink_element.props, "volume"):
+        if hasattr(sink_element.props, "volume") and not force_internal_volume:
             self._ext_vol_element = sink_element
 
             # In case we use the sink volume directly we can increase buffering
@@ -515,10 +530,7 @@ class GStreamerPlayer(BasePlayer, GStreamerPluginHandler):
                 # directsoundsink has a mute property but it doesn't work properly
                 # https://bugzilla.gnome.org/show_bug.cgi?id=755106
                 # un-muting doesn't take effect until we set the volume again
-                if (
-                    not self.props.mute
-                    and sink_element.get_factory().get_name() == "directsoundsink"
-                ):
+                if not self.props.mute and sink_name == AudioSinks.DIRECTSOUND.value:
                     self.props.volume = self.props.volume
                 # gets called from a thread
                 GLib.idle_add(self.notify, "mute")

--- a/quodlibet/player/gstbe/prefs.py
+++ b/quodlibet/player/gstbe/prefs.py
@@ -15,7 +15,7 @@ from quodlibet.qltk.ccb import ConfigCheckButton, ConfigSwitch
 from quodlibet.qltk.entry import UndoEntry
 from quodlibet.qltk.x import Button
 from quodlibet.qltk import Icons
-from quodlibet.util import connect_obj
+from quodlibet.util import connect_obj, is_windows
 
 
 class GstPlayerPreferences(Gtk.VBox):
@@ -106,10 +106,23 @@ class GstPlayerPreferences(Gtk.VBox):
         # Buffer
         hb = self._create_buffer_box(buffer_label, scale)
         self.pack_start(hb, False, False, 0)
-
         self.pack_start(gapless_button, False, False, 0)
         self.pack_start(jack_button, False, False, 0)
         self.pack_start(jack_connect, False, False, 0)
+
+        exclusive_button = ConfigSwitch(
+            _("Exclusive Mode"),
+            "player",
+            "gst_exclusive_mode",
+            populate=True,
+            tooltip=_(
+                "Enable exclusive audio access. "
+                "Other applications won't be able to use audio while active."
+            ),
+        )
+        if is_windows():
+            # atm this is a wasapi2sink-only feature, so only makes sense on Windows
+            self.pack_start(exclusive_button, False, False, 0)
 
         if debug:
 

--- a/quodlibet/player/gstbe/util.py
+++ b/quodlibet/player/gstbe/util.py
@@ -42,6 +42,8 @@ class AudioSinks(Enum):
 
     WASAPI = "wasapisink"
 
+    WASAPI2 = "wasapi2sink"
+
 
 def pulse_is_running():
     """Returns whether pulseaudio is running"""
@@ -127,7 +129,7 @@ def find_audio_sink() -> tuple[Gst.Element, str]:
             print_d("Using JACK output via Gstreamer")
             return [AudioSinks.JACK]
         if is_windows():
-            return [AudioSinks.DIRECTSOUND]
+            return [AudioSinks.WASAPI2, AudioSinks.DIRECTSOUND]
         if is_linux() and pulse_is_running():
             return [AudioSinks.PULSE]
         return [

--- a/tests/test_player_gst.py
+++ b/tests/test_player_gst.py
@@ -66,7 +66,7 @@ class TGStreamerSink(TestCase):
         obj, name = gstreamer_sink("")
         assert obj
         if os.name == "nt":
-            self.assertEqual(name, "directsoundsink")
+            self.assertEqual(name, "wasapi2sink")
         else:
             self.assertEqual(name, find_audio_sink()[1])
 


### PR DESCRIPTION
wasapi2sink is now included in our mingw build as well, and from what I understand recommended if Win10+ is enough.

While at it also expose the WASAPI excusive mode in the preferences.
