### PR TITLE
Fix residual tooltips on some systems (#4259)

### DIFF
--- a/quodlibet/qltk/views.py
+++ b/quodlibet/qltk/views.py
@@ -24,6 +24,7 @@ from quodlibet.qltk import (
     get_primary_accel_mod,
 )
 from quodlibet.qltk.image import get_surface_extents
+from quodlibet.util import is_windows
 
 from .util import GSignals
 
@@ -130,9 +131,15 @@ class TreeViewHints(Gtk.Window):
             Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION,
         )
 
+        if is_windows():
+            # See issues #4259, #4365
+            leave_notify_cb = self.__motion
+        else:
+            leave_notify_cb = self.__undisplay
+
         self.__handlers[view] = [
             view.connect("motion-notify-event", self.__motion),
-            view.connect("leave-notify-event", self.__motion),
+            view.connect("leave-notify-event", leave_notify_cb),
             view.connect("scroll-event", self.__undisplay),
             view.connect("key-press-event", self.__undisplay),
             view.connect("unmap", self.__undisplay),


### PR DESCRIPTION
Check-list
----------

 * [x] There is a linked issue discussing the motivations for this feature or bugfix
 * [x] Unit tests have been added where possible
 * [x] I've added / updated documentation for any user-facing features.
 * [x] Performance seems to be comparable or better than current `main`


What this change is adding / fixing
-----------------------------------

There was an old pull request (#4365) by @luk1337, which fixed the residual tooltip (#4259), but it seem the PR caused troubles on windows.  Since windows is a non-free platform, I think, it should not hinder the progress on other platforms.  So, this PR fixes the issue where we know a fix.  See the discussion in #4259. 

I've added @luk1337 as co-author, because this PR just selectively applies the original idea.