### PR TITLE
trayicon: fall back to AyatanaAppIndicator3 when AppIndicator3 is unavailable

### DIFF
--- a/quodlibet/ext/events/trayicon/appindicator.py
+++ b/quodlibet/ext/events/trayicon/appindicator.py
@@ -11,10 +11,19 @@ import gi
 
 try:
     gi.require_version("AppIndicator3", "0.1")
-except ValueError as e:
-    raise ImportError(f"Can't load ({e}). Install gir*-appindicator3* package?") from e
+except ValueError:
+    try:
+        gi.require_version("AyatanaAppIndicator3", "0.1")
+    except ValueError as e:
+        raise ImportError(
+            f"Can't load AppIndicator3 or AyatanaAppIndicator3 ({e}). "
+            "Install gir*-appindicator3* package?"
+        ) from e
+    from gi.repository import AyatanaAppIndicator3 as AppIndicator3
+else:
+    from gi.repository import AppIndicator3
 
-from gi.repository import AppIndicator3, Gdk
+from gi.repository import Gdk
 
 import quodlibet
 from quodlibet import _


### PR DESCRIPTION
Most distributions now ship `libayatana-appindicator` (GIR namespace `AyatanaAppIndicator3`) rather than the original `libappindicator` (`AppIndicator3`). The API is identical; only the GIR namespace differs.

Without this fallback, the AppIndicator import fails silently on these systems. The tray icon plugin then falls back to `Gtk.StatusIcon`, which does not work on Wayland compositors — so the plugin appears to do nothing when enabled.

This patch tries `AppIndicator3` first, then `AyatanaAppIndicator3`, and aliases whichever one loads so the rest of the module is unchanged.

Tested on Gentoo (Sway/Wayland) with `dev-libs/libayatana-appindicator` and waybar's SNI tray.