### PR TITLE
wininst: modernize the Python launcher code

### DIFF
--- a/dev-utils/win_installer/misc/create-launcher.py
+++ b/dev-utils/win_installer/misc/create-launcher.py
@@ -69,14 +69,34 @@ def get_launcher_code(entry_point):
 int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance,
                     PWSTR lpCmdLine, int nCmdShow)
 {
+    PyStatus status;
+    PyConfig config;
     int result;
 
-    Py_NoUserSiteDirectory = 1;
-    Py_IgnoreEnvironmentFlag = 1;
-    Py_DontWriteBytecodeFlag = 1;
-    Py_Initialize();
-    PySys_SetArgvEx(__argc, __wargv, 0);
+    PyConfig_InitPythonConfig(&config);
+
+    config.user_site_directory = 0;
+    config.use_environment = 0;
+    config.write_bytecode = 0;
+    config.safe_path = 1;
+
+    status = PyConfig_SetArgv(&config, __argc, __wargv);
+    if (PyStatus_Exception(status)) {
+        PyConfig_Clear(&config);
+        Py_ExitStatusException(status);
+        return 1;
+    }
+
+    status = Py_InitializeFromConfig(&config);
+    if (PyStatus_Exception(status)) {
+        PyConfig_Clear(&config);
+        Py_ExitStatusException(status);
+        return 1;
+    }
+    PyConfig_Clear(&config);
+
     result = PyRun_SimpleString("%s");
+
     Py_Finalize();
     return result;
 }


### PR DESCRIPTION
It was using long deprecated functions, port it to the new PyConfig APIs. Ideally it should behave the same, only thing I changed is adding safe_path, which is a python 3.11 feature, which can't hurt, see https://docs.python.org/3/c-api/init_config.html#c.PyConfig.safe_path

This fixes all the deprecation warnings when building the launcher.
