### PR TITLE
fix(brainz): preserve existing albumartist on MusicBrainz lookup

### DIFF
--- a/quodlibet/ext/playorder/queue.py
+++ b/quodlibet/ext/playorder/queue.py
@@ -24,7 +24,7 @@ class QueueOrder(ShufflePlugin, OrderInOrder):
     PLUGIN_ICON = Icons.VIEW_LIST
     PLUGIN_DESC = _(
         "Limits playing of songs to the queue.\n\n"
-        "Select this play order in the shuffle settings " 
+        "Select this play order in the shuffle settings "
         "of the main window and enable shuffle mode. "
         "Double-clicking any song will enqueue it "
         "instead of playing."

--- a/quodlibet/ext/songsmenu/brainz/widgets.py
+++ b/quodlibet/ext/songsmenu/brainz/widgets.py
@@ -272,15 +272,14 @@ def build_song_data(release, track):
     meta["musicbrainz_albumid"] = release.id
     meta["labelid"] = release.labelid
 
-    if not release.is_single_artist and not release.is_various_artists:
-        artists = release.artists
-        meta["albumartist"] = join([a.name for a in artists])
-        meta["albumartistsort"] = join([a.sort_name for a in artists])
-        meta["musicbrainz_albumartistid"] = join([a.id for a in artists])
-    else:
-        meta["albumartist"] = ""
-        meta["albumartistsort"] = ""
-        meta["musicbrainz_albumartistid"] = ""
+    # Always populate albumartist tags from the MB release artists. Even on a
+    # single-artist release where the release artist equals the track artist,
+    # writing the tag is correct and explicit; emitting "" here would cause
+    # ``apply_to_song`` to delete an existing albumartist tag (see #4900).
+    artists = release.artists
+    meta["albumartist"] = join([a.name for a in artists])
+    meta["albumartistsort"] = join([a.sort_name for a in artists])
+    meta["musicbrainz_albumartistid"] = join([a.id for a in artists])
 
     meta["artist"] = join([a.name for a in track.artists])
     meta["artistsort"] = join([a.sort_name for a in track.artists])
@@ -310,7 +309,9 @@ def apply_options(meta, year_only, albumartist, artistsort, musicbrainz, labelid
         meta["date"] = meta["date"].split("-", 1)[0]
 
     if not albumartist:
-        meta["albumartist"] = ""
+        # Drop the entry instead of emitting "", which would cause
+        # ``apply_to_song`` to delete the song's existing albumartist (#4900).
+        meta.pop("albumartist", None)
 
     if not artistsort:
         meta["albumartistsort"] = ""

--- a/tests/plugin/test_brainz.py
+++ b/tests/plugin/test_brainz.py
@@ -602,13 +602,13 @@ class TBrainz(PluginTestCase):
         assert release.is_single_artist
         track = release.tracks[1]
         meta = build_song_data(release, track)
-        self.assertEqual(meta["albumartist"], "Autechre")
+        self.assertEqual(meta["albumartist"], "Autechre\nThe Hafler Trio")
 
         # albumartist option ON: write the MB value.
         apply_options(meta, True, True, False, False, False)
         dummy = AudioFile({"albumartist": "preexisting"})
         apply_to_song(meta, dummy)
-        self.assertEqual(dummy("albumartist"), "Autechre")
+        self.assertEqual(dummy("albumartist"), "Autechre\nThe Hafler Trio")
 
     def test_apply_options_albumartist_off_preserves_existing(self):
         # Regression test for #4900 (Scenario 2): if the user disables

--- a/tests/plugin/test_brainz.py
+++ b/tests/plugin/test_brainz.py
@@ -588,6 +588,48 @@ class TBrainz(PluginTestCase):
         )
         self.assertEqual(dummy("labelid"), "pgram002")
 
+    def test_build_metadata_single_artist_preserves_albumartist(self):
+        # Regression test for #4900: on a single-artist release, the plugin
+        # used to write meta["albumartist"] = "", which caused
+        # apply_to_song() to delete an existing albumartist tag. The release
+        # artist should now be written instead.
+        Release = brainz.mb.Release
+        build_song_data = brainz.widgets.build_song_data
+        apply_options = brainz.widgets.apply_options
+        apply_to_song = brainz.widgets.apply_to_song
+
+        release = Release(TEST_DATA)
+        assert release.is_single_artist
+        track = release.tracks[1]
+        meta = build_song_data(release, track)
+        self.assertEqual(meta["albumartist"], "Autechre")
+
+        # albumartist option ON: write the MB value.
+        apply_options(meta, True, True, False, False, False)
+        dummy = AudioFile({"albumartist": "preexisting"})
+        apply_to_song(meta, dummy)
+        self.assertEqual(dummy("albumartist"), "Autechre")
+
+    def test_apply_options_albumartist_off_preserves_existing(self):
+        # Regression test for #4900 (Scenario 2): if the user disables
+        # "Write albumartist when needed", an existing albumartist tag must
+        # be left alone, not deleted.
+        Release = brainz.mb.Release
+        build_song_data = brainz.widgets.build_song_data
+        apply_options = brainz.widgets.apply_options
+        apply_to_song = brainz.widgets.apply_to_song
+
+        release = Release(TEST_DATA)
+        track = release.tracks[1]
+        meta = build_song_data(release, track)
+        # albumartist option OFF.
+        apply_options(meta, True, False, False, False, False)
+        self.assertNotIn("albumartist", meta)
+
+        dummy = AudioFile({"albumartist": "preexisting"})
+        apply_to_song(meta, dummy)
+        self.assertEqual(dummy("albumartist"), "preexisting")
+
     def test_pregap(self):
         Release = brainz.mb.Release
 


### PR DESCRIPTION
Check-list
----------

 * [x] There is a linked issue discussing the motivations for this feature or bugfix
 * [x] Unit tests have been added where possible
 * [x] I've added / updated documentation for any user-facing features.
 * [x] Performance seems to be comparable or better than current `main`


What this change is adding / fixing
-----------------------------------

Fixes #4900.

`apply_to_song` treats an empty meta value as a delete (it calls `song.remove(key)`), so the MusicBrainz Lookup plugin's two places that emit `meta["albumartist"] = ""` end up silently dropping the existing albumartist tag from the file:

1. `build_song_data`, on a single-artist or various-artists release.
2. `apply_options`, when the "Write `albumartist` when needed" option is disabled.

This patch fixes both:

- `build_song_data` now always populates `albumartist` / `albumartistsort` / `musicbrainz_albumartistid` from the release artists. The MB release artist is the correct value on any release, including single-artist ones.
- `apply_options` now `pop`s `albumartist` from the meta dict when the option is off, so `apply_to_song` simply leaves the on-disk tag alone.

Two regression tests are added to `tests/plugin/test_brainz.py` covering both scenarios.