### PR TITLE
Fix multimedia keys on macos

### DIFF
--- a/dev-utils/macos/QuodLibetDev.app/Contents/Info.plist
+++ b/dev-utils/macos/QuodLibetDev.app/Contents/Info.plist
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleIdentifier</key>
+    <string>io.github.quodlibet.QuodLibet.dev</string>
+    <key>CFBundleName</key>
+    <string>QuodLibet Dev</string>
+    <key>CFBundleExecutable</key>
+    <string>quodlibet-dev</string>
+    <key>CFBundleVersion</key>
+    <string>1</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>NSPrincipalClass</key>
+    <string>NSApplication</string>
+</dict>
+</plist>

--- a/dev-utils/macos/QuodLibetDev.app/Contents/MacOS/.gitignore
+++ b/dev-utils/macos/QuodLibetDev.app/Contents/MacOS/.gitignore
@@ -1,0 +1,1 @@
+quodlibet-dev

--- a/dev-utils/macos/run.sh
+++ b/dev-utils/macos/run.sh
@@ -24,7 +24,7 @@ fi
 
 # Copy the venv Python into the .app so _NSGetExecutablePath returns a path
 # inside the bundle. Symlinks don't work (macOS resolves them). Hard links
-# don't work across filesystems, so we copy and skip if already up to date.
+# don't work across filesystems, so copy and skip if already up to date.
 if [ ! -f "$LAUNCHER" ] || [ "$PYTHON_SRC" -nt "$LAUNCHER" ]; then
     cp -f "$PYTHON_SRC" "$LAUNCHER"
 fi

--- a/dev-utils/macos/run.sh
+++ b/dev-utils/macos/run.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# Run Quod Libet from source with a proper macOS bundle identity, so that
+# MPRemoteCommandCenter and media key routing work during development.
+#
+# Usage: ./dev-utils/macos/run.sh [quodlibet args...]
+#
+# How it works: NSBundle.mainBundle() uses the executable's path on disk to
+# find Info.plist. By hard-linking the venv Python binary into the stub .app
+# and exec'ing that link, the Python process appears to live inside the bundle,
+# so macOS assigns it the bundle ID from Info.plist and rcd routes media keys
+# to it.
+
+set -e
+
+REPO="$(cd "$(dirname "$0")/../.." && pwd)"
+APP="$(dirname "$0")/QuodLibetDev.app"
+PYTHON_SRC="$REPO/.venv/bin/python"
+LAUNCHER="$APP/Contents/MacOS/quodlibet-dev"
+
+if [ ! -f "$PYTHON_SRC" ]; then
+    echo "error: no venv found at $PYTHON_SRC — run 'poetry install' first" >&2
+    exit 1
+fi
+
+# Copy the venv Python into the .app so _NSGetExecutablePath returns a path
+# inside the bundle. Symlinks don't work (macOS resolves them). Hard links
+# don't work across filesystems, so we copy and skip if already up to date.
+if [ ! -f "$LAUNCHER" ] || [ "$PYTHON_SRC" -nt "$LAUNCHER" ]; then
+    cp -f "$PYTHON_SRC" "$LAUNCHER"
+fi
+
+PYTHON_VERSION=$("$PYTHON_SRC" -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")
+export PYTHONPATH="$REPO/.venv/lib/python${PYTHON_VERSION}/site-packages${PYTHONPATH:+:$PYTHONPATH}"
+
+exec "$LAUNCHER" "$REPO/quodlibet.py" "$@"

--- a/dev-utils/osx_bundle/modulesets/quodlibet.modules
+++ b/dev-utils/osx_bundle/modulesets/quodlibet.modules
@@ -759,6 +759,19 @@
     </dependencies>
   </distutils>
 
+  <distutils id="python-pyobjc-framework-MediaPlayer" python3="1">
+    <branch repo="pypi.org"
+            checkoutdir="python-pyobjc-framework-MediaPlayer-${version}"
+            module="e9/f0/851f6f47e11acbd62d5f5dcb8274afc969135e30018591f75bf3cbf6417f/pyobjc_framework_mediaplayer-${version}.tar.gz"
+            version="12.1"
+            hash="sha256:5ef3f669bdf837d87cdb5a486ec34831542360d14bcba099c7c2e0383380794c"/>
+    <dependencies>
+      <dep package="python-setuptools"/>
+      <dep package="python-pyobjc-core"/>
+      <dep package="python-pyobjc-framework-Cocoa"/>
+    </dependencies>
+  </distutils>
+
   <distutils id="python-pyobjc" python3="1">
     <branch repo="pypi.org"
             checkoutdir="python-pyobjc-${version}"
@@ -770,6 +783,7 @@
     <dep package="python-pyobjc-core"/>
     <dep package="python-pyobjc-framework-Cocoa"/>
     <dep package="python-pyobjc-framework-Quartz"/>
+    <dep package="python-pyobjc-framework-MediaPlayer"/>
     </dependencies>
   </distutils>
 

--- a/docs/development/devenv.rst
+++ b/docs/development/devenv.rst
@@ -63,53 +63,36 @@ Now clone the Git repository and start Quod Libet::
 |macosx-logo| MacOS
 -------------------
 
-On MacOS (formerly OS X) all the needed dependencies are included in the provided bundle
-itself.
-Download the latest bundle, which is guaranteed to work with current
-Git ``main``: `QuodLibet-latest.dmg
-<https://github.com/quodlibet/quodlibet/releases/download/ci/QuodLibet-latest.dmg>`__.
-It contains a ``run`` script which passes all arguments to the included Python with
-the right environment set up.
-
-::
-
-    $ git clone https://github.com/quodlibet/quodlibet.git
-    $ ./QuodLibet.app/Contents/MacOS/run <path_to_git_repo>/quodlibet/quodlibet.py
-
-On recent MacOS releases, the OS Gatekeeper will complain about the application not being recognised.
-It is easiest to just clear the `com.apple.quarantine` extended attribute from all files in the bundle
-rather than try and open each and every component that MacOS will refuse to open:
-
-::
-
-    $ xattr -rd com.apple.quarantine ./QuodLibet.app/Contents
-
-The bundle includes `pip`, so you can always install additional packages
-(such as `ruff`, `pytest` and `flaky`, for the test suite (or use Poetry)):
-
-::
-
-    $ ./QuodLibet.app/Contents/MacOS/run -m pip install ruff pytest flaky
-    $ ./QuodLibet.app/Contents/MacOS/run <path_to_git_repo>/setup.py test
-
-If you want to run the tests with your own Python command, you'll need to install some additonal software
-and packages:
-
-::
+Install the native dependencies via Homebrew, then use Poetry for Python packages::
 
     $ brew install cairo dbus gst-libav gst-plugins-bad gst-plugins-good gst-plugins-ugly \
         gstreamer gtk-mac-integration gtk+3 libsoup pkg-config pygobject3
     $ poetry install
     $ poetry run pip install pyobjc
 
-
-.. |quodlibet.modules ref| replace:: ``quodlibet.modules`` moduleset file 
+.. |quodlibet.modules ref| replace:: ``quodlibet.modules`` moduleset file
 .. _quodlibet.modules ref: https://github.com/quodlibet/quodlibet/tree/main/dev-utils/osx_bundle/modulesets/quodlibet.modules
 
-This will *almost* cover all the dependencies that the bundle will contain; at the time of writing the brew
-gstreamer plugins do not include the wavpack (``gst-plugins-good``) or game-music-emu (gme, in ``gst-plugins-bad``)
-plugins. The above list may be out of date, check the ``quodlibet`` metamodule section of the |quodlibet.modules ref|_
-for a more up-to-date list of dependencies.
+The brew list above may be out of date; check the ``quodlibet`` metamodule section of the
+|quodlibet.modules ref|_ for the authoritative list.
+
+Running the app
+~~~~~~~~~~~~~~~
+
+To run Quod Libet from source on macOS, use the helper script in ``dev-utils/macos/``::
+
+    $ ./dev-utils/macos/run.sh
+
+This is required for ``MPRemoteCommandCenter`` and media key routing to work. Without it,
+macOS will not route media keys to the process because it lacks a bundle identity.
+See ``dev-utils/macos/run.sh`` for details.
+
+Running tests
+~~~~~~~~~~~~~
+
+The test suite does not need a bundle identity — run it directly with Poetry::
+
+    $ poetry run pytest tests/
 
 If you want to build a bundle yourself or change/add dependencies,
 see the `osx_bundle directory

--- a/docs/development/testing.rst
+++ b/docs/development/testing.rst
@@ -6,49 +6,43 @@ Testing
 
 Quod Libet uses the CPython unittest framework for testing and `pytest
 <https://docs.pytest.org/en/latest/>`__ as a test runner. All testing related
-code can be found under ``quodlibet/tests``.
+code can be found under ``tests/``.
 
-To run the full tests suite simply execute::
+To run the full test suite::
 
-    ./setup.py test
+    poetry run pytest tests/
 
-For checking the code coverage of the test suite run::
+For checking code coverage::
 
-    ./setup.py coverage
+    poetry run coverage run -m pytest tests/
+    poetry run coverage report
 
 
 Selecting a Specific Test
 -------------------------
 
-To only test a subset of the test suite, pass a comma separated list of test
-class names to setup.py via the ``--to-run`` option. For example::
+Run a single file or a glob of files::
 
-    ./setup.py test --to-run=TMP3File,TAPICType
+    poetry run pytest tests/test_formats_mp3.py
+    poetry run pytest tests/test_formats*
 
-Similarly the coverage report can also be generated for a subset of tests::
+Run a single test class or method::
 
-    ./setup.py coverage --to-run=TMP3File,TAPICType
-
-Selecting by class name can take a long time because it needs to import all
-tests first. To speed things up you can just use pytest directly::
-
-    py.test tests/test_formats_mp3.py
-    py.test tests/test_formats*
-    py.test tests/test_formats_mp3.py::TMP3File
+    poetry run pytest tests/test_formats_mp3.py::TMP3File
+    poetry run pytest tests/test_formats_mp3.py::TMP3File::test_title
 
 To just run code quality tests::
 
-    py.test tests/quality
+    poetry run pytest tests/quality
 
-Some helpful ``py.test`` options are ``-s`` for not hiding stdout and ``-x``
-for stopping on the first error. For more information check out
+Some helpful options are ``-s`` for not hiding stdout and ``-x`` for stopping
+on the first error. For more information check out
 https://docs.pytest.org/en/latest/usage.html
 
 
 Abort on First Error
 --------------------
 
-By passing ``-x`` to ``setup.py test`` the test suite will abort once it
-sees the first error instead of printing a summary of errors at the end::
+Pass ``-x`` to abort on the first failure::
 
-    ./setup.py test -x
+    poetry run pytest tests/ -x

--- a/flake.nix
+++ b/flake.nix
@@ -94,6 +94,7 @@
                 libsoup_3
                 pcre2
                 shared-mime-info
+                pkg-config
               ]
               ++ lib.optionals stdenv.isLinux [
                 libappindicator-gtk3

--- a/poetry.lock
+++ b/poetry.lock
@@ -1209,7 +1209,7 @@ description = "An extremely fast Python linter and code formatter, written in Ru
 optional = false
 python-versions = ">=3.7"
 groups = ["dev"]
-markers = "sys_platform == \"linux\""
+markers = "sys_platform == \"linux\" or sys_platform == \"darwin\""
 files = [
     {file = "ruff-0.7.3-py3-none-linux_armv6l.whl", hash = "sha256:34f2339dc22687ec7e7002792d1f50712bf84a13d5152e75712ac08be565d344"},
     {file = "ruff-0.7.3-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:fb397332a1879b9764a3455a0bb1087bda876c2db8aca3a3cbb67b3dbce8cda0"},
@@ -1874,4 +1874,4 @@ plugins = ["dbus-python", "musicbrainzngs", "paho-mqtt", "pypresence", "regex", 
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<4.0"
-content-hash = "b06994aa359d59e8467563875822275ed3f31b7f1608d66235375839935d8060"
+content-hash = "ab2cc739728212619e3a4815e89a66a64a4455203b9a5b46dfabf0574349e3e3"

--- a/poetry.lock
+++ b/poetry.lock
@@ -832,6 +832,159 @@ files = [
 pycairo = ">=1.16"
 
 [[package]]
+name = "pyobjc-core"
+version = "12.1"
+description = "Python<->ObjC Interoperability Module"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+markers = "sys_platform == \"darwin\""
+files = [
+    {file = "pyobjc_core-12.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:93418e79c1655f66b4352168f8c85c942707cb1d3ea13a1da3e6f6a143bacda7"},
+    {file = "pyobjc_core-12.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:c918ebca280925e7fcb14c5c43ce12dcb9574a33cccb889be7c8c17f3bcce8b6"},
+    {file = "pyobjc_core-12.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:818bcc6723561f207e5b5453efe9703f34bc8781d11ce9b8be286bb415eb4962"},
+    {file = "pyobjc_core-12.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:01c0cf500596f03e21c23aef9b5f326b9fb1f8f118cf0d8b66749b6cf4cbb37a"},
+    {file = "pyobjc_core-12.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:177aaca84bb369a483e4961186704f64b2697708046745f8167e818d968c88fc"},
+    {file = "pyobjc_core-12.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:844515f5d86395b979d02152576e7dee9cc679acc0b32dc626ef5bda315eaa43"},
+    {file = "pyobjc_core-12.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:453b191df1a4b80e756445b935491b974714456ae2cbae816840bd96f86db882"},
+    {file = "pyobjc_core-12.1.tar.gz", hash = "sha256:2bb3903f5387f72422145e1466b3ac3f7f0ef2e9960afa9bcd8961c5cbf8bd21"},
+]
+
+[[package]]
+name = "pyobjc-framework-avfoundation"
+version = "12.1"
+description = "Wrappers for the framework AVFoundation on macOS"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+markers = "sys_platform == \"darwin\""
+files = [
+    {file = "pyobjc_framework_avfoundation-12.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:370d5f1149c1041028cb1f5fb61b9f56655fe53bbffafc79393b0824a474bef0"},
+    {file = "pyobjc_framework_avfoundation-12.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:82cc2c2d9ab6cc04feeb4700ff251d00f1fcafff573c63d4e87168ff80adb926"},
+    {file = "pyobjc_framework_avfoundation-12.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:bf634f89265b4d93126153200d885b6de4859ed6b3bc65e69ff75540bc398406"},
+    {file = "pyobjc_framework_avfoundation-12.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:f8ac7f7e0884ac8f12009cdb9d4fefc2f269294ab2ccfd84520a560859b69cec"},
+    {file = "pyobjc_framework_avfoundation-12.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:51aba2c6816badfb1fb5a2de1b68b33a23f065bf9e3b99d46ede0c8c774ac7a4"},
+    {file = "pyobjc_framework_avfoundation-12.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:9a3ffd1ae90bd72dbcf2875aa9254369e805b904140362a7338ebf1af54201a6"},
+    {file = "pyobjc_framework_avfoundation-12.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:394c99876b9a38db4851ddf8146db363556895c12e9c711ccd3c3f907ac8e273"},
+    {file = "pyobjc_framework_avfoundation-12.1.tar.gz", hash = "sha256:eda0bb60be380f9ba2344600c4231dd58a3efafa99fdc65d3673ecfbb83f6fcb"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=12.1"
+pyobjc-framework-Cocoa = ">=12.1"
+pyobjc-framework-CoreAudio = ">=12.1"
+pyobjc-framework-CoreMedia = ">=12.1"
+pyobjc-framework-Quartz = ">=12.1"
+
+[[package]]
+name = "pyobjc-framework-cocoa"
+version = "12.1"
+description = "Wrappers for the Cocoa frameworks on macOS"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+markers = "sys_platform == \"darwin\""
+files = [
+    {file = "pyobjc_framework_cocoa-12.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:9b880d3bdcd102809d704b6d8e14e31611443aa892d9f60e8491e457182fdd48"},
+    {file = "pyobjc_framework_cocoa-12.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:f52228bcf38da64b77328787967d464e28b981492b33a7675585141e1b0a01e6"},
+    {file = "pyobjc_framework_cocoa-12.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:547c182837214b7ec4796dac5aee3aa25abc665757b75d7f44f83c994bcb0858"},
+    {file = "pyobjc_framework_cocoa-12.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:5a3dcd491cacc2f5a197142b3c556d8aafa3963011110102a093349017705118"},
+    {file = "pyobjc_framework_cocoa-12.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:914b74328c22d8ca261d78c23ef2befc29776e0b85555973927b338c5734ca44"},
+    {file = "pyobjc_framework_cocoa-12.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:03342a60fc0015bcdf9b93ac0b4f457d3938e9ef761b28df9564c91a14f0129a"},
+    {file = "pyobjc_framework_cocoa-12.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:6ba1dc1bfa4da42d04e93d2363491275fb2e2be5c20790e561c8a9e09b8cf2cc"},
+    {file = "pyobjc_framework_cocoa-12.1.tar.gz", hash = "sha256:5556c87db95711b985d5efdaaf01c917ddd41d148b1e52a0c66b1a2e2c5c1640"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=12.1"
+
+[[package]]
+name = "pyobjc-framework-coreaudio"
+version = "12.1"
+description = "Wrappers for the framework CoreAudio on macOS"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+markers = "sys_platform == \"darwin\""
+files = [
+    {file = "pyobjc_framework_coreaudio-12.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:d676c85bb9dc51217d94adc3b5b60e7e5b59a81167446f06821b2687d92641d3"},
+    {file = "pyobjc_framework_coreaudio-12.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:a452de6b509fa4a20160c0410b72330ac871696cd80237883955a5b3a4de8f2a"},
+    {file = "pyobjc_framework_coreaudio-12.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:a5ad6309779663f846ab36fe6c49647e470b7e08473c3e48b4f004017bdb68a4"},
+    {file = "pyobjc_framework_coreaudio-12.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:3d8ef424850c8ae2146f963afaec6c4f5bf0c2e412871e68fb6ecfb209b8376f"},
+    {file = "pyobjc_framework_coreaudio-12.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:6552624df39dbc68ff9328f244ba56f59234ecbde8455db1e617a71bc4f3dd3a"},
+    {file = "pyobjc_framework_coreaudio-12.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:78ea67483a5deb21625c189328152008d278fe1da4304da9fcc1babd12627038"},
+    {file = "pyobjc_framework_coreaudio-12.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:8d81b0d0296ab4571a4ff302e5cdb52386e486eb8749e99b95b9141438558ca2"},
+    {file = "pyobjc_framework_coreaudio-12.1.tar.gz", hash = "sha256:a9e72925fcc1795430496ce0bffd4ddaa92c22460a10308a7283ade830089fe1"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=12.1"
+pyobjc-framework-Cocoa = ">=12.1"
+
+[[package]]
+name = "pyobjc-framework-coremedia"
+version = "12.1"
+description = "Wrappers for the framework CoreMedia on macOS"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+markers = "sys_platform == \"darwin\""
+files = [
+    {file = "pyobjc_framework_coremedia-12.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:4fce8570db3eaa7b841456a7890b24546504d1059157dc33e700b14d9d3073d8"},
+    {file = "pyobjc_framework_coremedia-12.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:ee7b822c9bb674b5b0a70bfb133410acae354e9241b6983f075395f3562f3c46"},
+    {file = "pyobjc_framework_coremedia-12.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:161a627f5c8cd30a5ebb935189f740e21e6cd94871a9afd463efdb5d51e255fa"},
+    {file = "pyobjc_framework_coremedia-12.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:98e885b7a092083fceaef0a7fc406a01ba7bcd3318fb927e59e055931c99cac8"},
+    {file = "pyobjc_framework_coremedia-12.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:d2b84149c1b3e65ec9050a3e5b617e6c0b4cdad2ab622c2d8c5747a20f013e16"},
+    {file = "pyobjc_framework_coremedia-12.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:737ec6e0b63414f42f7188030c85975d6d2124fbf6b15b52c99b6cc20250af4d"},
+    {file = "pyobjc_framework_coremedia-12.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:6a9419e0d143df16a1562520a13a389417386e2a53031530af6da60c34058ced"},
+    {file = "pyobjc_framework_coremedia-12.1.tar.gz", hash = "sha256:166c66a9c01e7a70103f3ca44c571431d124b9070612ef63a1511a4e6d9d84a7"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=12.1"
+pyobjc-framework-Cocoa = ">=12.1"
+
+[[package]]
+name = "pyobjc-framework-mediaplayer"
+version = "12.1"
+description = "Wrappers for the framework MediaPlayer on macOS"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+markers = "sys_platform == \"darwin\""
+files = [
+    {file = "pyobjc_framework_mediaplayer-12.1-py2.py3-none-any.whl", hash = "sha256:85d9baec131807bfdf0f4c24d4b943e83cce806ab31c95c7e19c78e3fb7eefc8"},
+    {file = "pyobjc_framework_mediaplayer-12.1.tar.gz", hash = "sha256:5ef3f669bdf837d87cdb5a486ec34831542360d14bcba099c7c2e0383380794c"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=12.1"
+pyobjc-framework-AVFoundation = ">=12.1"
+
+[[package]]
+name = "pyobjc-framework-quartz"
+version = "12.1"
+description = "Wrappers for the Quartz frameworks on macOS"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+markers = "sys_platform == \"darwin\""
+files = [
+    {file = "pyobjc_framework_quartz-12.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:c6f312ae79ef8b3019dcf4b3374c52035c7c7bc4a09a1748b61b041bb685a0ed"},
+    {file = "pyobjc_framework_quartz-12.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:19f99ac49a0b15dd892e155644fe80242d741411a9ed9c119b18b7466048625a"},
+    {file = "pyobjc_framework_quartz-12.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:7730cdce46c7e985535b5a42c31381af4aa6556e5642dc55b5e6597595e57a16"},
+    {file = "pyobjc_framework_quartz-12.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:629b7971b1b43a11617f1460cd218bd308dfea247cd4ee3842eb40ca6f588860"},
+    {file = "pyobjc_framework_quartz-12.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:53b84e880c358ba1ddcd7e8d5ea0407d760eca58b96f0d344829162cda5f37b3"},
+    {file = "pyobjc_framework_quartz-12.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:42d306b07f05ae7d155984503e0fb1b701fecd31dcc5c79fe8ab9790ff7e0de0"},
+    {file = "pyobjc_framework_quartz-12.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:0cc08fddb339b2760df60dea1057453557588908e42bdc62184b6396ce2d6e9a"},
+    {file = "pyobjc_framework_quartz-12.1.tar.gz", hash = "sha256:27f782f3513ac88ec9b6c82d9767eef95a5cf4175ce88a1e5a65875fee799608"},
+]
+
+[package.dependencies]
+pyobjc-core = ">=12.1"
+pyobjc-framework-Cocoa = ">=12.1"
+
+[[package]]
 name = "pypresence"
 version = "4.6.1"
 description = "Discord RPC client written in Python"
@@ -1721,4 +1874,4 @@ plugins = ["dbus-python", "musicbrainzngs", "paho-mqtt", "pypresence", "regex", 
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<4.0"
-content-hash = "c89b45dab633423b7ca5c0fb126d7d93f538dd0c87a688b59d115d100ebbfb65"
+content-hash = "b06994aa359d59e8467563875822275ed3f31b7f1608d66235375839935d8060"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ dev = [
   "pyvirtualdisplay~=3.0 ; sys_platform == 'linux'",
   "setuptools>=78.1.1,<82",
   "packaging>=24.2",
-  "ruff==0.7.3 ; sys_platform == 'linux'",
+  "ruff==0.7.3 ; sys_platform == 'linux' or sys_platform == 'darwin'",
 ]
 docs = [
   "sphinx>=7.2.2,<9",
@@ -75,6 +75,7 @@ package-mode = false
 
 [tool.poetry.group.docs]
 optional = true
+dependencies = {}
 
 [tool.mypy]
 python_version = "3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
   "feedparser>=6.0.11,<7.0.0",
   "pycairo>=1.19,<2.0",
   "pygobject>=3.34.0,<4.0.0",
+  "pyobjc-framework-mediaplayer>=12.1; sys_platform == 'darwin'",
 ]
 
 [project.optional-dependencies]

--- a/quodlibet/ext/playorder/queue.py
+++ b/quodlibet/ext/playorder/queue.py
@@ -24,7 +24,7 @@ class QueueOrder(ShufflePlugin, OrderInOrder):
     PLUGIN_ICON = Icons.VIEW_LIST
     PLUGIN_DESC = _(
         "Limits playing of songs to the queue.\n\n"
-        "Select this play order in the shuffle settings " 
+        "Select this play order in the shuffle settings "
         "of the main window and enable shuffle mode. "
         "Double-clicking any song will enqueue it "
         "instead of playing."

--- a/quodlibet/mmkeys/__init__.py
+++ b/quodlibet/mmkeys/__init__.py
@@ -68,6 +68,8 @@ class MMKeysHandler:
         self._backend.grab()
 
         self._window.connect("notify::is-active", self._focus_event)
+        self._player.connect("unpaused", self._on_unpaused)
+        self._player.connect("paused", self._on_paused)
 
     def quit(self):
         if self._backend:
@@ -75,6 +77,14 @@ class MMKeysHandler:
             self._backend = None
             self._window = None
             self._player = None
+
+    def _on_unpaused(self, player):
+        if self._backend:
+            self._backend.set_playing(True)
+
+    def _on_paused(self, player):
+        if self._backend:
+            self._backend.set_playing(False)
 
     def _focus_event(self, window, param):
         if window.get_property(param.name) and self._backend:

--- a/quodlibet/mmkeys/__init__.py
+++ b/quodlibet/mmkeys/__init__.py
@@ -68,6 +68,8 @@ class MMKeysHandler:
         self._backend.grab()
 
         self._window.connect("notify::is-active", self._focus_event)
+        self._player.connect("song-started", self._on_song_started)
+        self._player.connect("seek", self._on_seek)
         self._player.connect("unpaused", self._on_unpaused)
         self._player.connect("paused", self._on_paused)
 
@@ -78,19 +80,27 @@ class MMKeysHandler:
             self._window = None
             self._player = None
 
+    def _on_song_started(self, player, song):
+        if self._backend:
+            self._backend.update_now_playing(song, 0, not player.paused)
+
+    def _on_seek(self, player, song, position_ms):
+        if self._backend:
+            self._backend.update_now_playing(song, position_ms, not player.paused)
+
     def _on_unpaused(self, player):
         if self._backend:
-            self._backend.set_playing(True)
+            self._backend.update_now_playing(player.info, player.get_position(), True)
 
     def _on_paused(self, player):
         if self._backend:
-            self._backend.set_playing(False)
+            self._backend.update_now_playing(player.info, player.get_position(), False)
 
     def _focus_event(self, window, param):
         if window.get_property(param.name) and self._backend:
             self._backend.grab()
 
-    def _callback(self, action):
+    def _callback(self, action, *args):
         print_d(f"Event {action!r} from {type(self._backend).__name__!r}")
 
         def seek_relative(seconds):
@@ -120,6 +130,9 @@ class MMKeysHandler:
         elif action == MMKeysAction.REWIND:
             if player.song:
                 seek_relative(-10)
+        elif action == MMKeysAction.SEEK:
+            if player.song:
+                player.seek(int(args[0] * 1000))  # convert to ms
         elif action == MMKeysAction.REPEAT:
             player_options.repeat = not player_options.repeat
         elif action == MMKeysAction.SHUFFLE:

--- a/quodlibet/mmkeys/_base.py
+++ b/quodlibet/mmkeys/_base.py
@@ -42,6 +42,12 @@ class MMKeysBackend:
         (e.g. the main window got focused)
         """
 
+    def set_playing(self, playing):
+        """Called when the player starts or stops playing.
+        Backends that need to track play state (e.g. for system media routing)
+        can override this. No-op by default.
+        """
+
     def cancel(self):
         """After cancel returns the callback will no longer be called.
         Can be called multiple times.

--- a/quodlibet/mmkeys/_base.py
+++ b/quodlibet/mmkeys/_base.py
@@ -22,6 +22,7 @@ class MMKeysAction:
     REWIND = "rewind"
     REPEAT = "repeat"
     SHUFFLE = "shuffle"
+    SEEK = "seek"
 
 
 class MMKeysBackend:
@@ -46,6 +47,11 @@ class MMKeysBackend:
         """Called when the player starts or stops playing.
         Backends that need to track play state (e.g. for system media routing)
         can override this. No-op by default.
+        """
+
+    def update_now_playing(self, song, position_ms, playing):
+        """Push current track metadata and playback state to the system.
+        `song` may be None when stopped. No-op by default.
         """
 
     def cancel(self):

--- a/quodlibet/mmkeys/keybinder.py
+++ b/quodlibet/mmkeys/keybinder.py
@@ -6,7 +6,12 @@
 # the Free Software Foundation; either version 2 of the License, or
 # (at your option) any later version.
 
+import sys
+
 from ._base import MMKeysBackend, MMKeysAction, MMKeysImportError
+
+if sys.platform != "linux":
+    raise MMKeysImportError()
 
 import gi
 

--- a/quodlibet/mmkeys/osx.py
+++ b/quodlibet/mmkeys/osx.py
@@ -25,7 +25,12 @@ try:
     import objc
     from Foundation import NSObject
     from MediaPlayer import (
+        MPMediaItemPropertyAlbumTitle,
+        MPMediaItemPropertyArtist,
+        MPMediaItemPropertyPlaybackDuration,
+        MPMediaItemPropertyTitle,
         MPNowPlayingInfoCenter,
+        MPNowPlayingInfoPropertyElapsedPlaybackTime,
         MPNowPlayingInfoPropertyPlaybackRate,
         MPRemoteCommandCenter,
         MPRemoteCommandHandlerStatusSuccess,
@@ -50,7 +55,10 @@ class _CommandDispatcher(NSObject):
     def handle_command_(self, event):
         action = self._dispatch.get(event.command())
         if action is not None and self._callback is not None:
-            GLib.idle_add(self._callback, action)
+            if action == MMKeysAction.SEEK:
+                GLib.idle_add(self._callback, action, event.positionTime())
+            else:
+                GLib.idle_add(self._callback, action)
         return MPRemoteCommandHandlerStatusSuccess
 
     # Explicit ObjC selector name preserves the camelCase selector that
@@ -77,6 +85,7 @@ class OSXBackend(MMKeysBackend):
         self._register(center.stopCommand(), MMKeysAction.STOP)
         self._register(center.playCommand(), MMKeysAction.PLAY)
         self._register(center.pauseCommand(), MMKeysAction.PAUSE)
+        self._register(center.changePlaybackPositionCommand(), MMKeysAction.SEEK)
 
     def _register(self, command, action):
         command.setEnabled_(True)
@@ -84,9 +93,21 @@ class OSXBackend(MMKeysBackend):
         command.addTarget_action_(self._dispatcher, b"handleCommand:")
         self._commands.append(command)
 
-    def set_playing(self, playing):
+    def update_now_playing(self, song, position_ms, playing):
+        if song is None:
+            MPNowPlayingInfoCenter.defaultCenter().setNowPlayingInfo_(
+                {MPNowPlayingInfoPropertyPlaybackRate: 0.0}
+            )
+            return
         MPNowPlayingInfoCenter.defaultCenter().setNowPlayingInfo_(
-            {MPNowPlayingInfoPropertyPlaybackRate: 1.0 if playing else 0.0}
+            {
+                MPMediaItemPropertyTitle: song("title", ""),
+                MPMediaItemPropertyArtist: song.comma("artist"),
+                MPMediaItemPropertyAlbumTitle: song.comma("album"),
+                MPMediaItemPropertyPlaybackDuration: float(song("~#length", 0)),
+                MPNowPlayingInfoPropertyElapsedPlaybackTime: position_ms / 1000.0,
+                MPNowPlayingInfoPropertyPlaybackRate: 1.0 if playing else 0.0,
+            }
         )
 
     def cancel(self):

--- a/quodlibet/mmkeys/osx.py
+++ b/quodlibet/mmkeys/osx.py
@@ -23,10 +23,13 @@ from ._base import MMKeysBackend, MMKeysAction, MMKeysImportError
 
 try:
     import objc
+    from AppKit import NSImage
     from Foundation import NSObject
     from MediaPlayer import (
+        MPMediaItemArtwork,
         MPMediaItemPropertyAlbumTitle,
         MPMediaItemPropertyArtist,
+        MPMediaItemPropertyArtwork,
         MPMediaItemPropertyPlaybackDuration,
         MPMediaItemPropertyTitle,
         MPNowPlayingInfoCenter,
@@ -37,6 +40,26 @@ try:
     )
 except ImportError as e:
     raise MMKeysImportError from e
+
+# Provide block type metadata that pyobjc-framework-MediaPlayer may not include.
+# Arguments: 0=self, 1=SEL, 2=boundsSize, 3=requestHandler (block).
+objc.registerMetaDataForSelector(
+    b"MPMediaItemArtwork",
+    b"initWithBoundsSize:requestHandler:",
+    {
+        "arguments": {
+            3: {
+                "callable": {
+                    "retval": {"type": b"@"},
+                    "arguments": {
+                        0: {"type": b"^v"},
+                        1: {"type": b"{CGSize=dd}"},
+                    },
+                }
+            }
+        }
+    },
+)
 
 
 class _CommandDispatcher(NSObject):
@@ -74,6 +97,8 @@ class OSXBackend(MMKeysBackend):
         self._dispatcher._callback = callback
         center = MPRemoteCommandCenter.sharedCommandCenter()
         self._commands = []
+        self._art_song_key = None
+        self._art = None
 
         MPNowPlayingInfoCenter.defaultCenter().setNowPlayingInfo_(
             {MPNowPlayingInfoPropertyPlaybackRate: 0.0}
@@ -93,22 +118,57 @@ class OSXBackend(MMKeysBackend):
         command.addTarget_action_(self._dispatcher, b"handleCommand:")
         self._commands.append(command)
 
+    @staticmethod
+    def _build_artwork(song):
+        try:
+            embedded = song.get_primary_image()
+            if embedded is not None:
+                ns_image = NSImage.alloc().initWithData_(embedded.read())
+                if ns_image is not None:
+                    return (
+                        MPMediaItemArtwork.alloc().initWithBoundsSize_requestHandler_(
+                            (512.0, 512.0), lambda size: ns_image
+                        )
+                    )
+            from pathlib import Path
+
+            dirname = Path(song("~dirname", ""))
+            for name in ("cover.jpg", "cover.png", "folder.jpg", "folder.png"):
+                path = dirname / name
+                if path.exists():
+                    ns_image = NSImage.alloc().initWithContentsOfFile_(str(path))
+                    if ns_image is not None:
+                        artwork = MPMediaItemArtwork.alloc()
+                        return artwork.initWithBoundsSize_requestHandler_(
+                            (512.0, 512.0), lambda size, img=ns_image: img
+                        )
+        except Exception:
+            pass
+        return None
+
     def update_now_playing(self, song, position_ms, playing):
         if song is None:
+            self._art_song_key = None
+            self._art = None
             MPNowPlayingInfoCenter.defaultCenter().setNowPlayingInfo_(
                 {MPNowPlayingInfoPropertyPlaybackRate: 0.0}
             )
             return
-        MPNowPlayingInfoCenter.defaultCenter().setNowPlayingInfo_(
-            {
-                MPMediaItemPropertyTitle: song("title", ""),
-                MPMediaItemPropertyArtist: song.comma("artist"),
-                MPMediaItemPropertyAlbumTitle: song.comma("album"),
-                MPMediaItemPropertyPlaybackDuration: float(song("~#length", 0)),
-                MPNowPlayingInfoPropertyElapsedPlaybackTime: position_ms / 1000.0,
-                MPNowPlayingInfoPropertyPlaybackRate: 1.0 if playing else 0.0,
-            }
-        )
+        key = song("~filename", None)
+        if key != self._art_song_key:
+            self._art_song_key = key
+            self._art = self._build_artwork(song)
+        info = {
+            MPMediaItemPropertyTitle: song("title", ""),
+            MPMediaItemPropertyArtist: song.comma("artist"),
+            MPMediaItemPropertyAlbumTitle: song.comma("album"),
+            MPMediaItemPropertyPlaybackDuration: float(song("~#length", 0)),
+            MPNowPlayingInfoPropertyElapsedPlaybackTime: position_ms / 1000.0,
+            MPNowPlayingInfoPropertyPlaybackRate: 1.0 if playing else 0.0,
+        }
+        if self._art is not None:
+            info[MPMediaItemPropertyArtwork] = self._art
+        MPNowPlayingInfoCenter.defaultCenter().setNowPlayingInfo_(info)
 
     def cancel(self):
         for command in self._commands:
@@ -116,4 +176,6 @@ class OSXBackend(MMKeysBackend):
             command.setEnabled_(False)
         self._commands.clear()
         self._dispatcher = None
+        self._art = None
+        self._art_song_key = None
         MPNowPlayingInfoCenter.defaultCenter().setNowPlayingInfo_(None)

--- a/quodlibet/mmkeys/osx.py
+++ b/quodlibet/mmkeys/osx.py
@@ -1,5 +1,6 @@
 # Copyright 2012 Martijn Pieters <mj@zopatista.com>
 # Copyright 2014 Eric Le Lay elelay.fr:dev
+# Copyright 2025 Jost Schulte
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -7,165 +8,91 @@
 # (at your option) any later version.
 
 """
-osxmmkey - Mac OS X Media Keys support
---------------------------------------
+osxmmkey - Mac OS X Media Keys support via MPRemoteCommandCenter
+----------------------------------------------------------------
 
-Requires the PyObjC, with the Cocoa and Quartz bindings to be installed.
-Under macports, that's the `py27-pyobjc`, `py27-pyobjc-cocoa`
-and`py27-pyobjc-quartz` ports, or equivalents for the python version used by
-quodlibet.
+Requires pyobjc-framework-MediaPlayer to be installed.
 
-This plugin also requires that 'access for assistive devices' is enabled, see
-the Universal Access preference pane in the OS X System Prefences.
-
-We register a Quartz event tap to listen for the multimedia keys and
-intercept them to control QL and prevent iTunes to get them.
+Media key routing is handled by the system — multiple apps coexist correctly
+and no Accessibility permission is required.
 """
-
-import threading
 
 from gi.repository import GLib
 
 from ._base import MMKeysBackend, MMKeysAction, MMKeysImportError
 
 try:
-    from AppKit import NSKeyUp, NSSystemDefined, NSEvent
-    import Quartz
+    import objc
+    from Foundation import NSObject
+    from MediaPlayer import (
+        MPNowPlayingInfoCenter,
+        MPNowPlayingInfoPropertyPlaybackRate,
+        MPRemoteCommandCenter,
+        MPRemoteCommandHandlerStatusSuccess,
+    )
 except ImportError as e:
     raise MMKeysImportError from e
 
 
+class _CommandDispatcher(NSObject):
+    # NSObject subclass used as target for addTarget_action_. One instance is
+    # shared across all commands; the fired command is identified via its
+    # pointer, looked up in _dispatch.
+
+    def init(self):
+        self = objc.super(_CommandDispatcher, self).init()
+        if self is None:
+            return None
+        self._dispatch = {}
+        self._callback = None
+        return self
+
+    def handle_command_(self, event):
+        action = self._dispatch.get(event.command())
+        if action is not None and self._callback is not None:
+            GLib.idle_add(self._callback, action)
+        return MPRemoteCommandHandlerStatusSuccess
+
+    # Explicit ObjC selector name preserves the camelCase selector that
+    # addTarget_action_ registers against, while keeping the Python name lowercase.
+    handle_command_ = objc.selector(
+        handle_command_, selector=b"handleCommand:", signature=b"q@:@"
+    )
+
+
 class OSXBackend(MMKeysBackend):
     def __init__(self, name, callback):
-        self.__eventsapp = MacKeyEventsTap(callback)
-        self.__eventsapp.start()
+        self._dispatcher = _CommandDispatcher.alloc().init()
+        self._dispatcher._callback = callback
+        center = MPRemoteCommandCenter.sharedCommandCenter()
+        self._commands = []
+
+        MPNowPlayingInfoCenter.defaultCenter().setNowPlayingInfo_(
+            {MPNowPlayingInfoPropertyPlaybackRate: 0.0}
+        )
+
+        self._register(center.togglePlayPauseCommand(), MMKeysAction.PLAYPAUSE)
+        self._register(center.nextTrackCommand(), MMKeysAction.NEXT)
+        self._register(center.previousTrackCommand(), MMKeysAction.PREV)
+        self._register(center.stopCommand(), MMKeysAction.STOP)
+        self._register(center.playCommand(), MMKeysAction.PLAY)
+        self._register(center.pauseCommand(), MMKeysAction.PAUSE)
+
+    def _register(self, command, action):
+        command.setEnabled_(True)
+        self._dispatcher._dispatch[command] = action
+        command.addTarget_action_(self._dispatcher, b"handleCommand:")
+        self._commands.append(command)
+
+    def set_playing(self, playing):
+        MPNowPlayingInfoCenter.defaultCenter().setNowPlayingInfo_(
+            {MPNowPlayingInfoPropertyPlaybackRate: 1.0 if playing else 0.0}
+        )
 
     def cancel(self):
-        if self.__eventsapp is not None:
-            self.__eventsapp.stop()
-            self.__eventsapp = None
-
-
-class MacKeyEventsTap(threading.Thread):
-    # Quartz event tap, listens for media key events and translates these to
-    # control messages for quodlibet.
-
-    _EVENTS = {
-        16: MMKeysAction.PLAYPAUSE,
-        19: MMKeysAction.NEXT,
-        20: MMKeysAction.PREV,
-    }
-
-    def __init__(self, callback):
-        super().__init__()
-        self._callback = callback
-        self._tap = None
-        self._runLoopSource = None
-        self._event = threading.Event()
-
-    def _push_callback(self, action):
-        # push to the main thread, ignore if we have been stopped by now
-        def idle_call(action):
-            if self._tap:
-                self._callback(action)
-            return False
-
-        GLib.idle_add(idle_call, action)
-
-    def _event_tap(self, proxy, type_, event, refcon):
-        # evenTrap disabled by timeout or user input, re-enable
-        if (
-            type_ == Quartz.kCGEventTapDisabledByUserInput
-            or type_ == Quartz.kCGEventTapDisabledByTimeout
-        ):
-            assert self._tap is not None
-            Quartz.CGEventTapEnable(self._tap, True)
-            return event
-
-        # Convert the Quartz CGEvent into something more useful
-        keyEvent = NSEvent.eventWithCGEvent_(event)
-        if keyEvent.subtype() == 8:  # subtype 8 is media keys
-            data = keyEvent.data1()
-            keyCode = (data & 0xFFFF0000) >> 16
-            keyState = (data & 0xFF00) >> 8
-            if keyCode in self._EVENTS:
-                if keyState == NSKeyUp:
-                    self._push_callback(self._EVENTS[keyCode])
-                return None  # swallow the event, so iTunes doesn't launch
-        return event
-
-    def _loop_start(self, observer, activiti, info):
-        self._event.set()
-
-    def run(self):
-        self._tap = Quartz.CGEventTapCreate(
-            Quartz.kCGSessionEventTap,  # Session level is enough for our needs
-            Quartz.kCGHeadInsertEventTap,  # Insert wherever, we do not filter
-            # Active, to swallow the play/pause event is enough
-            Quartz.kCGEventTapOptionDefault,
-            # NSSystemDefined for media keys
-            Quartz.CGEventMaskBit(NSSystemDefined),
-            self._event_tap,
-            None,
-        )
-
-        # the above can fail
-        if self._tap is None:
-            self._event.set()
-            return
-
-        self._loop = Quartz.CFRunLoopGetCurrent()
-
-        # add an observer so we know when we can stop it
-        # without a race condition
-        self._observ = Quartz.CFRunLoopObserverCreate(
-            None, Quartz.kCFRunLoopEntry, False, 0, self._loop_start, None
-        )
-        Quartz.CFRunLoopAddObserver(
-            self._loop, self._observ, Quartz.kCFRunLoopCommonModes
-        )
-
-        # Create a runloop source and add it to the current loop
-        self._runLoopSource = Quartz.CFMachPortCreateRunLoopSource(None, self._tap, 0)
-
-        Quartz.CFRunLoopAddSource(
-            self._loop, self._runLoopSource, Quartz.kCFRunLoopDefaultMode
-        )
-
-        # Enable the tap
-        Quartz.CGEventTapEnable(self._tap, True)
-
-        # runrunrun
-        Quartz.CFRunLoopRun()
-
-    def stop(self):
-        """Call once from the main thread to stop the thread.
-        After this returns no callback will be called anymore.
-        """
-
-        # wait until we fail or the observer tells us that the loop has started
-        self._event.wait()
-
-        # failed to create a tap, nothing to stop
-        if self._tap is None:
-            return
-
-        # remove the runloop source
-        Quartz.CFRunLoopRemoveSource(
-            self._loop, self._runLoopSource, Quartz.kCFRunLoopDefaultMode
-        )
-        self._runLoopSource = None
-
-        # remove observer
-        Quartz.CFRunLoopRemoveObserver(
-            self._loop, self._observ, Quartz.kCFRunLoopCommonModes
-        )
-        self._observ = None
-
-        # stop the loop
-        Quartz.CFRunLoopStop(self._loop)
-        self._loop = None
-
-        # Disable the tap
-        Quartz.CGEventTapEnable(self._tap, False)
-        self._tap = None
+        for command in self._commands:
+            command.removeTarget_(self._dispatcher)
+            command.setEnabled_(False)
+        self._commands.clear()
+        self._dispatcher = None
+        MPNowPlayingInfoCenter.defaultCenter().setNowPlayingInfo_(None)

--- a/quodlibet/util/path.py
+++ b/quodlibet/util/path.py
@@ -377,7 +377,9 @@ def _normalize_darwin_path(filename, canonicalise=False):
     decoded = data.decode("utf-8", "quodlibet-osx-path-decode")
 
     try:
-        return bytes2fsn(NSString.fileSystemRepresentation(decoded), "utf-8")
+        return bytes2fsn(
+            NSString.stringWithString_(decoded).fileSystemRepresentation(), "utf-8"
+        )
     except ValueError:
         return filename
 

--- a/tests/test_mmkeys_osx.py
+++ b/tests/test_mmkeys_osx.py
@@ -1,0 +1,261 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+"""Tests for the macOS media keys backend (quodlibet/mmkeys/osx.py)."""
+
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tests import TestCase
+from quodlibet.formats import AudioFile
+from quodlibet.mmkeys._base import MMKeysAction
+
+# Skip the entire module when pyobjc / MediaPlayer is unavailable (non-macOS).
+pytest.importorskip("MediaPlayer")
+
+from MediaPlayer import (  # noqa: E402
+    MPMediaItemPropertyAlbumTitle,
+    MPMediaItemPropertyArtist,
+    MPMediaItemPropertyArtwork,
+    MPMediaItemPropertyPlaybackDuration,
+    MPMediaItemPropertyTitle,
+    MPNowPlayingInfoPropertyElapsedPlaybackTime,
+    MPNowPlayingInfoPropertyPlaybackRate,
+)
+from quodlibet.mmkeys.osx import OSXBackend, _CommandDispatcher  # noqa: E402
+
+_MOD = "quodlibet.mmkeys.osx"
+
+
+def _make_backend(callback=None):
+    """Create an OSXBackend with all ObjC framework calls mocked out."""
+    with (
+        patch(f"{_MOD}.MPRemoteCommandCenter"),
+        patch(f"{_MOD}.MPNowPlayingInfoCenter"),
+    ):
+        return OSXBackend("TestApp", callback or MagicMock())
+
+
+class TOSXBackendNowPlaying(TestCase):
+    def setUp(self):
+        self.backend = _make_backend()
+
+    def tearDown(self):
+        with patch(f"{_MOD}.MPNowPlayingInfoCenter"):
+            self.backend.cancel()
+
+    def _update(self, song, position_ms=0, playing=False, artwork=None):
+        """Call update_now_playing and return the dict passed to setNowPlayingInfo_."""
+        mock_info_center = MagicMock()
+        with (
+            patch(f"{_MOD}.MPNowPlayingInfoCenter") as mock_npc,
+            patch.object(OSXBackend, "_build_artwork", return_value=artwork),
+        ):
+            mock_npc.defaultCenter.return_value = mock_info_center
+            self.backend.update_now_playing(song, position_ms, playing)
+        return mock_info_center.setNowPlayingInfo_.call_args[0][0]
+
+    def test_song_fields_in_now_playing_info(self):
+        song = AudioFile(
+            {
+                "title": "Test Title",
+                "artist": "Test Artist",
+                "album": "Test Album",
+                "~#length": 240,
+                "~filename": "/music/test.mp3",
+            }
+        )
+        info = self._update(song, position_ms=30000, playing=True)
+        self.assertEqual(info[MPMediaItemPropertyTitle], "Test Title")
+        self.assertEqual(info[MPMediaItemPropertyArtist], "Test Artist")
+        self.assertEqual(info[MPMediaItemPropertyAlbumTitle], "Test Album")
+        self.assertAlmostEqual(info[MPMediaItemPropertyPlaybackDuration], 240.0)
+        self.assertAlmostEqual(info[MPNowPlayingInfoPropertyElapsedPlaybackTime], 30.0)
+
+    def test_playing_sets_rate_to_one(self):
+        song = AudioFile({"title": "T", "~filename": "/t.mp3"})
+        info = self._update(song, playing=True)
+        self.assertEqual(info[MPNowPlayingInfoPropertyPlaybackRate], 1.0)
+
+    def test_paused_sets_rate_to_zero(self):
+        song = AudioFile({"title": "T", "~filename": "/t.mp3"})
+        info = self._update(song, playing=False)
+        self.assertEqual(info[MPNowPlayingInfoPropertyPlaybackRate], 0.0)
+
+    def test_position_ms_converted_to_seconds(self):
+        song = AudioFile({"title": "T", "~filename": "/t.mp3"})
+        info = self._update(song, position_ms=90500)
+        self.assertAlmostEqual(info[MPNowPlayingInfoPropertyElapsedPlaybackTime], 90.5)
+
+    def test_none_song_clears_info(self):
+        mock_info_center = MagicMock()
+        with patch(f"{_MOD}.MPNowPlayingInfoCenter") as mock_npc:
+            mock_npc.defaultCenter.return_value = mock_info_center
+            self.backend.update_now_playing(None, 0, False)
+        info = mock_info_center.setNowPlayingInfo_.call_args[0][0]
+        self.assertEqual(info[MPNowPlayingInfoPropertyPlaybackRate], 0.0)
+        self.assertNotIn(MPMediaItemPropertyTitle, info)
+
+    def test_artwork_included_when_available(self):
+        mock_art = MagicMock()
+        song = AudioFile({"title": "T", "~filename": "/t.mp3"})
+        info = self._update(song, artwork=mock_art)
+        self.assertIs(info[MPMediaItemPropertyArtwork], mock_art)
+
+    def test_artwork_absent_when_none(self):
+        song = AudioFile({"title": "T", "~filename": "/t.mp3"})
+        info = self._update(song, artwork=None)
+        self.assertNotIn(MPMediaItemPropertyArtwork, info)
+
+    def test_artwork_cached_for_same_song(self):
+        song = AudioFile({"title": "T", "~filename": "/t.mp3"})
+        mock_info_center = MagicMock()
+        with (
+            patch(f"{_MOD}.MPNowPlayingInfoCenter") as mock_npc,
+            patch.object(OSXBackend, "_build_artwork", return_value=None) as mock_build,
+        ):
+            mock_npc.defaultCenter.return_value = mock_info_center
+            self.backend.update_now_playing(song, 0, True)
+            self.backend.update_now_playing(song, 1000, True)
+        mock_build.assert_called_once()
+
+    def test_artwork_refreshed_on_song_change(self):
+        song1 = AudioFile({"title": "A", "~filename": "/a.mp3"})
+        song2 = AudioFile({"title": "B", "~filename": "/b.mp3"})
+        mock_info_center = MagicMock()
+        with (
+            patch(f"{_MOD}.MPNowPlayingInfoCenter") as mock_npc,
+            patch.object(OSXBackend, "_build_artwork", return_value=None) as mock_build,
+        ):
+            mock_npc.defaultCenter.return_value = mock_info_center
+            self.backend.update_now_playing(song1, 0, True)
+            self.backend.update_now_playing(song2, 0, True)
+        self.assertEqual(mock_build.call_count, 2)
+
+
+class TOSXBuildArtwork(TestCase):
+    def _make_song(self, dirname, embedded_data=None):
+        song = MagicMock()
+        song.side_effect = (
+            lambda key, default="": dirname if key == "~dirname" else default
+        )
+        if embedded_data is not None:
+            mock_img = MagicMock()
+            mock_img.read.return_value = embedded_data
+            song.get_primary_image.return_value = mock_img
+        else:
+            song.get_primary_image.return_value = None
+        return song
+
+    def test_returns_none_when_no_image_and_no_cover_files(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            song = self._make_song(tmpdir)
+            result = OSXBackend._build_artwork(song)
+        self.assertIsNone(result)
+
+    def test_uses_embedded_image(self):
+        mock_ns_image = MagicMock()
+        mock_artwork = MagicMock()
+        song = self._make_song("/music", embedded_data=b"\xff\xd8")
+        with (
+            patch(f"{_MOD}.NSImage") as mock_NSImage,
+            patch(f"{_MOD}.MPMediaItemArtwork") as mock_MPArtwork,
+        ):
+            mock_NSImage.alloc.return_value.initWithData_.return_value = mock_ns_image
+            artwork_factory = mock_MPArtwork.alloc.return_value
+            init_artwork = artwork_factory.initWithBoundsSize_requestHandler_
+            init_artwork.return_value = mock_artwork
+            result = OSXBackend._build_artwork(song)
+        self.assertIs(result, mock_artwork)
+
+    def test_falls_back_to_cover_jpg(self):
+        mock_ns_image = MagicMock()
+        mock_artwork = MagicMock()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            Path(tmpdir, "cover.jpg").touch()
+            song = self._make_song(tmpdir)
+            with (
+                patch(f"{_MOD}.NSImage") as mock_NSImage,
+                patch(f"{_MOD}.MPMediaItemArtwork") as mock_MPArtwork,
+            ):
+                mock_NSImage.alloc.return_value.initWithContentsOfFile_.return_value = (
+                    mock_ns_image
+                )
+                artwork_factory = mock_MPArtwork.alloc.return_value
+                init_artwork = artwork_factory.initWithBoundsSize_requestHandler_
+                init_artwork.return_value = mock_artwork
+                result = OSXBackend._build_artwork(song)
+        self.assertIs(result, mock_artwork)
+
+    def test_prefers_embedded_over_cover_file(self):
+        mock_artwork = MagicMock()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            Path(tmpdir, "cover.jpg").touch()
+            song = self._make_song(tmpdir, embedded_data=b"\xff\xd8")
+            with (
+                patch(f"{_MOD}.NSImage") as mock_NSImage,
+                patch(f"{_MOD}.MPMediaItemArtwork") as mock_MPArtwork,
+            ):
+                mock_NSImage.alloc.return_value.initWithData_.return_value = MagicMock()
+                artwork_factory = mock_MPArtwork.alloc.return_value
+                init_artwork = artwork_factory.initWithBoundsSize_requestHandler_
+                init_artwork.return_value = mock_artwork
+                OSXBackend._build_artwork(song)
+            # initWithContentsOfFile_ should never have been called
+            mock_NSImage.alloc.return_value.initWithContentsOfFile_.assert_not_called()
+
+    def test_returns_none_on_exception(self):
+        song = self._make_song("/music", embedded_data=b"\xff\xd8")
+        with patch(f"{_MOD}.NSImage") as mock_NSImage:
+            mock_NSImage.alloc.side_effect = RuntimeError("ObjC error")
+            result = OSXBackend._build_artwork(song)
+        self.assertIsNone(result)
+
+
+class TOSXCommandDispatcher(TestCase):
+    def setUp(self):
+        self.dispatcher = _CommandDispatcher.alloc().init()
+        self.received = []
+        self.dispatcher._callback = lambda *args: self.received.append(args)
+
+    def _fire(self, command_key, action, position_time=None):
+        self.dispatcher._dispatch[command_key] = action
+        mock_event = MagicMock()
+        mock_event.command.return_value = command_key
+        if position_time is not None:
+            mock_event.positionTime.return_value = position_time
+        with patch(f"{_MOD}.GLib") as mock_glib:
+            mock_glib.idle_add.side_effect = lambda fn, *args: fn(*args)
+            self.dispatcher.handle_command_(mock_event)
+
+    def test_dispatches_next(self):
+        self._fire(object(), MMKeysAction.NEXT)
+        self.assertEqual(self.received, [(MMKeysAction.NEXT,)])
+
+    def test_dispatches_playpause(self):
+        self._fire(object(), MMKeysAction.PLAYPAUSE)
+        self.assertEqual(self.received, [(MMKeysAction.PLAYPAUSE,)])
+
+    def test_seek_passes_position(self):
+        self._fire(object(), MMKeysAction.SEEK, position_time=42.5)
+        self.assertEqual(self.received, [(MMKeysAction.SEEK, 42.5)])
+
+    def test_unknown_command_is_ignored(self):
+        mock_event = MagicMock()
+        mock_event.command.return_value = object()
+        with patch(f"{_MOD}.GLib"):
+            self.dispatcher.handle_command_(mock_event)
+        self.assertEqual(self.received, [])
+
+    def test_no_callback_does_not_raise(self):
+        cmd = object()
+        self.dispatcher._dispatch[cmd] = MMKeysAction.NEXT
+        self.dispatcher._callback = None
+        mock_event = MagicMock()
+        mock_event.command.return_value = cmd
+        with patch(f"{_MOD}.GLib"):
+            self.dispatcher.handle_command_(mock_event)


### PR DESCRIPTION
Check-list
----------

 * [x] There is a linked issue discussing the motivations for this feature or bugfix
 * [x] Unit tests have been added where possible
 * [x] I've added / updated documentation for any user-facing features.
 * [x] Performance seems to be comparable or better than current `main`


What this change is adding / fixing
-----------------------------------

Multimedia keys on macos weren't working without granting accessibility privileges in system settings. When granted, QL would claim all events and other apps weren't controllable with media keys any longer. macOS's current media management service wasn't used at all.

Now QL registers the proper event handlers for the Remote Command Center. It displays the info of the currently played artist and title, allows for scrubbing in the timeline and displays artwork. Accessibility privileges are no longer needed.

Tests on macos can now be run on the current source code without downloading the static .DMG file. Tests for the mm keys were added. The documentation for running tests on macos was updated too.

Related issues https://github.com/quodlibet/quodlibet/issues/2692, https://github.com/quodlibet/quodlibet/issues/4025, https://github.com/quodlibet/quodlibet/issues/3316