### PR TITLE
Remove various fsnative calls with just constants

### DIFF
--- a/quodlibet/commands.py
+++ b/quodlibet/commands.py
@@ -569,7 +569,7 @@ def _print_playing(app, fstring=None):
     pattern = make_pattern(fstring, "<artist~album~tracknumber~title>")
     song = app.player.info
     if song is None:
-        song = AudioFile({"~filename": fsnative("/")})
+        song = AudioFile({"~filename": "/"})
         song.sanitize()
     else:
         song = app.player.with_elapsed_info(song)

--- a/quodlibet/exfalso.py
+++ b/quodlibet/exfalso.py
@@ -9,7 +9,6 @@
 import os
 import sys
 
-from senf import fsnative
 
 from quodlibet import _
 from quodlibet import app
@@ -38,7 +37,7 @@ def main(argv=None):
         "[{}]".format(_("directory")),
     )
 
-    argv.append(os.path.abspath(fsnative(".")))
+    argv.append(os.path.abspath("."))
     opts, args = opts.parse(argv[1:])
     args[0] = os.path.realpath(args[0])
 

--- a/quodlibet/formats/_audio.py
+++ b/quodlibet/formats/_audio.py
@@ -719,7 +719,7 @@ class AudioFile(dict, ImageContainer, HasKey):
 
         if "~" in key or key == "title":
             if key in FILESYSTEM_TAGS:
-                v = fsn2text(self(key, fsnative()))
+                v = fsn2text(self(key, ""))
             else:
                 v = self(key, "")
         else:
@@ -919,11 +919,11 @@ class AudioFile(dict, ImageContainer, HasKey):
                 head, tail = os.path.split(head)
                 # Prevent infinite loop without a fully-qualified filename
                 # (the unit tests use these).
-                head = head or fsnative("/")
+                head = head or "/"
                 if ismount(head):
                     self["~mountpoint"] = head
         else:
-            self["~mountpoint"] = fsnative("/")
+            self["~mountpoint"] = "/"
 
         # Fill in necessary values.
         self.setdefault("~#added", int(time.time()))

--- a/quodlibet/pattern/_pattern.py
+++ b/quodlibet/pattern/_pattern.py
@@ -237,7 +237,7 @@ class PatternFormatter:
     class Dummy(dict):
         def __call__(self, key, *args):
             if key in FILESYSTEM_TAGS:
-                return fsnative("_")
+                return "_"
             if key[:2] == "~#" and "~" not in key[2:]:
                 return 0
             return "_"

--- a/quodlibet/qltk/filesel.py
+++ b/quodlibet/qltk/filesel.py
@@ -225,7 +225,7 @@ class DirectoryTree(RCMHintedTreeView, MultiDragTreeView):
             niter = model.append(None, [path])
             if path is not None:
                 assert isinstance(path, fsnative)
-                model.append(niter, [fsnative("dummy")])
+                model.append(niter, ["dummy"])
 
         self.get_selection().set_mode(Gtk.SelectionMode.MULTIPLE)
         self.connect("test-expand-row", DirectoryTree.__expanded, model)
@@ -283,7 +283,7 @@ class DirectoryTree(RCMHintedTreeView, MultiDragTreeView):
         # Find the top level row which has the largest common
         # path with the path we want to go to
         roots = {p: i for (i, p) in model.iterrows(None)}
-        head, tail = path_to_go, fsnative("")
+        head, tail = path_to_go, ""
         to_find = []
         while head and head not in roots:
             new_head, tail = os.path.split(head)

--- a/quodlibet/qltk/songlistcolumns.py
+++ b/quodlibet/qltk/songlistcolumns.py
@@ -9,7 +9,7 @@
 # (at your option) any later version.
 
 from gi.repository import Gtk, Pango, GLib, Gio
-from senf import fsnative, fsn2text
+from senf import fsn2text
 
 from quodlibet.util.string.date import format_date
 from quodlibet import _, print_d
@@ -314,7 +314,7 @@ class FSColumn(WideTextColumn):
 
     def _fetch_value(self, model, iter_):
         values = model.get_value(iter_).list(self.header_name)
-        return values[0] if values else fsnative("")
+        return values[0] if values else ""
 
     def _apply_value(self, model, iter_, cell, value):
         cell.set_property("text", fsn2text(unexpand(value)))

--- a/quodlibet/qltk/textedit.py
+++ b/quodlibet/qltk/textedit.py
@@ -7,7 +7,6 @@
 
 from gi.repository import Gtk, GLib, Pango
 
-from senf import fsnative
 
 from quodlibet import _
 from quodlibet import qltk
@@ -93,7 +92,7 @@ def validate_markup_pattern(text, alternative_markup=True, links=False):
 
     assert isinstance(text, str)
 
-    f = AudioFile({"~filename": fsnative("dummy")})
+    f = AudioFile({"~filename": "dummy"})
 
     try:
         if alternative_markup:

--- a/quodlibet/util/atomic.py
+++ b/quodlibet/util/atomic.py
@@ -63,8 +63,8 @@ def atomic_save(filename, mode):
     fileobj = NamedTemporaryFile(
         mode=mode,
         dir=dir_,
-        prefix=basename + fsnative("_"),
-        suffix=fsnative(".tmp"),
+        prefix=basename + "_",
+        suffix=".tmp",
         delete=False,
     )
 

--- a/quodlibet/util/library.py
+++ b/quodlibet/util/library.py
@@ -82,9 +82,9 @@ def set_scan_dirs(dirs):
     assert all(isinstance(d, fsnative) for d in dirs)
 
     if is_windows():
-        joined = fsnative(":").join(dirs)
+        joined = ":".join(dirs)
     else:
-        joined = join_escape(dirs, fsnative(":"))
+        joined = join_escape(dirs, ":")
     config.setbytes("settings", "scan", fsn2bytes(joined, "utf-8"))
 
 

--- a/quodlibet/util/path.py
+++ b/quodlibet/util/path.py
@@ -193,7 +193,7 @@ def unexpand(filename):
         fsnative: The path with the home directory replaced
     """
 
-    sub = (os.name == "nt" and fsnative("%USERPROFILE%")) or fsnative("~")
+    sub = (os.name == "nt" and "%USERPROFILE%") or "~"
     home = os.path.normcase(get_home_dir()).rstrip(os.path.sep)
     norm = os.path.normcase(filename)
     if norm == home:
@@ -325,11 +325,11 @@ def get_temp_cover_file(data: bytes, mime: str | None = None) -> Any:
         if mime:
             mime = mime.lower()
             if "png" in mime:
-                suffix = fsnative(".png")
+                suffix = ".png"
             elif "jpg" in mime or "jpeg" in mime:
-                suffix = fsnative(".jpg")
+                suffix = ".jpg"
         # pass fsnative so that mkstemp() uses unicode on Windows
-        fn = NamedTemporaryFile(prefix=fsnative("cover-"), suffix=suffix)
+        fn = NamedTemporaryFile(prefix="cover-", suffix=suffix)
         fn.write(data)
         fn.flush()
         fn.seek(0, 0)
@@ -428,7 +428,7 @@ def limit_path(path, ellipsis=True):
 
         if len(p) > limit:
             if ellipsis:
-                p = p[: limit - 2] + fsnative("..")
+                p = p[: limit - 2] + ".."
             else:
                 p = p[:limit]
         parts[i] = p

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -173,7 +173,7 @@ def init_test_environ():
     global _TEMP_DIR, _BUS_INFO, _VDISPLAY
 
     # create a user dir in /tmp and set env vars
-    _TEMP_DIR = tempfile.mkdtemp(prefix=fsnative("QL-TEST-"))
+    _TEMP_DIR = tempfile.mkdtemp(prefix="QL-TEST-")
 
     # force the old cache dir so that GStreamer can re-use the GstRegistry
     # cache file
@@ -182,7 +182,7 @@ def init_test_environ():
     # (in Gst.init()). Since it takes 0.5s here and doesn't add much,
     # disable it. If the registry cache is missing it will be created
     # despite this setting.
-    os.environ["GST_REGISTRY_UPDATE"] = fsnative("no")
+    os.environ["GST_REGISTRY_UPDATE"] = "no"
 
     # In flatpak we might get a registry from a different/old flatpak build
     # when testing new versions etc. Better always update in that case.
@@ -190,7 +190,7 @@ def init_test_environ():
         del os.environ["GST_REGISTRY_UPDATE"]
 
     # set HOME and remove all XDG vars that default to it if not set
-    home_dir = tempfile.mkdtemp(prefix=fsnative("HOME-"), dir=_TEMP_DIR)
+    home_dir = tempfile.mkdtemp(prefix="HOME-", dir=_TEMP_DIR)
     os.environ["HOME"] = home_dir
 
     # set to new default

--- a/tests/plugin/test_html.py
+++ b/tests/plugin/test_html.py
@@ -5,7 +5,6 @@
 # the Free Software Foundation; either version 2 of the License, or
 # (at your option) any later version.
 
-from senf import fsnative
 
 from tests.plugin import PluginTestCase
 
@@ -18,20 +17,20 @@ SONGS = [
         {
             "title": "one",
             "artist": "piman",
-            "~filename": fsnative("/dev/null"),
+            "~filename": "/dev/null",
         }
     ),
     AudioFile(
         {
             "title": "\xf6\xe4\xfc",
-            "~filename": fsnative("/dev/zero"),
+            "~filename": "/dev/zero",
         }
     ),
     AudioFile(
         {
             "title": "three",
             "artist": "boris",
-            "~filename": fsnative("/bin/ls"),
+            "~filename": "/bin/ls",
         }
     ),
 ]

--- a/tests/plugin/test_mpdserver.py
+++ b/tests/plugin/test_mpdserver.py
@@ -9,7 +9,6 @@
 import os
 import socket
 
-from senf import fsnative
 from gi.repository import Gtk
 
 from quodlibet.formats import AudioFile
@@ -41,7 +40,7 @@ class TMPDServer(PluginTestCase):
         format_tags = self.mod.main.format_tags
 
         def getline(key, value):
-            song = AudioFile({"~filename": fsnative("/dev/null")})
+            song = AudioFile({"~filename": "/dev/null"})
             song.sanitize()
             song[key] = value
             lines = format_tags(song).splitlines()
@@ -108,7 +107,7 @@ class TMPDCommands(PluginTestCase):
         app.player.go_to(
             AudioFile(
                 {
-                    "~filename": fsnative(),
+                    "~filename": "",
                     "~#length": 12.25,
                 }
             )

--- a/tests/plugin/test_mpris.py
+++ b/tests/plugin/test_mpris.py
@@ -13,7 +13,6 @@ except ImportError:
     dbus = None
 
 from gi.repository import Gtk
-from senf import fsnative
 
 from tests import skipUnless, run_gtk_loop
 from tests.plugin import PluginTestCase, init_fake_app, destroy_fake_app
@@ -33,7 +32,7 @@ A1 = AudioFile(
         "artist": "fooman\ngo",
         "~#lastplayed": 1234,
         "~#rating": 0.75,
-        "~filename": fsnative("/foo a/b"),
+        "~filename": "/foo a/b",
         "~#length": 123,
         "albumartist": "aa\nbb",
         "bpm": "123.5",
@@ -49,7 +48,7 @@ A2 = AudioFile(
         "artist": "fooman\ufffe",
         "~#lastplayed": 1234,
         "~#rating": 1.0,
-        "~filename": fsnative("/foo"),
+        "~filename": "/foo",
         "discnumber": "4294967296",
     }
 )

--- a/tests/plugin/test_scrobbler.py
+++ b/tests/plugin/test_scrobbler.py
@@ -13,13 +13,10 @@ from quodlibet import config
 from quodlibet.ext.events.qlscrobbler import QLSubmitQueue
 from quodlibet.formats import AudioFile
 from quodlibet.util.picklehelper import pickle_load
-from senf import fsnative
 from tests import run_gtk_loop, init_fake_app, destroy_fake_app
 from tests.plugin import PluginTestCase
 
-A_SONG = AudioFile(
-    {"~filename": fsnative("fake.mp3"), "artist": "Foo bar", "title": "The Title"}
-)
+A_SONG = AudioFile({"~filename": "fake.mp3", "artist": "Foo bar", "title": "The Title"})
 
 
 class TScrobbler(PluginTestCase):

--- a/tests/plugin/test_songsmenu.py
+++ b/tests/plugin/test_songsmenu.py
@@ -6,7 +6,6 @@
 # (at your option) any later version.
 
 from gi.repository import Gtk
-from senf import fsnative
 
 from quodlibet.plugins.songsmenu import SongsMenuPlugin
 from tests.plugin import PluginTestCase
@@ -21,21 +20,21 @@ SONGS = [
         {
             "title": "one",
             "artist": "piman",
-            "~filename": fsnative("/dev/null"),
+            "~filename": "/dev/null",
         }
     ),
     AudioFile(
         {
             "title": "two",
             "artist": "mu",
-            "~filename": fsnative("/dev/zero"),
+            "~filename": "/dev/zero",
         }
     ),
     AudioFile(
         {
             "title": "three",
             "artist": "boris",
-            "~filename": fsnative("/bin/ls"),
+            "~filename": "/bin/ls",
         }
     ),
 ]

--- a/tests/test_browsers_albums.py
+++ b/tests/test_browsers_albums.py
@@ -10,7 +10,6 @@
 from functools import cmp_to_key
 
 from gi.repository import Gtk
-from senf import fsnative
 
 from quodlibet.browsers._base import DisplayPatternMixin
 from . import TestCase, run_gtk_loop
@@ -39,28 +38,28 @@ SONGS = [
         {
             "album": "one",
             "artist": "piman",
-            "~filename": fsnative("/dev/null"),
+            "~filename": "/dev/null",
         }
     ),
     AudioFile(
         {
             "album": "two",
             "artist": "mu",
-            "~filename": fsnative("/dev/zero"),
+            "~filename": "/dev/zero",
         }
     ),
     AudioFile(
         {
             "album": "three",
             "artist": "boris",
-            "~filename": fsnative("/bin/ls"),
+            "~filename": "/bin/ls",
         }
     ),
     AudioFile(
         {
             "album": "three",
             "artist": "boris",
-            "~filename": fsnative("/bin/ls2"),
+            "~filename": "/bin/ls2",
         }
     ),
 ]

--- a/tests/test_browsers_covergrid.py
+++ b/tests/test_browsers_covergrid.py
@@ -9,7 +9,6 @@
 
 
 from quodlibet.browsers.covergrid.main import CoverGrid
-from senf import fsnative
 
 from . import TestCase, run_gtk_loop
 from .helper import realized
@@ -26,28 +25,28 @@ SONGS = [
         {
             "album": "one",
             "artist": "piman",
-            "~filename": fsnative("/dev/null"),
+            "~filename": "/dev/null",
         }
     ),
     AudioFile(
         {
             "album": "two",
             "artist": "mu",
-            "~filename": fsnative("/dev/zero"),
+            "~filename": "/dev/zero",
         }
     ),
     AudioFile(
         {
             "album": "three",
             "artist": "boris",
-            "~filename": fsnative("/bin/ls"),
+            "~filename": "/bin/ls",
         }
     ),
     AudioFile(
         {
             "album": "three",
             "artist": "boris",
-            "~filename": fsnative("/bin/ls2"),
+            "~filename": "/bin/ls2",
         }
     ),
 ]

--- a/tests/test_browsers_paned.py
+++ b/tests/test_browsers_paned.py
@@ -7,7 +7,6 @@ from tests import TestCase, run_gtk_loop
 from .helper import realized
 
 from gi.repository import Gtk
-from senf import fsnative
 
 from quodlibet import config, util
 
@@ -30,7 +29,7 @@ SONGS = [
             "title": "three",
             "artist": "<boris>",
             "genre": "Rock",
-            "~filename": fsnative("/bin/ls"),
+            "~filename": "/bin/ls",
             "foo": "bar",
         }
     ),
@@ -39,7 +38,7 @@ SONGS = [
             "title": "two",
             "artist": "mu",
             "genre": "Rock",
-            "~filename": fsnative("/dev/zero"),
+            "~filename": "/dev/zero",
             "foo": "bar",
         }
     ),
@@ -48,7 +47,7 @@ SONGS = [
             "title": "four",
             "artist": "piman",
             "genre": "J-Pop",
-            "~filename": fsnative("/dev/null"),
+            "~filename": "/dev/null",
             "foo": "bar\nquux",
         }
     ),
@@ -57,11 +56,11 @@ SONGS = [
             "title": "one",
             "artist": "piman",
             "genre": "J-Pop",
-            "~filename": fsnative("/bin/foo"),
+            "~filename": "/bin/foo",
             "foo": "bar\nnope",
         }
     ),
-    AudioFile({"title": "xxx", "~filename": fsnative("/bin/bar"), "foo": "bar"}),
+    AudioFile({"title": "xxx", "~filename": "/bin/bar", "foo": "bar"}),
 ]
 
 UNKNOWN_ARTIST = AudioFile(dict(SONGS[0]))

--- a/tests/test_browsers_playlists.py
+++ b/tests/test_browsers_playlists.py
@@ -25,7 +25,7 @@ from quodlibet.library.librarians import SongLibrarian
 from quodlibet.qltk.songlist import DND_QL
 from quodlibet.util.collection import FileBackedPlaylist, XSPFBackedPlaylist
 from quodlibet.util.path import mkdir
-from senf import fsnative, fsn2uri, fsn2bytes
+from senf import fsn2uri, fsn2bytes
 from tests import (
     TestCase,
     get_data_path,
@@ -316,7 +316,7 @@ class TPlaylistsBrowser(TestCase):
     def test_drag_data_get(self):
         b = self.bar
         song = AudioFile()
-        song["~filename"] = fsnative("foo")
+        song["~filename"] = "foo"
         sel = MockSelData()
         qltk.selection_set_songs(sel, [song])
         b._drag_data_get(None, None, sel, DND_QL, None)
@@ -326,9 +326,9 @@ class TPlaylistsBrowser(TestCase):
         song1 = AudioFile()
         song2 = AudioFile()
         song3 = AudioFile()
-        song1["~filename"] = fsnative("foo1")
-        song2["~filename"] = fsnative("foo2")
-        song3["~filename"] = fsnative("foo3")
+        song1["~filename"] = "foo1"
+        song2["~filename"] = "foo2"
+        song3["~filename"] = "foo3"
         sel = MockSelData()
         qltk.selection_set_songs(sel, [song1, song2, song3])
         filenames = qltk.selection_get_filenames(sel)
@@ -345,9 +345,9 @@ class TPlaylistsBrowser(TestCase):
         song1 = AudioFile()
         song2 = AudioFile()
         song3 = AudioFile()
-        song1["~filename"] = fsnative("foo1")
-        song2["~filename"] = fsnative("foo2")
-        song3["~filename"] = fsnative("foo3")
+        song1["~filename"] = "foo1"
+        song2["~filename"] = "foo2"
+        song3["~filename"] = "foo3"
         sel = MockSelData()
         qltk.selection_set_songs(sel, [song1, song2, song3])
         filenames = qltk.selection_get_filenames(sel)

--- a/tests/test_browsers_search.py
+++ b/tests/test_browsers_search.py
@@ -10,28 +10,27 @@ from quodlibet.browsers.tracks import TrackList
 from quodlibet.formats import AudioFile
 from quodlibet.library import SongLibrary, SongLibrarian
 from quodlibet.qltk.songlist import SongList
-from senf import fsnative
 from tests import TestCase, run_gtk_loop
 
 # Don't sort yet, album_key makes it complicated...
 SONGS = [
-    AudioFile({"title": "one", "artist": "piman", "~filename": fsnative("/dev/null")}),
+    AudioFile({"title": "one", "artist": "piman", "~filename": "/dev/null"}),
     AudioFile(
         {
             "title": "two",
             "artist": "mu",
             "~#length": 234,
-            "~filename": fsnative("/dev/zero"),
+            "~filename": "/dev/zero",
         }
     ),
-    AudioFile({"title": "three", "artist": "boris", "~filename": fsnative("/bin/ls")}),
+    AudioFile({"title": "three", "artist": "boris", "~filename": "/bin/ls"}),
     AudioFile(
         {
             "title": "four",
             "artist": "random",
             "album": "don't stop",
             "labelid": "65432-1",
-            "~filename": fsnative("/dev/random"),
+            "~filename": "/dev/random",
         }
     ),
     AudioFile(
@@ -40,7 +39,7 @@ SONGS = [
             "artist": "shell",
             "album": "don't stop",
             "labelid": "12345-6",
-            "~filename": fsnative("/tmp/five € and £!"),
+            "~filename": "/tmp/five € and £!",
         }
     ),
 ]

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -37,16 +37,12 @@ class TCommands(TCommandBase):
         self.assertEqual(self._send("print-query-text"), "foo\n")
 
     def test_print_playing_elapsed(self):
-        app.player.info = AudioFile(
-            {"album": "foo", "~filename": fsnative("/dev/null")}
-        )
+        app.player.info = AudioFile({"album": "foo", "~filename": "/dev/null"})
         app.player.seek(123 * 1000)
         assert self._send("print-playing <album~~elapsed>") == "foo - 2:03\n"
 
     def test_print_playing_elapsed_numeric(self):
-        app.player.info = AudioFile(
-            {"album": "foo", "~filename": fsnative("/dev/null")}
-        )
+        app.player.info = AudioFile({"album": "foo", "~filename": "/dev/null"})
         app.player.seek(234.56 * 1000)
         assert self._send("print-playing <~#elapsed>") == "234.56\n"
 
@@ -114,9 +110,7 @@ class TCommands(TCommandBase):
         self.assertEqual(app.window.playlist.q.get(), songs)
 
     def test_rating(self):
-        app.player.song = AudioFile(
-            {"album": "foo", "~filename": fsnative("/dev/null")}
-        )
+        app.player.song = AudioFile({"album": "foo", "~filename": "/dev/null"})
         self._send("rating +")
         self.assertAlmostEqual(app.player.song["~#rating"], 0.75)
         self._send("rating 0.4")

--- a/tests/test_formats__audio.py
+++ b/tests/test_formats__audio.py
@@ -39,7 +39,7 @@ from .helper import temp_filename
 
 bar_1_1 = AudioFile(
     {
-        "~filename": fsnative("/fakepath/1"),
+        "~filename": "/fakepath/1",
         "title": "A song",
         "discnumber": "1/2",
         "tracknumber": "1/3",
@@ -49,7 +49,7 @@ bar_1_1 = AudioFile(
 )
 bar_1_2 = AudioFile(
     {
-        "~filename": fsnative("/fakepath/2"),
+        "~filename": "/fakepath/2",
         "title": "Perhaps another",
         "titlesort": "Titles don't sort",
         "discnumber": "1",
@@ -64,7 +64,7 @@ bar_1_2 = AudioFile(
 )
 bar_2_1 = AudioFile(
     {
-        "~filename": fsnative("/does not/exist"),
+        "~filename": "/does not/exist",
         "title": "more songs",
         "discnumber": "2/2",
         "tracknumber": "1",
@@ -120,7 +120,7 @@ class TAudioFile(TestCase):
     def test_tag_strs(self):
         for t in format_types:
             i = AudioFile.__new__(t)
-            i["~filename"] = fsnative("foo")
+            i["~filename"] = "foo"
             for tag in TAGS.values():
                 name = tag.name
                 # brute force
@@ -136,7 +136,7 @@ class TAudioFile(TestCase):
                 ]
                 for name in variants:
                     if name in FILESYSTEM_TAGS:
-                        assert isinstance(i(name, fsnative()), fsnative)
+                        assert isinstance(i(name, ""), fsnative)
                     else:
                         assert isinstance(i(name), str)
 
@@ -154,7 +154,7 @@ class TAudioFile(TestCase):
         assert "album" in self.quux.realkeys()
 
     def test_iterrealitems(self):
-        af = AudioFile({"~filename": fsnative("foo"), "album": "Quuxly"})
+        af = AudioFile({"~filename": "foo", "album": "Quuxly"})
         assert list(af.iterrealitems()) == [("album", "Quuxly")]
 
     def test_language(self):
@@ -257,7 +257,7 @@ class TAudioFile(TestCase):
         for key in bar_1_1.realkeys():
             self.assertEqual(bar_1_1.list(key), [bar_1_1(key)])
 
-        af = AudioFile({"~filename": fsnative("foo")})
+        af = AudioFile({"~filename": "foo"})
         self.assertEqual(af.list("artist"), [])
         self.assertEqual(af.list("title"), [af("title")])
         self.assertEqual(af.list("not a key"), [])
@@ -277,7 +277,7 @@ class TAudioFile(TestCase):
         self.assertEqual(bar_1_1.list_sort("title"), [("A song", "A song")])
         self.assertEqual(bar_1_1.list_sort("artist"), [("Foo", "Foo")])
 
-        af = AudioFile({"~filename": fsnative("foo")})
+        af = AudioFile({"~filename": "foo"})
         self.assertEqual(af.list_sort("artist"), [])
         self.assertEqual(af.list_sort("title"), [(af("title"), af("title"))])
         self.assertEqual(af.list_sort("not a key"), [])
@@ -438,7 +438,7 @@ class TAudioFile(TestCase):
     def test_rename_to_existing(self):
         self.quux.rename(self.quux("~filename"))
         if os.name != "nt":
-            self.assertRaises(ValueError, self.quux.rename, fsnative("/dev/null"))
+            self.assertRaises(ValueError, self.quux.rename, "/dev/null")
 
         with temp_filename() as new_file:
             with self.assertRaises(ValueError):
@@ -458,7 +458,7 @@ class TAudioFile(TestCase):
 
     def test_mountpoint(self):
         song = AudioFile()
-        song["~filename"] = fsnative("filename")
+        song["~filename"] = "filename"
         song.sanitize()
         assert isinstance(song["~mountpoint"], fsnative)
         assert isinstance(song.comma("~mointpoint"), str)
@@ -469,9 +469,7 @@ class TAudioFile(TestCase):
         q.sanitize()
         b.pop("~filename")
         self.assertRaises(ValueError, b.sanitize)
-        n = AudioFile(
-            {"artist": "foo\0bar", "title": "baz\0", "~filename": fsnative("whatever")}
-        )
+        n = AudioFile({"artist": "foo\0bar", "title": "baz\0", "~filename": "whatever"})
         n.sanitize()
         self.assertEqual(n["artist"], "foo\nbar")
         self.assertEqual(n["title"], "baz")
@@ -761,7 +759,7 @@ class TAudioFile(TestCase):
         ]
         for tags, expected in album_key_tests:
             afile = AudioFile(**tags)
-            afile.sanitize(fsnative("/dir/fn"))
+            afile.sanitize("/dir/fn")
             self.assertEqual(afile.album_key, expected)
 
     def test_eq_ne(self):
@@ -879,7 +877,7 @@ class TAudioFile(TestCase):
     def test_reload_fail(self):
         audio = MusicFile(get_data_path("silence-44-s.mp3"))
         audio["title"] = "foo"
-        audio.sanitize(fsnative("/dev/null"))
+        audio.sanitize("/dev/null")
         self.assertRaises(AudioFileError, audio.reload)
         self.assertEqual(audio["title"], "foo")
 
@@ -924,7 +922,7 @@ class Tdecode_value(TestCase):
         self.assertEqual(decode_value("~#foo", 4), "4")
         self.assertEqual(decode_value("~#foo", "bar"), "bar")
         assert isinstance(decode_value("~#foo", "bar"), str)
-        path = fsnative("/foobar")
+        path = "/foobar"
         self.assertEqual(decode_value("~filename", path), fsn2text(path))
 
     def test_path(self):
@@ -1045,7 +1043,7 @@ class Treplay_gain(TestCase):
 class TAudioFileLyrics(TestCase):
     def test_lyrics_path(self):
         song = AudioFile()
-        song["~filename"] = fsnative("filename")
+        song["~filename"] = "filename"
         assert isinstance(song.lyrics_path, Path)
         song["title"] = "Title"
         song["artist"] = "Artist"

--- a/tests/test_library_libraries.py
+++ b/tests/test_library_libraries.py
@@ -44,7 +44,7 @@ class AlbumSong(AudioFile):
 
     def __init__(self, num, album=None):
         super().__init__()
-        self["~filename"] = fsnative("file_%d.mp3" % (num + 1))
+        self["~filename"] = "file_%d.mp3" % (num + 1)
         self["title"] = "Song %d" % (num + 1)
         self["artist"] = "Fakeman"
         if album is None:

--- a/tests/test_operon.py
+++ b/tests/test_operon.py
@@ -9,7 +9,7 @@ import os
 import sys
 
 from quodlibet.util import is_osx, is_windows
-from senf import fsnative, path2fsn
+from senf import path2fsn
 
 from tests import TestCase, get_data_path, mkstemp, skipIf
 from .helper import capture_output, get_temp_copy
@@ -331,7 +331,7 @@ class TOperonEdit(TOperonBase):
         self.check_false(["edit", "foo", "bar"], False, True)
 
     def test_nonexist_editor(self):
-        editor = fsnative("/this/path/does/not/exist/hopefully")
+        editor = "/this/path/does/not/exist/hopefully"
         os.environ["VISUAL"] = editor
         e = self.check_false(["edit", self.f], False, True)[1]
         assert editor in e

--- a/tests/test_pattern.py
+++ b/tests/test_pattern.py
@@ -417,7 +417,7 @@ class TFileFromPattern(_TFileFromPattern):
         self.assertEqual(pat.format(self.e), "0007. Title7.mp3")
 
     def test_ext_case_preservation(self):
-        x = AudioFile({"~filename": fsnative("/tmp/Xx.Flac"), "title": "Xx"})
+        x = AudioFile({"~filename": "/tmp/Xx.Flac", "title": "Xx"})
         # If pattern has a particular ext, preserve case of ext
         p1 = self._create("<~basename>")
         self.assertEqual(p1.format(x), "Xx.Flac")

--- a/tests/test_player.py
+++ b/tests/test_player.py
@@ -5,7 +5,6 @@
 # the Free Software Foundation; either version 2 of the License, or
 # (at your option) any later version.
 
-from senf import fsnative
 
 from tests import TestCase, skipUnless, get_data_path
 
@@ -20,9 +19,9 @@ from quodlibet.qltk.controls import Volume
 
 
 FILES = [
-    AudioFile({"~filename": fsnative("/foo/bar1"), "title": "1"}),
-    AudioFile({"~filename": fsnative("/foo/bar2"), "title": "2"}),
-    AudioFile({"~filename": fsnative("/foo/bar3"), "title": "3"}),
+    AudioFile({"~filename": "/foo/bar1", "title": "1"}),
+    AudioFile({"~filename": "/foo/bar2", "title": "2"}),
+    AudioFile({"~filename": "/foo/bar3", "title": "3"}),
 ]
 for file_ in FILES:
     file_.sanitize()

--- a/tests/test_qltk___init__.py
+++ b/tests/test_qltk___init__.py
@@ -6,7 +6,7 @@
 from tests import TestCase
 
 from gi.repository import Gtk, Gdk
-from senf import fsnative, fsn2bytes
+from senf import fsn2bytes
 
 from quodlibet.formats import AudioFile
 from quodlibet import qltk
@@ -134,9 +134,9 @@ class TQltk(TestCase):
 class Tselection_data(TestCase):
     def test_selection_set_songs(self):
         song = AudioFile()
-        song["~filename"] = fsnative("foo")
+        song["~filename"] = "foo"
         sel = MockSelData()
         qltk.selection_set_songs(sel, [song])
-        assert sel.data == fsn2bytes(fsnative("foo"), "utf-8")
+        assert sel.data == fsn2bytes("foo", "utf-8")
 
-        assert qltk.selection_get_filenames(sel) == [fsnative("foo")]
+        assert qltk.selection_get_filenames(sel) == ["foo"]

--- a/tests/test_qltk_bookmarks.py
+++ b/tests/test_qltk_bookmarks.py
@@ -6,7 +6,6 @@
 # the Free Software Foundation; either version 2 of the License, or
 # (at your option) any later version.
 
-from senf import fsnative
 
 from tests import TestCase
 
@@ -23,7 +22,7 @@ class TBookmarks(TestCase):
         player = NullPlayer()
         song = AudioFile()
         song.bookmarks = [(10, "bla")]
-        song.sanitize(fsnative("/"))
+        song.sanitize("/")
         player.song = song
         self.player = player
         self.library = SongLibrary()

--- a/tests/test_qltk_chooser.py
+++ b/tests/test_qltk_chooser.py
@@ -66,5 +66,5 @@ class Tchooser(TestCase):
         assert isinstance(path, fsnative)
 
     def test_set_current_dir(self):
-        set_current_dir(fsnative("."))
+        set_current_dir(".")
         assert get_current_dir() == os.getcwd()

--- a/tests/test_qltk_delete.py
+++ b/tests/test_qltk_delete.py
@@ -4,7 +4,6 @@
 # (at your option) any later version.
 
 from gi.repository import Gtk
-from senf import fsnative
 
 from tests import TestCase
 
@@ -12,7 +11,7 @@ from quodlibet import config
 from quodlibet.formats import AudioFile
 from quodlibet.qltk.delete import DeleteDialog, TrashDialog, TrashMenuItem
 
-SONG = AudioFile({"~filename": fsnative("/dev/null")})
+SONG = AudioFile({"~filename": "/dev/null"})
 SONG.sanitize()
 
 

--- a/tests/test_qltk_filesel.py
+++ b/tests/test_qltk_filesel.py
@@ -81,8 +81,8 @@ class TDirectoryTree(TestCase):
             assert selected[0].startswith(path)
 
     def test_bad_go_to(self):
-        newpath = fsnative("/woooooo/bar/fun/broken")
-        dirlist = DirectoryTree(fsnative("/"), folders=self.ROOTS)
+        newpath = "/woooooo/bar/fun/broken"
+        dirlist = DirectoryTree("/", folders=self.ROOTS)
         dirlist.go_to(newpath)
         dirlist.destroy()
 

--- a/tests/test_qltk_information.py
+++ b/tests/test_qltk_information.py
@@ -3,7 +3,6 @@
 # the Free Software Foundation; either version 2 of the License, or
 # (at your option) any later version.
 
-from senf import fsnative
 
 from tests import TestCase, init_fake_app, destroy_fake_app
 
@@ -45,42 +44,42 @@ class TInformation(TestCase):
         Information(self.library, []).destroy()
 
     def test_one(self):
-        f = AF({"~filename": fsnative("/dev/null")})
+        f = AF({"~filename": "/dev/null"})
         self.inf = Information(self.library, [f])
         self.assert_is_of_type(OneSong)
 
     def test_two(self):
-        f = AF({"~filename": fsnative("/dev/null")})
-        f2 = AF({"~filename": fsnative("/dev/null2")})
+        f = AF({"~filename": "/dev/null"})
+        f2 = AF({"~filename": "/dev/null2"})
         self.inf = Information(self.library, [f, f2])
         self.assert_is_of_type(ManySongs)
 
     def test_album(self):
-        f = AF({"~filename": fsnative("/dev/null"), "album": "woo"})
-        f2 = AF({"~filename": fsnative("/dev/null2"), "album": "woo"})
+        f = AF({"~filename": "/dev/null", "album": "woo"})
+        f2 = AF({"~filename": "/dev/null2", "album": "woo"})
         self.inf = Information(self.library, [f, f2])
         self.assert_is_of_type(OneAlbum)
 
     def test_album_special_chars(self):
-        f = AF({"~filename": fsnative("/dev/null"), "album": "woo & hoo"})
-        f2 = AF({"~filename": fsnative("/dev/null2"), "album": "woo & hoo"})
+        f = AF({"~filename": "/dev/null", "album": "woo & hoo"})
+        f2 = AF({"~filename": "/dev/null2", "album": "woo & hoo"})
         self.inf = Information(self.library, [f, f2])
         self.assert_is_of_type(OneAlbum)
 
     def test_artist(self):
-        f = AF({"~filename": fsnative("/dev/null"), "artist": "woo"})
-        f2 = AF({"~filename": fsnative("/dev/null2"), "artist": "woo"})
+        f = AF({"~filename": "/dev/null", "artist": "woo"})
+        f2 = AF({"~filename": "/dev/null2", "artist": "woo"})
         self.inf = Information(self.library, [f, f2])
         self.assert_is_of_type(OneArtist)
 
     def test_performer_roles(self):
-        f = AF({"~filename": fsnative("/dev/null"), "performer:piano": "woo"})
+        f = AF({"~filename": "/dev/null", "performer:piano": "woo"})
         self.inf = Information(self.library, [f])
         self.assert_is_of_type(OneSong)
 
     def test_remove_song(self):
-        f = AF({"~filename": fsnative("/dev/null"), "artist": "woo"})
-        f2 = AF({"~filename": fsnative("/dev/null2"), "artist": "woo"})
+        f = AF({"~filename": "/dev/null", "artist": "woo"})
+        f2 = AF({"~filename": "/dev/null2", "artist": "woo"})
         self.library.add([f, f2])
         self.inf = Information(self.library, [f, f2])
         self.library.remove([f])
@@ -92,10 +91,10 @@ class TInformation(TestCase):
 class TUtils(TestCase):
     def test_sort_albums(self):
         # Make sure we have more than one album, one having a null date
-        f = AF({"~filename": fsnative("/1"), "album": "one"})
-        f2 = AF({"~filename": fsnative("/2"), "album": "one"})
-        f3 = AF({"~filename": fsnative("/3"), "album": "two", "date": "2009"})
-        f4 = AF({"~filename": fsnative("/4")})
+        f = AF({"~filename": "/1", "album": "one"})
+        f2 = AF({"~filename": "/2", "album": "one"})
+        f3 = AF({"~filename": "/3", "album": "two", "date": "2009"})
+        f4 = AF({"~filename": "/4"})
         albums, count = _sort_albums([f, f2, f3, f4])
         self.assertEqual(count, 1)
         self.assertEqual(len(albums), 2)

--- a/tests/test_qltk_properties.py
+++ b/tests/test_qltk_properties.py
@@ -5,7 +5,6 @@
 
 from tests import TestCase, run_gtk_loop
 
-from senf import fsnative
 
 from quodlibet.formats import AudioFile
 from quodlibet.qltk.properties import SongProperties
@@ -32,9 +31,9 @@ class DummyPlugins:
 
 class TSongProperties(TestCase):
     af1 = AudioFile({"title": "woo"})
-    af1.sanitize(fsnative("invalid"))
+    af1.sanitize("invalid")
     af2 = AudioFile({"title": "bar", "album": "quux"})
-    af2.sanitize(fsnative("alsoinvalid"))
+    af2.sanitize("alsoinvalid")
 
     def setUp(self):
         SongProperties.plugins = DummyPlugins()

--- a/tests/test_qltk_ratingsmenu.py
+++ b/tests/test_qltk_ratingsmenu.py
@@ -7,7 +7,6 @@
 # (at your option) any later version.
 
 from gi.repository import Gtk
-from senf import fsnative
 
 from tests import TestCase
 from quodlibet import config
@@ -24,7 +23,7 @@ class TRatingsMenuItem(TestCase):
         self.assertEqual(config.RATINGS.number, NUM_RATINGS)
         self.library = SongLibrary()
         self.library.librarian = SongLibrarian()
-        self.af = AudioFile({"~filename": fsnative("/foo"), "~#rating": 1.0})
+        self.af = AudioFile({"~filename": "/foo", "~#rating": 1.0})
         self.af.sanitize()
         self.rmi = RatingsMenuItem([self.af], self.library)
 
@@ -45,7 +44,7 @@ class TRatingsMenuItem(TestCase):
         self.assertEqual(children[1].get_active(), False)
 
     def test_no_rating(self):
-        af = AudioFile({"~filename": fsnative("/foobar"), "artist": "foo"})
+        af = AudioFile({"~filename": "/foobar", "artist": "foo"})
         rmi = RatingsMenuItem([af], self.library)
         children = [
             mi

--- a/tests/test_qltk_renamefiles.py
+++ b/tests/test_qltk_renamefiles.py
@@ -36,13 +36,13 @@ class TFilter(TestCase):
 
 class TFilterMixin:
     def test_mix_empty(self):
-        empty = fsnative("")
+        empty = ""
         v = self.c.filter(empty, "")
         assert v == ""
         assert isinstance(v, str)
 
     def test_mix_safe(self):
-        empty = fsnative("")
+        empty = ""
         safe = "safe"
         assert self.c.filter(empty, safe) == safe
 
@@ -64,13 +64,13 @@ class TStripWindowsIncompat(TFilter, TFilterMixin):
             assert self.c.filter("", 'foo\\:*?;"<>|/') == "foo_________/"
 
     def test_type(self):
-        empty = fsnative("")
+        empty = ""
         assert isinstance(self.c.filter(empty, empty), fsnative)
 
     def test_ends_with_dots_or_spaces(self):
-        empty = fsnative("")
-        v = self.c.filter(empty, fsnative("foo. . "))
-        assert v == fsnative("foo. ._")
+        empty = ""
+        v = self.c.filter(empty, "foo. . ")
+        assert v == "foo. ._"
         assert isinstance(v, fsnative)
 
         if os.name == "nt":
@@ -103,11 +103,11 @@ class TReplaceColons(TFilter, TFilterMixin):
         )
 
     def test_type(self):
-        empty = fsnative("")
+        empty = ""
         assert isinstance(self.c.filter(empty, empty), fsnative)
 
     def conv(self, s: str):
-        return self.c.filter(fsnative(""), s)
+        return self.c.filter("", s)
 
     def unaffected(self, s: str) -> bool:
         return self.conv(s) == s
@@ -117,7 +117,7 @@ class TStripDiacriticals(TFilter, TFilterMixin):
     Kind = StripDiacriticals
 
     def test_conv(self):
-        empty = fsnative("")
+        empty = ""
         test = "\u00c1 test"
         out = "A test"
         v = self.c.filter(empty, test)
@@ -129,7 +129,7 @@ class TStripNonASCII(TFilter, TFilterMixin):
     Kind = StripNonASCII
 
     def test_conv(self):
-        empty = fsnative("")
+        empty = ""
         in_ = "foo \u00c1 \u1234"
         out = "foo _ _"
         v = self.c.filter(empty, in_)
@@ -141,14 +141,14 @@ class TLowercase(TFilter, TFilterMixin):
     Kind = Lowercase
 
     def test_conv(self):
-        empty = fsnative("")
+        empty = ""
 
-        v = self.c.filter(empty, fsnative("foobar baz"))
-        assert v == fsnative("foobar baz")
+        v = self.c.filter(empty, "foobar baz")
+        assert v == "foobar baz"
         assert isinstance(v, fsnative)
 
-        v = self.c.filter(empty, fsnative("Foobar.BAZ"))
-        assert v == fsnative("foobar.baz")
+        v = self.c.filter(empty, "Foobar.BAZ")
+        assert v == "foobar.baz"
         assert isinstance(v, fsnative)
 
 

--- a/tests/test_qltk_songlist.py
+++ b/tests/test_qltk_songlist.py
@@ -17,7 +17,6 @@ from quodlibet.qltk.songlist import (
     get_sort_tag,
 )
 from quodlibet.qltk.songlistcolumns import SongListColumn
-from senf import fsnative
 from tests import TestCase, run_gtk_loop
 
 
@@ -211,7 +210,7 @@ class TSongList(TestCase):
         assert self.songs_removed == [{song}], f"Signal not emitted: {self.__sigs}"
 
     def test_header_menu(self):
-        song = AudioFile({"~filename": fsnative("/dev/null")})
+        song = AudioFile({"~filename": "/dev/null"})
         song.sanitize()
         self.songlist.set_songs([song])
 

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -13,7 +13,6 @@ from quodlibet.plugins import Plugin
 from quodlibet.plugins.query import QueryPlugin, QUERY_HANDLER
 from quodlibet.query import Query, QueryType
 from quodlibet.query import _match as match
-from senf import fsnative
 from tests import TestCase, skip
 
 
@@ -194,7 +193,7 @@ class TQuery(TestCase):
                 "artist": "piman",
                 "title": "Quuxly",
                 "version": "cake mix",
-                "~filename": fsnative("/dir1/foobar.ogg"),
+                "~filename": "/dir1/foobar.ogg",
                 "~#length": 224,
                 "~#skipcount": 13,
                 "~#playcount": 24,
@@ -207,7 +206,7 @@ class TQuery(TestCase):
                 "album": "Foo the Bar",
                 "artist": "mu",
                 "title": "Rockin' Out",
-                "~filename": fsnative("/dir2/something.mp3"),
+                "~filename": "/dir2/something.mp3",
                 "tracknumber": "12/15",
             }
         )
@@ -215,8 +214,8 @@ class TQuery(TestCase):
         self.s3 = AudioFile(
             {
                 "artist": "piman\nmu",
-                "~filename": fsnative("/test/\xf6\xe4\xfc/fo\xfc.ogg"),
-                "~mountpoint": fsnative("/bla/\xf6\xe4\xfc/fo\xfc"),
+                "~filename": "/test/\xf6\xe4\xfc/fo\xfc.ogg",
+                "~mountpoint": "/bla/\xf6\xe4\xfc/fo\xfc",
             }
         )
         self.s4 = AudioFile({"title": "Ångström", "utf8": "Ångström"})
@@ -270,7 +269,7 @@ class TQuery(TestCase):
         assert r == "<Query string='&(/bar/d)' type=TEXT star=['foo']>"
 
     def test_2007_07_27_synth_search(self):
-        song = AudioFile({"~filename": fsnative("foo/64K/bar.ogg")})
+        song = AudioFile({"~filename": "foo/64K/bar.ogg"})
         query = Query("~dirname = !64K")
         assert not query.search(song), f"{query!r}, {song!r}"
 
@@ -498,7 +497,7 @@ class TQuery(TestCase):
         assert Query("mountpoint=öä").search(self.s3)
 
     def test_mountpoint_no_value(self):
-        af = AudioFile({"~filename": fsnative("foo")})
+        af = AudioFile({"~filename": "foo"})
         assert not Query("~mountpoint=bla").search(af)
 
     def test_star_numeric(self):

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -117,7 +117,7 @@ class Tunexpand(TestCase):
             self.assertEqual(path, "~")
 
     def test_only_profile_case(self):
-        assert isinstance(unexpand(os.path.expanduser(fsnative("~"))), fsnative)
+        assert isinstance(unexpand(os.path.expanduser("~")), fsnative)
 
     def test_base_trailing(self):
         path = unexpand(self.d + os.path.sep)
@@ -710,9 +710,9 @@ class TNormalizePath(TestCase):
     def test_types(self):
         from quodlibet.util.path import normalize_path
 
-        assert isinstance(normalize_path(fsnative("foo"), False), fsnative)
         assert isinstance(normalize_path("foo", False), fsnative)
-        assert isinstance(normalize_path(fsnative("foo"), True), fsnative)
+        assert isinstance(normalize_path("foo", False), fsnative)
+        assert isinstance(normalize_path("foo", True), fsnative)
         assert isinstance(normalize_path("foo", True), fsnative)
 
     def test_canonicalise(self):
@@ -801,9 +801,9 @@ class Tload_library(TestCase):
 
 class Tstrip_win32_incompat_from_path(TestCase):
     def test_types(self):
-        v = strip_win32_incompat_from_path(fsnative(""))
+        v = strip_win32_incompat_from_path("")
         assert isinstance(v, fsnative)
-        v = strip_win32_incompat_from_path(fsnative("foo"))
+        v = strip_win32_incompat_from_path("foo")
         assert isinstance(v, fsnative)
 
         v = strip_win32_incompat_from_path("")
@@ -822,7 +822,7 @@ class Tstrip_win32_incompat_from_path(TestCase):
 
 class TPathHandling(TestCase):
     def test_main(self):
-        v = fsnative("foo")
+        v = "foo"
         assert isinstance(v, fsnative)
 
         v3 = bytes2fsn(fsn2bytes(v, "utf-8"), "utf-8")

--- a/tests/test_util_collection.py
+++ b/tests/test_util_collection.py
@@ -27,7 +27,7 @@ from quodlibet.util.collection import (
     XSPFBackedPlaylist,
     XSPF_NS,
 )
-from senf import fsnative, uri2fsn
+from senf import uri2fsn
 from tests import TestCase, mkdtemp
 
 config.RATINGS = config.HardCodedRatingsPrefs()
@@ -35,7 +35,7 @@ config.RATINGS = config.HardCodedRatingsPrefs()
 NUMERIC_SONGS = [
     Fakesong(
         {
-            "~filename": fsnative("fake1-\xf0.mp3"),
+            "~filename": "fake1-\xf0.mp3",
             "~#length": 4,
             "~#added": 5,
             "~#lastplayed": 1,
@@ -48,7 +48,7 @@ NUMERIC_SONGS = [
     ),
     Fakesong(
         {
-            "~filename": fsnative("fake2.mp3"),
+            "~filename": "fake2.mp3",
             "~#length": 7,
             "~#added": 7,
             "~#lastplayed": 88,
@@ -61,7 +61,7 @@ NUMERIC_SONGS = [
     ),
     Fakesong(
         {
-            "~filename": fsnative("fake3.mp3"),
+            "~filename": "fake3.mp3",
             "~#length": 1,
             "~#added": 3,
             "~#lastplayed": 43,
@@ -591,7 +591,7 @@ class TFileBackedPlaylist(TPlaylist):
     def test_write(self):
         with self.wrap("playlist") as pl:
             pl.extend(NUMERIC_SONGS)
-            pl.extend([fsnative("xf0xf0")])
+            pl.extend(["xf0xf0"])
             pl.write()
 
             with open(pl.path, "rb") as h:
@@ -652,7 +652,7 @@ class TFileBackedPlaylist(TPlaylist):
         # playlists can contain songs and paths for masked handling..
         lib = FileLibrary("foobar")
         with self.wrap("playlist", lib) as pl:
-            song = Fakesong({"date": "2038", "~filename": fsnative("/fake")})
+            song = Fakesong({"date": "2038", "~filename": "/fake"})
             song.sanitize()
             lib.add([song])
 
@@ -704,7 +704,7 @@ class TXSPFBackedPlaylist(TFileBackedPlaylist):
     def test_write(self):
         with self.wrap("playlist") as pl:
             pl.extend(NUMERIC_SONGS)
-            some_path = fsnative(os.path.join(self.temp, "xf0xf0"))
+            some_path = os.path.join(self.temp, "xf0xf0")
             pl.extend([some_path])
             pl.write()
 

--- a/tests/test_util_cover.py
+++ b/tests/test_util_cover.py
@@ -10,7 +10,6 @@ from pathlib import Path
 from gi.repository import Gio
 
 from quodlibet.util.path import normalize_path
-from senf import fsnative
 
 from quodlibet import config
 from quodlibet.ext.covers.artwork_url import ArtworkUrlCover
@@ -22,7 +21,7 @@ from tests import TestCase, mkdtemp
 
 bar_2_1 = AudioFile(
     {
-        "~filename": fsnative("does not/exist"),
+        "~filename": "does not/exist",
         "title": "more songs",
         "discnumber": "2/2",
         "tracknumber": "1",
@@ -94,7 +93,7 @@ class TCoverManager(TestCase):
         self.test_labelid()  # labelid must work with other files present
 
     def test_file_encoding(self):
-        p = self.add_file(fsnative("öäü - AlbumName - cover.jpg"))
+        p = self.add_file("öäü - AlbumName - cover.jpg")
         assert isinstance(self.song("album"), str)
         h = self._find_cover(self.song)
         assert h, "Nothing found"

--- a/tests/test_util_library.py
+++ b/tests/test_util_library.py
@@ -22,12 +22,10 @@ from quodlibet.util.path import get_home_dir, unexpand
 from tests import TestCase
 
 
-STANDARD_PATH = fsnative("/home/user/Music")
-OTHER_PATH = fsnative("/opt/party")
-GVFS_PATH = fsnative(
-    "/run/user/12345/gvfs/smb-share:server=12.23.34.45,share=/foo/bar/baz/path"
-)
-GVFS_PATH_ESCAPED = fsnative(
+STANDARD_PATH = "/home/user/Music"
+OTHER_PATH = "/opt/party"
+GVFS_PATH = "/run/user/12345/gvfs/smb-share:server=12.23.34.45,share=/foo/bar/baz/path"
+GVFS_PATH_ESCAPED = (
     "/run/user/12345/gvfs/smb-share\\:server=12.23.34.45,share=/foo/bar/baz/path"
 )
 

--- a/tests/test_util_path.py
+++ b/tests/test_util_path.py
@@ -37,15 +37,15 @@ def test_uri2gsturi():
 class Tishidden(TestCase):
     @skipIf(is_win, "unix-like hidden")
     def test_leading_dot(self):
-        assert is_hidden(fsnative("."))
-        assert is_hidden(fsnative("foo/.bar"))
+        assert is_hidden(".")
+        assert is_hidden("foo/.bar")
 
     def test_normal_names_not_hidden(self):
-        assert not is_hidden(fsnative("foo"))
-        assert not is_hidden(fsnative(".foo/bar"))
+        assert not is_hidden("foo")
+        assert not is_hidden(".foo/bar")
 
     def test_multiple_dots(self):
-        assert not is_hidden(fsnative("...and Justice For All.flac"))
+        assert not is_hidden("...and Justice For All.flac")
 
 
 class Turi(TestCase):
@@ -53,11 +53,11 @@ class Turi(TestCase):
         if os.name != "nt":
             path = uri2fsn("file:///home/piman/cr%21azy")
             assert isinstance(path, fsnative)
-            self.assertEqual(path, fsnative("/home/piman/cr!azy"))
+            self.assertEqual(path, "/home/piman/cr!azy")
         else:
             path = uri2fsn("file:///C:/foo")
             assert isinstance(path, fsnative)
-            self.assertEqual(path, fsnative("C:\\foo"))
+            self.assertEqual(path, "C:\\foo")
 
     def test_uri2fsn_invalid(self):
         self.assertRaises(ValueError, uri2fsn, "http://example.com")
@@ -70,10 +70,10 @@ class Turi(TestCase):
 
     def test_fsn2uri(self):
         if os.name != "nt":
-            uri = fsn2uri(fsnative("/öäü.txt"))
+            uri = fsn2uri("/öäü.txt")
             self.assertEqual(uri, "file:///%C3%B6%C3%A4%C3%BC.txt")
         else:
-            uri = fsn2uri(fsnative("C:\\öäü.txt"))
+            uri = fsn2uri("C:\\öäü.txt")
             self.assertEqual(uri, "file:///C:/%C3%B6%C3%A4%C3%BC.txt")
             self.assertEqual(fsn2uri("C:\\SomeDir\xe4"), "file:///C:/SomeDir%C3%A4")
 
@@ -84,9 +84,9 @@ class Turi(TestCase):
             paths = ["/öäü.txt", "/a/foo/bar", "/a/b/foo/bar"]
 
         for source in paths:
-            path = uri2fsn(fsn2uri(fsnative(source)))
+            path = uri2fsn(fsn2uri(source))
             assert isinstance(path, fsnative)
-            self.assertEqual(path, fsnative(source))
+            self.assertEqual(path, source)
 
     def test_win_unc_path(self):
         if os.name == "nt":
@@ -124,19 +124,19 @@ class Tlimit_path(TestCase):
             path = limit_path(path)
             self.assertEqual(len(path), 1 + 6 + 1 + 255 + 1 + 255)
 
-        path = fsnative("foo%s.ext" % ("x" * 300))
+        path = "foo%s.ext" % ("x" * 300)
         new = limit_path(path, ellipsis=False)
         assert isinstance(new, fsnative)
         self.assertEqual(len(new), 255)
-        assert new.endswith(fsnative("xx.ext"))
+        assert new.endswith("xx.ext")
 
         new = limit_path(path)
         assert isinstance(new, fsnative)
         self.assertEqual(len(new), 255)
-        assert new.endswith(fsnative("...ext"))
+        assert new.endswith("...ext")
 
-        assert isinstance(limit_path(fsnative()), fsnative)
-        self.assertEqual(limit_path(fsnative()), fsnative())
+        assert isinstance(limit_path(""), fsnative)
+        self.assertEqual(limit_path(""), "")
 
 
 class Tiscommand(TestCase):

--- a/tests/test_util_tagsfrompath.py
+++ b/tests/test_util_tagsfrompath.py
@@ -7,7 +7,6 @@ from tests import TestCase
 
 import os
 
-from senf import fsnative
 
 from quodlibet.util.tagsfrompath import TagsFromPattern
 
@@ -64,9 +63,7 @@ class TTagsFromPattern(TestCase):
 
     def test_nongreedy(self):
         pat = TagsFromPattern("<artist> - <title>")
-        dic = pat.match_path(
-            fsnative("Prefuse 73 - The End of Biters - International.ogg")
-        )
+        dic = pat.match_path("Prefuse 73 - The End of Biters - International.ogg")
         self.assertEqual(dic["artist"], "Prefuse 73")
         self.assertEqual(dic["title"], "The End of Biters - International")
 
@@ -143,14 +140,14 @@ class TTagsFromPattern(TestCase):
     def test_disctrack(self):
         pat = TagsFromPattern("<discnumber><tracknumber>. <title>")
         self.assertEqual(
-            pat.match_path(fsnative("101. T1.ogg")),
+            pat.match_path("101. T1.ogg"),
             {"discnumber": "1", "tracknumber": "01", "title": "T1"},
         )
         self.assertEqual(
-            pat.match_path(fsnative("1318. T18.ogg")),
+            pat.match_path("1318. T18.ogg"),
             {"discnumber": "13", "tracknumber": "18", "title": "T18"},
         )
         self.assertEqual(
-            pat.match_path(fsnative("24. T4.ogg")),
+            pat.match_path("24. T4.ogg"),
             {"discnumber": "2", "tracknumber": "4", "title": "T4"},
         )


### PR DESCRIPTION
Assuming valid input they are equivalent to the input with Python 3, so just remove them.
