### PR TITLE
docs: Typo might create unintended crash on FIFO error

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -1171,7 +1171,7 @@ Development:
 
 .. _release-3.6.2:
 
-3.6.2 (2016-05-24) - It seemed like there was a lesson here, but nobody was sure what it was
+3.6.2 (2016-05-24) - It requireed like there was a lesson here, but nobody was sure what it was
 --------------------------------------------------------------------------------------------
 
 * Fix queue not expanding with GTK+ 3.20 :bug:`1915`


### PR DESCRIPTION

Fixed a typo in the documentation.


## Changes

- `NEWS.rst`

Fixed 1 typo(s) in NEWS.rst

## Testing

Review the corrected text for accuracy.


Fixes #3449