### PR TITLE
Mpd query

### DIFF
--- a/quodlibet/ext/events/mpdserver/__init__.py
+++ b/quodlibet/ext/events/mpdserver/__init__.py
@@ -62,8 +62,7 @@ class MPDServerPlugin(EventPlugin, PluginConfigMixin):
     PLUGIN_NAME = _("MPD Server")
     PLUGIN_DESC = _(
         "Allows remote control of Quod Libet using an MPD Client. "
-        "Streaming, playlist and library management "
-        "are not supported."
+        "Streaming and library management are not supported."
     )
     PLUGIN_ICON = Icons.NETWORK_WORKGROUP
 

--- a/quodlibet/ext/events/mpdserver/filtering.py
+++ b/quodlibet/ext/events/mpdserver/filtering.py
@@ -1,0 +1,606 @@
+# Copyright 2026 Felicián Németh <felician.nemeth@gmail.com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+
+"""Translate MPD filter expressions into Quod Libet query syntax."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import time
+
+from quodlibet.util import parse_date, re_escape
+
+
+class MPDFilterError(Exception):
+    pass
+
+
+class MPDSearchConverter:
+    TAG_MAP = {
+        "file": "~filename",
+        "title": "title",
+        "titlesort": "titlesort",
+        "album": "album",
+        "albumsort": "albumsort",
+        "artist": "artist",
+        "artistsort": "artistsort",
+        "albumartist": "albumartist,artist",
+        "albumartistsort": "albumartistsort",
+        "track": "tracknumber",
+        "name": "name",
+        "genre": "genre",
+        "mood": "mood",
+        "date": "date,~year",
+        "originaldate": "originaldate,~originalyear",
+        "composer": "composer",
+        "composersort": "composersort",
+        "performer": "performer",
+        "conductor": "conductor",
+        "work": "work",
+        "ensemble": "ensemble",
+        "movement": "movement",
+        "movementnumber": "movementnumber",
+        "showmovement": "showmovement",
+        "location": "location",
+        "grouping": "grouping",
+        "comment": "comment",
+        "disc": "discnumber",
+        "label": "label",
+        "musicbrainz_artistid": "musicbrainz_artistid",
+        "musicbrainz_albumid": "musicbrainz_albumid",
+        "musicbrainz_albumartistid": "musicbrainz_albumartistid",
+        "musicbrainz_trackid": "musicbrainz_trackid",
+        "musicbrainz_releasegroupid": "musicbrainz_releasegroupid",
+        "musicbrainz_releasetrackid": "musicbrainz_releasetrackid",
+        "musicbrainz_workid": "musicbrainz_workid",
+        "any": "any",
+    }
+    ANY_TAGS = (
+        "title",
+        "artist",
+        "album",
+        "albumartist",
+        "genre",
+        "~filename",
+    )
+    CASE_FALLBACK = {
+        "eq_cs": "==",
+        "eq_ci": "==",
+        "!eq_cs": "!=",
+        "!eq_ci": "!=",
+        "contains_cs": "contains",
+        "contains_ci": "contains",
+        "!contains_cs": "!contains",
+        "!contains_ci": "!contains",
+        "starts_with_cs": "starts_with",
+        "starts_with_ci": "starts_with",
+        "!starts_with_cs": "!starts_with",
+        "!starts_with_ci": "!starts_with",
+    }
+
+    def to_query(self, filter_expr: str) -> str:
+        expr = filter_expr.strip()
+        if not expr:
+            raise MPDFilterError("Wrong arg count")
+
+        tokens = _tokenize(expr)
+        parser = _FilterParser(tokens)
+        node = parser.parse_filter()
+        if not parser.is_done():
+            raise MPDFilterError("invalid arg")
+        return node.to_query(self)
+
+    def legacy_to_query(self, args: list[str]) -> str:
+        if not args:
+            raise MPDFilterError("Wrong arg count")
+        if len(args) % 2:
+            raise MPDFilterError("Wrong arg count")
+
+        terms = []
+        # Legacy MPD form: search <tag> <value> [<tag> <value> ...]
+        # We treat it as a case-insensitive substring search.
+        for index in range(0, len(args), 2):
+            tag = args[index].lower()
+            value = args[index + 1]
+            terms.append(self._term_query(tag, "contains", value))
+        return _combine_query("&", terms)
+
+    def _term_query(self, tag: str, op: str, value: str) -> str:
+        if tag not in self.TAG_MAP:
+            raise MPDFilterError("invalid arg")
+
+        qtag = self.TAG_MAP[tag]
+
+        # TODO: Respect case-sensitive operators when mapping to queries.
+        normalized = self.CASE_FALLBACK.get(op, op)
+        negate = False
+
+        if normalized in {"!=", "!contains", "!starts_with", "!~"}:
+            negate = True
+            normalized = normalized[1:]
+            if normalized == "=":
+                normalized = "=="
+
+        if normalized == "==":
+            term = self._format_match(qtag, value, exact=True)
+        elif normalized == "contains":
+            term = self._format_contains(qtag, value)
+        elif normalized == "starts_with":
+            term = self._format_starts_with(qtag, value)
+        elif normalized == "=~":
+            # MPD uses PCRE if available; Quod Libet uses Python regex. We fall
+            # back to Python regex search semantics here.
+            term = self._format_regex(qtag, value)
+        else:
+            raise MPDFilterError("invalid arg")
+
+        if negate:
+            return _negate_query(term)
+        return term
+
+    def _any_query(self, value: str, exact: bool) -> str:
+        terms = [_format_query_term(tag, value, exact) for tag in self.ANY_TAGS]
+        return _combine_query("|", terms)
+
+    def _format_match(
+        self,
+        tag: str,
+        value: str,
+        exact: bool = False,
+        prefix: bool = False,
+    ) -> str:
+        if "," in tag:
+            terms = [
+                self._format_match(part.strip(), value, exact, prefix)
+                for part in tag.split(",")
+            ]
+            return _combine_query("|", terms)
+        if tag == "any":
+            if prefix:
+                terms = [
+                    _format_regex_term(t, _format_prefix_regex(value))
+                    for t in self.ANY_TAGS
+                ]
+                return _combine_query("|", terms)
+            return self._any_query(value, exact)
+
+        if prefix:
+            return _format_regex_term(tag, _format_prefix_regex(value))
+
+        return _format_query_term(tag, value, exact)
+
+    def _format_contains(self, tag: str, value: str) -> str:
+        return self._format_regex_query(tag, re_escape(value))
+
+    def _format_starts_with(self, tag: str, value: str) -> str:
+        return self._format_regex_query(tag, _format_prefix_regex(value))
+
+    def _format_regex_query(self, tag: str, pattern: str) -> str:
+        if "," in tag:
+            tags = tag.split(",")
+            terms = [_format_regex_term(part.strip(), pattern) for part in tags]
+            return _combine_query("|", terms)
+        if tag == "any":
+            terms = [_format_regex_term(t, pattern) for t in self.ANY_TAGS]
+            return _combine_query("|", terms)
+        return _format_regex_term(tag, pattern)
+
+    def _format_regex(self, tag: str, value: str) -> str:
+        pattern = value.replace("/", "\\/")
+        if "," in tag:
+            terms = [
+                _format_regex_term(part.strip(), pattern) for part in tag.split(",")
+            ]
+            return _combine_query("|", terms)
+        if tag == "any":
+            terms = [_format_regex_term(t, pattern) for t in self.ANY_TAGS]
+            return _combine_query("|", terms)
+        return _format_regex_term(tag, pattern)
+
+
+def _format_query_term(tag: str, value: str, exact: bool) -> str:
+    escaped = value.replace("\\", "\\\\").replace('"', '\\"')
+    if exact:
+        return f'{tag}="{escaped}"'
+    return f"{tag}={escaped}"
+
+
+def _format_regex_term(tag: str, pattern: str) -> str:
+    return f"{tag}=/{pattern}/d"
+
+
+def _format_prefix_regex(value: str) -> str:
+    return f"^{re_escape(value)}"
+
+
+def _negate_query(query: str) -> str:
+    return f"!{query}"
+
+
+def _negate_term(tag: str, term: str) -> str:
+    if tag == "any" or "," in tag:
+        return _negate_query(term)
+    if term.startswith(f"{tag}="):
+        return term.replace("=", "!=", 1)
+    return _negate_query(term)
+
+
+def _combine_query(op: str, terms: list[str]) -> str:
+    if len(terms) == 1:
+        return terms[0]
+    return f"{op}({', '.join(terms)})"
+
+
+class _FilterNode:
+    def to_query(self, converter: MPDSearchConverter) -> str:
+        raise NotImplementedError
+
+
+class _TermNode(_FilterNode):
+    def __init__(self, tag: str, op: str, value: str) -> None:
+        self.tag = tag
+        self.op = op
+        self.value = value
+
+    def to_query(self, converter: MPDSearchConverter) -> str:
+        return converter._term_query(self.tag, self.op, self.value)
+
+
+class _BaseNode(_FilterNode):
+    def __init__(self, value: str) -> None:
+        self.value = value
+
+    def to_query(self, converter: MPDSearchConverter) -> str:
+        # MPD base matches a subdirectory. We approximate this as a filename
+        # substring search because Quod Libet has no music-dir-relative view.
+        return converter._term_query("file", "contains", self.value)
+
+
+class _SinceNode(_FilterNode):
+    def __init__(self, tag: str, value: str) -> None:
+        self.tag = tag
+        self.value = value
+
+    def to_query(self, converter: MPDSearchConverter) -> str:
+        timestamp = _parse_timestamp(self.value)
+        age = max(0, int(time.time()) - timestamp)
+        return f"#({self.tag} <= {age:d})"
+
+
+class _AudioFormatNode(_FilterNode):
+    def __init__(self, op: str, value: str) -> None:
+        self.op = op
+        self.value = value
+
+    def to_query(self, converter: MPDSearchConverter) -> str:
+        return _audioformat_query(self.op, self.value)
+
+
+class _PrioNode(_FilterNode):
+    def __init__(self, op: str, value: str) -> None:
+        self.op = op
+        self.value = value
+
+    def to_query(self, converter: MPDSearchConverter) -> str:
+        number = _parse_int(self.value)
+        return f"#(prio {self.op} {number:d})"
+
+
+class _AndNode(_FilterNode):
+    def __init__(self, left: _FilterNode, right: _FilterNode) -> None:
+        self.left = left
+        self.right = right
+
+    def to_query(self, converter: MPDSearchConverter) -> str:
+        return _combine_query(
+            "&",
+            [self.left.to_query(converter), self.right.to_query(converter)],
+        )
+
+
+class _OrNode(_FilterNode):
+    def __init__(self, left: _FilterNode, right: _FilterNode) -> None:
+        self.left = left
+        self.right = right
+
+    def to_query(self, converter: MPDSearchConverter) -> str:
+        return _combine_query(
+            "|",
+            [self.left.to_query(converter), self.right.to_query(converter)],
+        )
+
+
+class _NotNode(_FilterNode):
+    def __init__(self, node: _FilterNode) -> None:
+        self.node = node
+
+    def to_query(self, converter: MPDSearchConverter) -> str:
+        return _negate_query(self.node.to_query(converter))
+
+
+class _Token:
+    def __init__(self, value: str, kind: str) -> None:
+        self.value = value
+        self.kind = kind
+
+
+class _FilterParser:
+    def __init__(self, tokens: list[_Token]) -> None:
+        self._tokens = tokens
+        self._index = 0
+
+    def is_done(self) -> bool:
+        return self._index >= len(self._tokens)
+
+    def parse_filter(self) -> _FilterNode:
+        return self._parse_group()
+
+    def _parse_group(self) -> _FilterNode:
+        self._expect("(")
+        node = self._parse_or()
+        self._expect(")")
+        return node
+
+    def _parse_or(self) -> _FilterNode:
+        node = self._parse_and()
+        while True:
+            token = self._peek()
+            if token is None:
+                break
+            if token.value == "|" or token.value.upper() == "OR":
+                self._next()
+                node = _OrNode(node, self._parse_and())
+                continue
+            break
+        return node
+
+    def _parse_and(self) -> _FilterNode:
+        node = self._parse_term()
+        while True:
+            token = self._peek()
+            if token is None:
+                break
+            if token.value.upper() != "AND":
+                break
+            self._next()
+            node = _AndNode(node, self._parse_term())
+        return node
+
+    def _parse_term(self) -> _FilterNode:
+        token = self._peek()
+        if token is None:
+            raise MPDFilterError("invalid arg")
+        if token.value == "!":
+            self._next()
+            return _NotNode(self._parse_group())
+        if token.value == "(":
+            return self._parse_group()
+        return self._parse_predicate()
+
+    def _parse_predicate(self) -> _FilterNode:
+        tag = self._expect_word().lower()
+
+        if tag == "base":
+            value = self._expect_value()
+            return _BaseNode(value)
+
+        if tag in {"added-since", "modified-since"}:
+            value = self._expect_value()
+            mapped = "added" if tag == "added-since" else "mtime"
+            return _SinceNode(mapped, value)
+
+        if tag == "audioformat":
+            op = self._expect_operator({"==", "=~"})
+            value = self._expect_value()
+            return _AudioFormatNode(op, value)
+
+        if tag == "prio":
+            op = self._expect_operator({"==", "!=", ">=", "<=", ">", "<"})
+            value = self._expect_value()
+            return _PrioNode(op, value)
+
+        op = self._expect_operator(
+            {
+                "==",
+                "!=",
+                "contains",
+                "!contains",
+                "starts_with",
+                "!starts_with",
+                "=~",
+                "!~",
+                "eq_cs",
+                "eq_ci",
+                "!eq_cs",
+                "!eq_ci",
+                "contains_cs",
+                "contains_ci",
+                "!contains_cs",
+                "!contains_ci",
+                "starts_with_cs",
+                "starts_with_ci",
+                "!starts_with_cs",
+                "!starts_with_ci",
+            }
+        )
+        value = self._expect_value()
+        return _TermNode(tag, op, value)
+
+    def _peek(self) -> _Token | None:
+        if self._index >= len(self._tokens):
+            return None
+        return self._tokens[self._index]
+
+    def _next(self) -> _Token | None:
+        if self._index >= len(self._tokens):
+            return None
+        value = self._tokens[self._index]
+        self._index += 1
+        return value
+
+    def _expect(self, value: str) -> None:
+        token = self._next()
+        if token is None or token.value != value:
+            raise MPDFilterError("invalid arg")
+
+    def _expect_word(self) -> str:
+        token = self._next()
+        if token is None or token.kind != "word":
+            raise MPDFilterError("invalid arg")
+        return token.value
+
+    def _expect_value(self) -> str:
+        token = self._next()
+        if token is None or token.kind not in {"word", "string"}:
+            raise MPDFilterError("invalid arg")
+        return token.value
+
+    def _expect_operator(self, allowed: set[str]) -> str:
+        token = self._next()
+        if token is None or token.kind not in {"word", "op"}:
+            raise MPDFilterError("invalid arg")
+        op = token.value.lower()
+        if op not in allowed:
+            raise MPDFilterError("invalid arg")
+        return op
+
+
+def _tokenize(expr: str) -> list[_Token]:
+    tokens: list[_Token] = []
+    i = 0
+    while i < len(expr):
+        char = expr[i]
+        if char.isspace():
+            i += 1
+            continue
+        if char in "()|":
+            tokens.append(_Token(char, "symbol"))
+            i += 1
+            continue
+        if char in ('"', "'"):
+            quote = char
+            i += 1
+            buf = []
+            while i < len(expr):
+                if expr[i] == "\\" and i + 1 < len(expr):
+                    buf.append(expr[i + 1])
+                    i += 2
+                    continue
+                if expr[i] == quote:
+                    i += 1
+                    break
+                buf.append(expr[i])
+                i += 1
+            else:
+                raise MPDFilterError("invalid arg")
+            tokens.append(_Token("".join(buf), "string"))
+            continue
+        if char == "!" and i + 1 < len(expr) and expr[i + 1].isalpha():
+            start = i
+            i += 1
+            while i < len(expr) and not expr[i].isspace() and expr[i] not in "()|=!<>":
+                i += 1
+            tokens.append(_Token(expr[start:i], "word"))
+            continue
+        if char in "=!<>":
+            if expr.startswith("==", i):
+                tokens.append(_Token("==", "op"))
+                i += 2
+                continue
+            if expr.startswith("!=", i):
+                tokens.append(_Token("!=", "op"))
+                i += 2
+                continue
+            if expr.startswith("=~", i):
+                tokens.append(_Token("=~", "op"))
+                i += 2
+                continue
+            if expr.startswith("!~", i):
+                tokens.append(_Token("!~", "op"))
+                i += 2
+                continue
+            if expr.startswith(">=", i):
+                tokens.append(_Token(">=", "op"))
+                i += 2
+                continue
+            if expr.startswith("<=", i):
+                tokens.append(_Token("<=", "op"))
+                i += 2
+                continue
+            if char in "<>":
+                tokens.append(_Token(char, "op"))
+                i += 1
+                continue
+            if char == "!":
+                tokens.append(_Token("!", "symbol"))
+                i += 1
+                continue
+            raise MPDFilterError("invalid arg")
+
+        start = i
+        while i < len(expr):
+            if expr[i].isspace() or expr[i] in "()|=!<>":
+                break
+            i += 1
+        tokens.append(_Token(expr[start:i], "word"))
+
+    return tokens
+
+
+def _parse_int(value: str) -> int:
+    try:
+        return int(value)
+    except ValueError as e:
+        raise MPDFilterError("invalid arg") from e
+
+
+def _parse_timestamp(value: str) -> int:
+    if value.isdigit():
+        return _parse_int(value)
+
+    iso_value = value
+    if iso_value.endswith("Z"):
+        iso_value = iso_value[:-1] + "+00:00"
+    try:
+        parsed = datetime.fromisoformat(iso_value)
+    except ValueError:
+        try:
+            return int(parse_date(value))
+        except ValueError as e:
+            raise MPDFilterError("invalid arg") from e
+
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return int(parsed.timestamp())
+
+
+def _audioformat_query(op: str, value: str) -> str:
+    parts = value.split(":")
+    if len(parts) != 3:
+        raise MPDFilterError("invalid arg")
+    samplerate, bitdepth, channels = parts
+
+    allow_wildcard = op == "=~"
+
+    terms = []
+    terms.extend(_audioformat_term("samplerate", samplerate, allow_wildcard))
+    terms.extend(_audioformat_term("bitdepth", bitdepth, allow_wildcard))
+    terms.extend(_audioformat_term("channels", channels, allow_wildcard))
+
+    if not terms:
+        raise MPDFilterError("invalid arg")
+    return _combine_query("&", terms)
+
+
+def _audioformat_term(tag: str, value: str, allow_wildcard: bool) -> list[str]:
+    if value == "*":
+        if allow_wildcard:
+            return []
+        raise MPDFilterError("invalid arg")
+
+    number = _parse_int(value)
+    return [f"#({tag} == {number:d})"]

--- a/quodlibet/ext/events/mpdserver/main.py
+++ b/quodlibet/ext/events/mpdserver/main.py
@@ -1,4 +1,5 @@
-# Copyright 2014 Christoph Reiter <reiter.christoph@gmail.com>
+# Copyright 2014-2026 Christoph Reiter <reiter.christoph@gmail.com>
+# Copyright 2026 Felicián Németh <felician.nemeth@gmail.com>
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -14,6 +15,7 @@ from senf import bytes2fsn, fsn2bytes
 from quodlibet import const
 from quodlibet.util import print_d, print_w
 from .tcpserver import BaseTCPServer, BaseTCPConnection
+from .filtering import MPDSearchConverter, MPDFilterError
 
 
 class AckError:
@@ -37,13 +39,7 @@ class Permissions:
     ADD = 2
     CONTROL = 4
     ADMIN = 8
-    ALL = (
-        NONE
-        | READ
-        | ADD
-        | CONTROL
-        | ADMIN
-    )
+    ALL = NONE | READ | ADD | CONTROL | ADMIN
 
 
 TAG_MAPPING = [
@@ -127,7 +123,7 @@ def parse_command(line):
 class MPDService:
     """This is the actual shared MPD service which the clients talk to"""
 
-    version = (0, 17, 0)
+    version = (0, 25, 0)
 
     def __init__(self, app, config):
         self._app = app
@@ -440,6 +436,15 @@ class MPDService:
         parts.append(f"Id: {self._get_id(song):d}")
         return "\n".join(parts)
 
+    def _format_library_song(self, song):
+        parts = []
+        parts.append(f"file: {song('~filename')}")
+        tag_info = format_tags(song)
+        if tag_info:
+            parts.append(tag_info)
+        parts.append(f"Time: {int(song('~#length') or 0):d}")
+        return "\n".join(parts)
+
     def queue_song_by_pos(self, songpos):
         songs = self.queue_songs()
         if songpos < 0 or songpos >= len(songs):
@@ -489,6 +494,9 @@ class MPDService:
         for offset, song in enumerate(songs):
             self._queue_model.insert(position + offset, row=[song])
 
+    def search_library(self, ql_query_text):
+        return self._app.library.query(ql_query_text)
+
     def playlistinfo(self, start=None, end=None):
         if start is not None and start > 1:
             return None
@@ -533,6 +541,111 @@ class MPDRequestError(Exception):
         self.msg = msg
         self.code = code
         self.index = index
+
+
+def _mpd_filter_error(e: MPDFilterError) -> MPDRequestError:
+    if e.args and e.args[0] == "Wrong arg count":
+        return MPDRequestError("Wrong arg count")
+    return MPDRequestError("invalid arg")
+
+
+def _parse_search_options(filter_expr, remaining):
+    # MPD uses a parenthesized filter expression followed by key/value options.
+    if not (filter_expr.startswith("(") and filter_expr.endswith(")")):
+        raise MPDFilterError("invalid arg")
+
+    # Store parsed values; keys are always present even if None.
+    options = {"range": None, "position": None, "sort": None}
+
+    if len(remaining) % 2:
+        raise MPDFilterError("invalid arg")
+
+    for idx in range(0, len(remaining), 2):
+        key = remaining[idx]
+        value = remaining[idx + 1]
+        if key == "window":
+            options["range"] = _parse_window(value)  # type: ignore[assignment]
+            continue
+        if key == "sort":
+            options["sort"] = _parse_sort(value)  # type: ignore[assignment]
+            continue
+        if key == "position":
+            options["position"] = _parse_position(value)  # type: ignore[assignment]
+            continue
+        raise MPDFilterError("invalid arg")
+
+    return options
+
+
+def _parse_window(arg):
+    try:
+        start, end = _parse_range(arg)
+    except MPDRequestError as e:
+        raise MPDRequestError("invalid arg") from e
+    if start < 0 or end < 0:
+        raise MPDRequestError("invalid arg")
+    return start, end
+
+
+def _parse_position(arg):
+    try:
+        return _parse_int(arg)
+    except MPDRequestError as e:
+        raise MPDRequestError("invalid arg") from e
+
+
+def _parse_sort(arg):
+    if not arg:
+        raise MPDFilterError("invalid arg")
+    if arg.startswith("-"):
+        tag = arg[1:]
+        if not tag:
+            raise MPDFilterError("invalid arg")
+        return tag, "desc"
+    return arg, "asc"
+
+
+def _prepare_search(args):
+    converter = MPDSearchConverter()
+    if _is_legacy_search_args(args, converter.TAG_MAP):
+        options = {"range": None, "position": None, "sort": None}
+        return converter.legacy_to_query(args), options
+
+    if not args:
+        raise MPDFilterError("Wrong arg count")
+
+    filter_expr = args[0]
+    options = _parse_search_options(filter_expr, args[1:])
+    query_text = converter.to_query(filter_expr)
+    return query_text, options
+
+
+def _is_legacy_search_args(args, tag_map):
+    if not args or len(args) % 2:
+        return False
+    for index in range(0, len(args), 2):
+        if args[index].lower() not in tag_map:
+            return False
+    return True
+
+
+def _apply_window_position(songs, window_range):
+    if window_range is not None:
+        start, end = window_range
+        songs = songs[start:end]
+    return songs
+
+
+def _run_search(service, args):
+    try:
+        query_text, options = _prepare_search(args)
+    except MPDFilterError as e:
+        raise _mpd_filter_error(e) from e
+
+    songs = service.search_library(query_text)
+    if options["position"] is not None:
+        _parse_position(options["position"])
+    return _apply_window_position(songs, options["range"])
 
 
 class MPDConnection(BaseTCPConnection):
@@ -986,6 +1099,28 @@ def _cmd_tagtypes(conn, service, args):
 @MPDConnection.Command("lsinfo", Permissions.READ)
 def _cmd_lsinfo(conn, service, args):
     _verify_length(args, 1)
+
+
+@MPDConnection.Command("search", Permissions.READ)
+def _cmd_search(conn, service, args):
+    songs = _run_search(service, args)
+    for song in songs:
+        conn.write_line(service._format_library_song(song))
+
+
+@MPDConnection.Command("searchadd", Permissions.ADD)
+def _cmd_searchadd(conn, service, args):
+    songs = _run_search(service, args)
+    if songs:
+        service.queue_insert(songs)
+
+
+@MPDConnection.Command("searchcount", Permissions.READ)
+def _cmd_searchcount(conn, service, args):
+    songs = _run_search(service, args)
+    playtime = sum(int(song("~#length") or 0) for song in songs)
+    conn.write_line(f"songs: {len(songs):d}")
+    conn.write_line(f"playtime: {playtime:d}")
 
 
 @MPDConnection.Command("playlistinfo", Permissions.READ)

--- a/quodlibet/ext/events/mpdserver/main.py
+++ b/quodlibet/ext/events/mpdserver/main.py
@@ -136,9 +136,17 @@ class MPDService:
         self._idle_queue = {}
         self._pl_ver = 0
 
+        # Queue-as-playlist note: when the queue is empty but playback is
+        # sourced from the main song list, MPD clients will see an empty
+        # playlist (playlistlength=0, playlist/playlistinfo empty) while
+        # currentsong still reports the active track.
+        self._queue_model = None
+        self._queue_sigs = []
+
         self._config = config
         self._options = app.player_options
 
+        # If no password is set, all clients get full permissions by default.
         if not self._config.config_get("password"):
             self.default_permission = Permissions.ALL
         else:
@@ -176,6 +184,28 @@ class MPDService:
         id_ = app.player.connect("song-started", playlist_changed)
         self._player_sigs.append(id_)
 
+        # Queue support design notes:
+        # - We treat the QL queue as the MPD "current playlist".
+        # - MPD song IDs are derived from the song object's identity (see _get_id),
+        #   so they are process-local and change if the backing object changes.
+        # - Playlist version (_pl_ver) increments on queue mutations so MPD
+        #   clients using idle can observe playlist changes.
+        self._queue_model = self._get_queue_model()
+        if self._queue_model is not None:
+            for signal_name in ("row-inserted", "row-deleted", "rows-reordered"):
+                self._queue_sigs.append(
+                    self._queue_model.connect(signal_name, self._queue_changed)
+                )
+
+    def _get_queue_model(self):
+        window = getattr(self._app, "window", None)
+        qexpander = getattr(window, "qexpander", None)
+        return getattr(qexpander, "model", None)
+
+    def _queue_changed(self, *args):
+        self._pl_ver += 1
+        self.emit_changed("playlist")
+
     def _get_id(self, info):
         # XXX: we need a unique 31 bit ID, but don't have one.
         # Given that the heap is continuous and each object is >16 bytes
@@ -185,6 +215,10 @@ class MPDService:
     def destroy(self):
         for id_ in self._player_sigs:
             self._app.player.disconnect(id_)
+        for id_ in self._queue_sigs:
+            if self._queue_model is not None:
+                self._queue_model.disconnect(id_)
+        self._queue_sigs = []
         del self._options
         del self._app
 
@@ -300,6 +334,8 @@ class MPDService:
         app = self._app
         info = app.player.info
 
+        queue_length = self.queue_length()
+
         if info:
             if app.player.paused:
                 state = "pause"
@@ -315,7 +351,7 @@ class MPDService:
             ("single", int(self._options.single)),
             ("consume", 0),
             ("playlist", self._pl_ver),
-            ("playlistlength", int(bool(app.player.info))),
+            ("playlistlength", queue_length),
             ("mixrampdb", 0.0),
             ("state", state),
         ]
@@ -367,6 +403,92 @@ class MPDService:
 
         return "\n".join(parts)
 
+    def queue_songs(self):
+        if self._queue_model is None:
+            return []
+        return [row[0] for row in self._queue_model]
+
+    def queue_length(self):
+        if self._queue_model is None:
+            return 0
+        return len(self._queue_model)
+
+    def queue_songinfo(self, start=None, end=None):
+        start, _end, songs = self._slice_queue(start, end)
+
+        info = []
+        for index, song in enumerate(songs, start=start):
+            info.append(self._format_queue_song(song, index))
+        return info
+
+    def queue_songinfo_by_id(self, songid):
+        info = []
+        for index, song in enumerate(self.queue_songs()):
+            if self._get_id(song) != songid:
+                continue
+            info.append(self._format_queue_song(song, index))
+        return info
+
+    def _format_queue_song(self, song, index):
+        parts = []
+        parts.append(f"file: {song('~filename')}")
+        tag_info = format_tags(song)
+        if tag_info:
+            parts.append(tag_info)
+        parts.append(f"Time: {int(song('~#length') or 0):d}")
+        parts.append(f"Pos: {index:d}")
+        parts.append(f"Id: {self._get_id(song):d}")
+        return "\n".join(parts)
+
+    def queue_song_by_pos(self, songpos):
+        songs = self.queue_songs()
+        if songpos < 0 or songpos >= len(songs):
+            raise MPDRequestError("No such song", AckError.NO_EXIST)
+        return songs[songpos]
+
+    def queue_playlist(self, start=None, end=None):
+        _start, _end, songs = self._slice_queue(start, end)
+        return [f"file: {song('~filename')}" for song in songs]
+
+    def queue_posid_info(self):
+        info = []
+        for index, song in enumerate(self.queue_songs()):
+            parts = [
+                f"file: {song('~filename')}",
+                f"Pos: {index:d}",
+                f"Id: {self._get_id(song):d}",
+            ]
+            info.append("\n".join(parts))
+        return info
+
+    def _slice_queue(self, start, end):
+        songs = self.queue_songs()
+        if start is None and end is None:
+            return 0, len(songs), songs
+        start = 0 if start is None else start
+        end = len(songs) if end is None else end
+        return start, end, songs[start:end]
+
+    def queue_remove_positions(self, positions):
+        if self._queue_model is None:
+            raise MPDRequestError("No queue", AckError.NO_EXIST)
+        for pos in sorted(positions, reverse=True):
+            if pos < 0 or pos >= len(self._queue_model):
+                raise MPDRequestError("No such song", AckError.NO_EXIST)
+            iter_ = self._queue_model.get_iter((pos,))
+            self._queue_model.remove(iter_)
+
+    def queue_insert(self, songs, position=None):
+        if self._queue_model is None:
+            raise MPDRequestError("No queue", AckError.NO_EXIST)
+        if position is None or position >= len(self._queue_model):
+            self._queue_model.append_many(songs)
+            return
+        if position < 0:
+            raise MPDRequestError("No such song", AckError.NO_EXIST)
+        for offset, song in enumerate(songs):
+            self._queue_model.insert(position + offset, row=[song])
+
     def playlistinfo(self, start=None, end=None):
         if start is not None and start > 1:
             return None
@@ -378,18 +500,13 @@ class MPDService:
 
     def plchanges(self, version):
         if version != self._pl_ver:
-            return self.currentsong()
-        return None
+            return self.queue_songinfo()
+        return []
 
     def plchangesposid(self, version):
-        info = self._app.player.info
-        if version != self._pl_ver and info:
-            parts = []
-            parts.append(f"file: {info('~filename')}")
-            parts.append(f"Pos: {0:d}")
-            parts.append(f"Id: {self._get_id(info):d}")
-            return "\n".join(parts)
-        return None
+        if version != self._pl_ver:
+            return self.queue_posid_info()
+        return []
 
 
 class MPDServer(BaseTCPServer):
@@ -645,6 +762,13 @@ def _parse_range(arg):
     raise MPDRequestError("invalid range")
 
 
+def _parse_songpos(arg):
+    pos = _parse_int(arg)
+    if pos < 0:
+        raise MPDRequestError("No such song", AckError.NO_EXIST)
+    return pos
+
+
 @MPDConnection.Command("idle", ack=False)
 def _cmd_idle(conn, service, args):
     service.register_idle(conn, args)
@@ -673,7 +797,14 @@ def _cmd_close(conn, service, args):
 
 @MPDConnection.Command("play", Permissions.CONTROL)
 def _cmd_play(conn, service, args):
-    service.play()
+    if args:
+        _verify_length(args, 1)
+        songpos = _parse_songpos(args[0])
+        song = service.queue_song_by_pos(songpos)
+        service._app.player.go_to(song, explicit=True, source=service._queue_model)
+        service._app.player.paused = False
+    else:
+        service.play()
 
 
 @MPDConnection.Command("listplaylists", Permissions.READ)
@@ -690,7 +821,12 @@ def _cmd_list(conn, service, args):
 def _cmd_playid(conn, service, args):
     _verify_length(args, 1)
     songid = _parse_int(args[0])
-    service.playid(songid)
+    for song in service.queue_songs():
+        if service._get_id(song) == songid:
+            service._app.player.go_to(song, explicit=True, source=service._queue_model)
+            service._app.player.paused = False
+            return
+    raise MPDRequestError("No such song", AckError.NO_EXIST)
 
 
 @MPDConnection.Command("pause", Permissions.CONTROL)
@@ -777,8 +913,8 @@ def _cmd_plchanges(conn, service, args):
     _verify_length(args, 1)
     version = _parse_int(args[0])
     changes = service.plchanges(version)
-    if changes is not None:
-        conn.write_line(changes)
+    for entry in changes:
+        conn.write_line(entry)
 
 
 @MPDConnection.Command("plchangesposid", Permissions.READ)
@@ -786,8 +922,8 @@ def _cmd_plchangesposid(conn, service, args):
     _verify_length(args, 1)
     version = _parse_int(args[0])
     changes = service.plchangesposid(version)
-    if changes is not None:
-        conn.write_line(changes)
+    for entry in changes:
+        conn.write_line(entry)
 
 
 @MPDConnection.Command("listallinfo", Permissions.READ)
@@ -857,19 +993,65 @@ def _cmd_playlistinfo(conn, service, args):
     if args:
         _verify_length(args, 1)
         start, end = _parse_range(args[0])
-        result = service.playlistinfo(start, end)
     else:
-        result = service.playlistinfo()
-    if result is not None:
-        conn.write_line(result)
+        start = end = None
+    for entry in service.queue_songinfo(start, end):
+        conn.write_line(entry)
 
 
 @MPDConnection.Command("playlistid", Permissions.READ)
 def _cmd_playlistid(conn, service, args):
     if args:
         songid = _parse_int(args[0])
+        matches = service.queue_songinfo_by_id(songid)
     else:
-        songid = None
-    result = service.playlistid(songid)
-    if result is not None:
-        conn.write_line(result)
+        matches = service.queue_songinfo()
+    for entry in matches:
+        conn.write_line(entry)
+
+
+@MPDConnection.Command("playlist", Permissions.READ)
+def _cmd_playlist(conn, service, args):
+    if args:
+        _verify_length(args, 1)
+        start, end = _parse_range(args[0])
+    else:
+        start = end = None
+    for entry in service.queue_playlist(start, end):
+        conn.write_line(entry)
+
+
+@MPDConnection.Command("clear", Permissions.ADD)
+def _cmd_clear(conn, service, args):
+    _verify_length(args, 0)
+    if service._queue_model is None:
+        raise MPDRequestError("No queue", AckError.NO_EXIST)
+    service._queue_model.clear()
+
+
+@MPDConnection.Command("delete", Permissions.ADD)
+def _cmd_delete(conn, service, args):
+    _verify_length(args, 1)
+    pos = _parse_songpos(args[0])
+    service.queue_remove_positions([pos])
+
+
+@MPDConnection.Command("add", Permissions.ADD)
+def _cmd_add(conn, service, args):
+    _verify_length(args, 1)
+    filename = args[0]
+    song = service._app.library.add_filename(filename, add=False)
+    if song is None:
+        raise MPDRequestError("No such song", AckError.NO_EXIST)
+    service.queue_insert([song])
+
+
+@MPDConnection.Command("addid", Permissions.ADD)
+def _cmd_addid(conn, service, args):
+    _verify_length(args, 1)
+    filename = args[0]
+    song = service._app.library.add_filename(filename, add=False)
+    if song is None:
+        raise MPDRequestError("No such song", AckError.NO_EXIST)
+    service.queue_insert([song])
+    conn.write_line(f"Id: {service._get_id(song):d}")

--- a/quodlibet/ext/events/mpdserver/main.py
+++ b/quodlibet/ext/events/mpdserver/main.py
@@ -32,17 +32,17 @@ class AckError:
 
 
 class Permissions:
-    PERMISSION_NONE = 0
-    PERMISSION_READ = 1
-    PERMISSION_ADD = 2
-    PERMISSION_CONTROL = 4
-    PERMISSION_ADMIN = 8
-    PERMISSION_ALL = (
-        PERMISSION_NONE
-        | PERMISSION_READ
-        | PERMISSION_ADD
-        | PERMISSION_CONTROL
-        | PERMISSION_ADMIN
+    NONE = 0
+    READ = 1
+    ADD = 2
+    CONTROL = 4
+    ADMIN = 8
+    ALL = (
+        NONE
+        | READ
+        | ADD
+        | CONTROL
+        | ADMIN
     )
 
 
@@ -140,9 +140,9 @@ class MPDService:
         self._options = app.player_options
 
         if not self._config.config_get("password"):
-            self.default_permission = Permissions.PERMISSION_ALL
+            self.default_permission = Permissions.ALL
         else:
-            self.default_permission = Permissions.PERMISSION_NONE
+            self.default_permission = Permissions.NONE
 
         def options_changed(*args):
             self.emit_changed("options")
@@ -483,7 +483,7 @@ class MPDConnection(BaseTCPConnection):
 
     def authenticate(self, password):
         if password == self.service._config.config_get("password"):
-            self.permission = Permissions.PERMISSION_ALL
+            self.permission = Permissions.ALL
         else:
             self.permission = self.service.default_permission
             raise MPDRequestError("Password incorrect", AckError.PASSWORD)
@@ -594,7 +594,7 @@ class MPDConnection(BaseTCPConnection):
     _commands: dict[str, tuple[Callable, bool, int]] = {}
 
     @classmethod
-    def Command(cls, name, ack=True, permission=Permissions.PERMISSION_ADMIN):
+    def Command(cls, name, permission=Permissions.ADMIN, ack=True):
         def wrap(func):
             assert name not in cls._commands, name
             cls._commands[name] = (func, ack, permission)
@@ -650,12 +650,12 @@ def _cmd_idle(conn, service, args):
     service.register_idle(conn, args)
 
 
-@MPDConnection.Command("ping", permission=Permissions.PERMISSION_NONE)
+@MPDConnection.Command("ping", Permissions.NONE)
 def _cmd_ping(conn, service, args):
     return
 
 
-@MPDConnection.Command("password", permission=Permissions.PERMISSION_NONE)
+@MPDConnection.Command("password", Permissions.NONE)
 def _cmd_password(conn, service, args):
     _verify_length(args, 1)
     conn.authenticate(args[0])
@@ -666,34 +666,34 @@ def _cmd_noidle(conn, service, args):
     service.unregister_idle(conn)
 
 
-@MPDConnection.Command("close", ack=False, permission=Permissions.PERMISSION_NONE)
+@MPDConnection.Command("close", Permissions.NONE, ack=False)
 def _cmd_close(conn, service, args):
     conn.close()
 
 
-@MPDConnection.Command("play")
+@MPDConnection.Command("play", Permissions.CONTROL)
 def _cmd_play(conn, service, args):
     service.play()
 
 
-@MPDConnection.Command("listplaylists")
+@MPDConnection.Command("listplaylists", Permissions.READ)
 def _cmd_listplaylists(conn, service, args):
     pass
 
 
-@MPDConnection.Command("list")
+@MPDConnection.Command("list", Permissions.READ)
 def _cmd_list(conn, service, args):
     pass
 
 
-@MPDConnection.Command("playid")
+@MPDConnection.Command("playid", Permissions.CONTROL)
 def _cmd_playid(conn, service, args):
     _verify_length(args, 1)
     songid = _parse_int(args[0])
     service.playid(songid)
 
 
-@MPDConnection.Command("pause")
+@MPDConnection.Command("pause", Permissions.CONTROL)
 def _cmd_pause(conn, service, args):
     value = None
     if args:
@@ -702,77 +702,77 @@ def _cmd_pause(conn, service, args):
     service.pause(value)
 
 
-@MPDConnection.Command("stop")
+@MPDConnection.Command("stop", Permissions.CONTROL)
 def _cmd_stop(conn, service, args):
     service.stop()
 
 
-@MPDConnection.Command("next")
+@MPDConnection.Command("next", Permissions.CONTROL)
 def _cmd_next(conn, service, args):
     service.next()
 
 
-@MPDConnection.Command("previous")
+@MPDConnection.Command("previous", Permissions.CONTROL)
 def _cmd_previous(conn, service, args):
     service.previous()
 
 
-@MPDConnection.Command("repeat")
+@MPDConnection.Command("repeat", Permissions.CONTROL)
 def _cmd_repeat(conn, service, args):
     _verify_length(args, 1)
     value = _parse_bool(args[0])
     service.repeat(value)
 
 
-@MPDConnection.Command("random")
+@MPDConnection.Command("random", Permissions.CONTROL)
 def _cmd_random(conn, service, args):
     _verify_length(args, 1)
     value = _parse_bool(args[0])
     service.random(value)
 
 
-@MPDConnection.Command("single")
+@MPDConnection.Command("single", Permissions.CONTROL)
 def _cmd_single(conn, service, args):
     _verify_length(args, 1)
     value = _parse_bool(args[0])
     service.single(value)
 
 
-@MPDConnection.Command("setvol")
+@MPDConnection.Command("setvol", Permissions.CONTROL)
 def _cmd_setvol(conn, service, args):
     _verify_length(args, 1)
     value = _parse_int(args[0])
     service.setvol(value)
 
 
-@MPDConnection.Command("status")
+@MPDConnection.Command("status", Permissions.READ)
 def _cmd_status(conn, service, args):
     status = service.status()
     for k, v in status:
         conn.write_line(f"{k}: {v}")
 
 
-@MPDConnection.Command("stats")
+@MPDConnection.Command("stats", Permissions.READ)
 def _cmd_stats(conn, service, args):
     status = service.stats()
     for k, v in status:
         conn.write_line(f"{k}: {v}")
 
 
-@MPDConnection.Command("currentsong")
+@MPDConnection.Command("currentsong", Permissions.READ)
 def _cmd_currentsong(conn, service, args):
     stats = service.currentsong()
     if stats is not None:
         conn.write_line(stats)
 
 
-@MPDConnection.Command("count")
+@MPDConnection.Command("count", Permissions.READ)
 def _cmd_count(conn, service, args):
     conn.write_line("songs: 0")
     conn.write_line("playtime: 0")
 
 
-@MPDConnection.Command("plchanges")
+@MPDConnection.Command("plchanges", Permissions.READ)
 def _cmd_plchanges(conn, service, args):
     _verify_length(args, 1)
     version = _parse_int(args[0])
@@ -781,7 +781,7 @@ def _cmd_plchanges(conn, service, args):
         conn.write_line(changes)
 
 
-@MPDConnection.Command("plchangesposid")
+@MPDConnection.Command("plchangesposid", Permissions.READ)
 def _cmd_plchangesposid(conn, service, args):
     _verify_length(args, 1)
     version = _parse_int(args[0])
@@ -790,12 +790,12 @@ def _cmd_plchangesposid(conn, service, args):
         conn.write_line(changes)
 
 
-@MPDConnection.Command("listallinfo")
+@MPDConnection.Command("listallinfo", Permissions.READ)
 def _cmd_listallinfo(*args):
     _cmd_currentsong(*args)
 
 
-@MPDConnection.Command("seek")
+@MPDConnection.Command("seek", Permissions.CONTROL)
 def _cmd_seek(conn, service, args):
     _verify_length(args, 2)
     songpos = _parse_int(args[0])
@@ -803,7 +803,7 @@ def _cmd_seek(conn, service, args):
     service.seek(songpos, time_)
 
 
-@MPDConnection.Command("seekid")
+@MPDConnection.Command("seekid", Permissions.CONTROL)
 def _cmd_seekid(conn, service, args):
     _verify_length(args, 2)
     songid = _parse_int(args[0])
@@ -811,7 +811,7 @@ def _cmd_seekid(conn, service, args):
     service.seekid(songid, time_)
 
 
-@MPDConnection.Command("seekcur")
+@MPDConnection.Command("seekcur", Permissions.CONTROL)
 def _cmd_seekcur(conn, service, args):
     _verify_length(args, 1)
 
@@ -828,31 +828,31 @@ def _cmd_seekcur(conn, service, args):
     service.seekcur(time_, relative)
 
 
-@MPDConnection.Command("outputs")
+@MPDConnection.Command("outputs", Permissions.READ)
 def _cmd_outputs(conn, service, args):
     conn.write_line("outputid: 0")
     conn.write_line("outputname: dummy")
     conn.write_line("outputenabled: 1")
 
 
-@MPDConnection.Command("commands", permission=Permissions.PERMISSION_NONE)
+@MPDConnection.Command("commands", Permissions.NONE)
 def _cmd_commands(conn, service, args):
     for name in conn.list_commands():
         conn.write_line(f"command: {name!s}")
 
 
-@MPDConnection.Command("tagtypes")
+@MPDConnection.Command("tagtypes", Permissions.READ)
 def _cmd_tagtypes(conn, service, args):
     for mpd_key, _ql_key in TAG_MAPPING:
         conn.write_line(mpd_key)
 
 
-@MPDConnection.Command("lsinfo")
+@MPDConnection.Command("lsinfo", Permissions.READ)
 def _cmd_lsinfo(conn, service, args):
     _verify_length(args, 1)
 
 
-@MPDConnection.Command("playlistinfo")
+@MPDConnection.Command("playlistinfo", Permissions.READ)
 def _cmd_playlistinfo(conn, service, args):
     if args:
         _verify_length(args, 1)
@@ -864,7 +864,7 @@ def _cmd_playlistinfo(conn, service, args):
         conn.write_line(result)
 
 
-@MPDConnection.Command("playlistid")
+@MPDConnection.Command("playlistid", Permissions.READ)
 def _cmd_playlistid(conn, service, args):
     if args:
         songid = _parse_int(args[0])

--- a/tests/plugin/test_mpdserver.py
+++ b/tests/plugin/test_mpdserver.py
@@ -16,7 +16,7 @@ from quodlibet.formats import AudioFile
 from quodlibet import app
 from quodlibet import config
 from tests.plugin import PluginTestCase, init_fake_app, destroy_fake_app
-from tests import skipIf, run_gtk_loop
+from tests import skipIf, run_gtk_loop, get_data_path
 
 
 @skipIf(os.name == "nt", "mpd server not supported under Windows")
@@ -105,6 +105,7 @@ class TMPDCommands(PluginTestCase):
         config.quit()
 
     def test_currentsong_length(self):
+        assert app.player is not None
         app.player.go_to(
             AudioFile(
                 {
@@ -115,14 +116,33 @@ class TMPDCommands(PluginTestCase):
         )
 
         response = self._cmd(b"currentsong\n")
+        assert response is not None
         assert b"Time: 12\n" in response
 
     def test_tagtypes(self):
         response = self._cmd(b"tagtypes\n")
+        assert response is not None
         assert b"Time\n" not in response
 
     def test_commands(self):
-        skip = ["close", "idle", "noidle"]
+        skip = [
+            "add",
+            "addid",
+            "close",
+            "delete",
+            "idle",
+            "list",
+            "listplaylists",
+            "lsinfo",
+            "noidle",
+            "password",
+            "playid",
+            "plchanges",
+            "plchangesposid",
+            "seek",
+            "seekcur",
+            "seekid",
+        ]
         cmds = [c for c in self.conn.list_commands() if c not in skip]
         for cmd in cmds:
             self._cmd(cmd.encode("ascii") + b"\n")
@@ -135,3 +155,41 @@ class TMPDCommands(PluginTestCase):
     def test_idle_close(self):
         for cmd in ["idle", "noidle", "close"]:
             self._cmd(cmd.encode("ascii") + b"\n")
+
+    def test_queue_add_list_delete(self):
+        filename = get_data_path("silence-44-s.mp3")
+        response = self._cmd(f"add {filename}\n".encode("utf-8"))
+        assert response is not None
+        assert b"OK\n" in response
+
+        response = self._cmd(b"playlist\n")
+        assert response is not None
+        assert f"file: {filename}".encode("utf-8") in response
+
+        response = self._cmd(b"delete 0\n")
+        assert response is not None
+        assert b"OK\n" in response
+
+        response = self._cmd(b"playlist\n")
+        assert response is not None
+        assert f"file: {filename}".encode("utf-8") not in response
+
+    def test_queue_addid_and_plchanges(self):
+        filename = get_data_path("silence-44-s.mp3")
+
+        status = self._cmd(b"status\n")
+        assert status is not None
+        before = None
+        for line in status.splitlines():
+            if line.startswith(b"playlist:"):
+                before = int(line.split(b":", 1)[1].strip())
+                break
+        assert before is not None
+
+        response = self._cmd(f"addid {filename}\n".encode("utf-8"))
+        assert response is not None
+        assert b"Id:" in response
+
+        response = self._cmd(f"plchanges {before}\n".encode("utf-8"))
+        assert response is not None
+        assert f"file: {filename}".encode("utf-8") in response

--- a/tests/plugin/test_mpdserver.py
+++ b/tests/plugin/test_mpdserver.py
@@ -70,6 +70,11 @@ class TMPDCommands(PluginTestCase):
         config.init()
         init_fake_app()
 
+        filename = get_data_path("silence-44-s.mp3")
+        song = AudioFile({"~filename": fsnative(filename)})
+        song.sanitize()
+        app.library.add([song])
+
         MPDServerPlugin = self.mod.MPDServerPlugin
         MPDConnection = self.mod.main.MPDConnection
         MPDService = self.mod.main.MPDService
@@ -139,6 +144,9 @@ class TMPDCommands(PluginTestCase):
             "playid",
             "plchanges",
             "plchangesposid",
+            "search",
+            "searchadd",
+            "searchcount",
             "seek",
             "seekcur",
             "seekid",
@@ -158,13 +166,13 @@ class TMPDCommands(PluginTestCase):
 
     def test_queue_add_list_delete(self):
         filename = get_data_path("silence-44-s.mp3")
-        response = self._cmd(f"add {filename}\n".encode("utf-8"))
+        response = self._cmd(f"add {filename}\n".encode())
         assert response is not None
         assert b"OK\n" in response
 
         response = self._cmd(b"playlist\n")
         assert response is not None
-        assert f"file: {filename}".encode("utf-8") in response
+        assert f"file: {filename}".encode() in response
 
         response = self._cmd(b"delete 0\n")
         assert response is not None
@@ -172,7 +180,7 @@ class TMPDCommands(PluginTestCase):
 
         response = self._cmd(b"playlist\n")
         assert response is not None
-        assert f"file: {filename}".encode("utf-8") not in response
+        assert f"file: {filename}".encode() not in response
 
     def test_queue_addid_and_plchanges(self):
         filename = get_data_path("silence-44-s.mp3")
@@ -186,10 +194,178 @@ class TMPDCommands(PluginTestCase):
                 break
         assert before is not None
 
-        response = self._cmd(f"addid {filename}\n".encode("utf-8"))
+        response = self._cmd(f"addid {filename}\n".encode())
         assert response is not None
         assert b"Id:" in response
 
-        response = self._cmd(f"plchanges {before}\n".encode("utf-8"))
+        response = self._cmd(f"plchanges {before}\n".encode())
         assert response is not None
-        assert f"file: {filename}".encode("utf-8") in response
+        assert f"file: {filename}".encode() in response
+
+    def test_search_and_searchcount(self):
+        filename = get_data_path("silence-44-s.mp3")
+        response = self._cmd(f"search file {filename}\n".encode())
+        assert response is not None
+        assert f"file: {filename}".encode() in response
+
+        response = self._cmd(f"searchcount file {filename}\n".encode())
+        assert response is not None
+        assert b"songs: 1" in response
+
+    def test_searchadd(self):
+        filename = get_data_path("silence-44-s.mp3")
+
+        response = self._cmd(f"searchadd file {filename}\n".encode())
+        assert response is not None
+        assert b"OK\n" in response
+
+        response = self._cmd(b"playlist\n")
+        assert response is not None
+        assert f"file: {filename}".encode() in response
+
+    def test_search_invalid_args(self):
+        response = self._cmd(b"search artist\n")
+        assert response is not None
+        assert b"ACK" in response
+
+    def test_search_any(self):
+        filename = get_data_path("silence-44-s.mp3")
+        response = self._cmd(f"search any {filename}\n".encode())
+        assert response is not None
+        assert f"file: {filename}".encode() in response
+
+    def test_search_filter_expression(self):
+        filename = get_data_path("silence-44-s.mp3")
+        response = self._cmd(f'search "(file contains \\"{filename}\\")"\n'.encode())
+        assert response is not None
+        assert f"file: {filename}".encode() in response
+
+    def test_search_filter_and_expression(self):
+        filename = get_data_path("silence-44-s.mp3")
+        mpd_query = '((file contains \\"silence-44-s\\") AND (file contains \\"mp3\\"))'
+        response = self._cmd(f'search "{mpd_query}"\n'.encode())
+        assert response is not None
+        assert f"file: {filename}".encode() in response
+
+    def test_search_filter_single_quotes(self):
+        filename = get_data_path("silence-44-s.mp3")
+        response = self._cmd(f"search \"(file contains '{filename}')\"\n".encode())
+        assert response is not None
+        assert f"file: {filename}".encode() in response
+
+    def test_search_filter_escaped_quotes(self):
+        song = AudioFile(
+            {
+                "~filename": fsnative("/dev/null"),
+                "artist": "foo'bar\"",
+            }
+        )
+        song.sanitize()
+        app.library.add([song])
+
+        response = self._cmd(b'search "(artist == \\"foo\\\'bar\\\\\\"\\")"\n')
+        assert response is not None
+        assert b"Artist: foo'bar\"" in response
+
+    def test_search_filter_parentheses_in_value(self):
+        song = AudioFile(
+            {
+                "~filename": fsnative("/dev/null"),
+                "artist": "foo (bar) baz",
+            }
+        )
+        song.sanitize()
+        app.library.add([song])
+
+        response = self._cmd(b'search "(artist == \\"foo (bar) baz\\")"\n')
+        assert response is not None
+        assert b"Artist: foo (bar) baz" in response
+
+    def test_search_window(self):
+        filename = get_data_path("silence-44-s.mp3")
+        response = self._cmd(
+            f'search "(file contains \\"{filename}\\")" window 0:1\n'.encode()
+        )
+        assert response is not None
+        assert f"file: {filename}".encode() in response
+
+    def test_search_filter_starts_with(self):
+        filename = get_data_path("silence-44-s.mp3")
+        prefix = os.path.dirname(filename)
+        response = self._cmd(f'search "(file starts_with \\"{prefix}\\")"\n'.encode())
+        assert response is not None
+        assert f"file: {filename}".encode() in response
+
+    def test_search_filter_eq_ci_fallback(self):
+        filename = get_data_path("silence-44-s.mp3")
+        response = self._cmd(f'search "(file eq_ci \\"{filename}\\")"\n'.encode())
+        assert response is not None
+        assert f"file: {filename}".encode() in response
+
+    def test_search_filter_regex_fallback(self):
+        filename = get_data_path("silence-44-s.mp3")
+        response = self._cmd(b'search "(file =~ "silence-44-s\\.mp3$")"\n')
+        assert response is not None
+        assert f"file: {filename}".encode() in response
+
+    def test_search_filter_not_contains(self):
+        filename = get_data_path("silence-44-s.mp3")
+        response = self._cmd(b'search "(file !contains \\"nope\\")"\n')
+        assert response is not None
+        assert f"file: {filename}".encode() in response
+
+    def test_search_filter_base(self):
+        filename = get_data_path("silence-44-s.mp3")
+        base = os.path.dirname(filename)
+        response = self._cmd(f'search "(base \\"{base}\\")"\n'.encode())
+        assert response is not None
+        assert f"file: {filename}".encode() in response
+
+    def test_search_filter_added_since(self):
+        filename = get_data_path("silence-44-s.mp3")
+        response = self._cmd(b'search "(added-since \\"0\\")"\n')
+        assert response is not None
+        assert f"file: {filename}".encode() in response
+
+    def test_search_filter_modified_since(self):
+        filename = get_data_path("silence-44-s.mp3")
+        response = self._cmd(b'search "(modified-since \\"0\\")"\n')
+        assert response is not None
+        assert f"file: {filename}".encode() in response
+
+    def test_search_filter_sort_parsing(self):
+        filename = get_data_path("silence-44-s.mp3")
+
+        response = self._cmd(
+            b'search "(file contains \\"silence-44-s\\")" sort artist\n'
+        )
+        assert response is not None
+        assert f"file: {filename}".encode() in response
+
+        response = self._cmd(
+            b'search "(file contains \\"silence-44-s\\")" sort -artist\n'
+        )
+        assert response is not None
+        assert f"file: {filename}".encode() in response
+
+    def test_search_filter_sort_invalid(self):
+        response = self._cmd(b'search "(file contains \\"silence-44-s\\")" sort -\n')
+        assert response is not None
+        assert b"ACK" in response
+
+    def test_search_position(self):
+        filename = get_data_path("silence-44-s.mp3")
+        response = self._cmd(
+            f'search "(file contains \\"{filename}\\")" position 0\n'.encode()
+        )
+        assert response is not None
+        assert f"file: {filename}".encode() in response
+
+    def test_search_window_term_in_filter(self):
+        response = self._cmd(b'search "(album contains window)"\n')
+        assert response is not None
+
+    def test_search_requires_parentheses(self):
+        response = self._cmd(b"search album contains foo\n")
+        assert response is not None
+        assert b"ACK" in response


### PR DESCRIPTION
Check-list
----------

 * [?] There is a linked issue discussing the motivations for this feature or bugfix
 * [x] Unit tests have been added where possible
 * [x] I've added / updated documentation for any user-facing features.
 * [x] Performance seems to be comparable or better than current `main`


What this change is adding / fixing
-----------------------------------

I use KDE Connect to remotely interact with Quod Libet (through the mpris procol), but it does not make possible to remotely enqueue songs.  This PR allows the user to  run queries against the QL database and enqueue songs from the result.  Issue #2016 seems to request the same feature.  This one only implements search related mpd commands, the find related ones are omitted.

I don't know what is the policy here, but I used an AI assistant.  However, the resulting patch is mostly readable, or at least better than what I could have written.  Although maybe the filter expression parser of filtering.py is not easy to understand.

I'm not sure I added and modified copyright notices correctly.  Please, double check them.

If this PR is accepted, I can can work on implementing additional mpd commands (playlist, channels, and others).

Thanks!