### PR TITLE
unity: Handle GLib.GError gracefully

### DIFF
--- a/quodlibet/qltk/unity.py
+++ b/quodlibet/qltk/unity.py
@@ -12,7 +12,10 @@ See the MPRIS plugin for sound menu integration.
 
 import gi
 
+from gi.repository import GLib
+
 from quodlibet import _
+from quodlibet import util
 from quodlibet.util import gi_require_versions
 
 
@@ -43,7 +46,11 @@ def init(desktop_id, player):
     if not is_unity:
         return
 
-    launcher = Unity.LauncherEntry.get_for_desktop_id(desktop_id)
+    try:
+        launcher = Unity.LauncherEntry.get_for_desktop_id(desktop_id)
+    except GLib.GError:
+        util.print_exc()
+        return
 
     main = Dbusmenu.Menuitem()
 


### PR DESCRIPTION
Check-list
----------

 * [x] There is a linked issue discussing the motivations for this feature or bugfix
 * [ ] Unit tests have been added where possible
 * [ ] I've added / updated documentation for any user-facing features.
 * [x] Performance seems to be comparable or better than current `main`


What this change is adding / fixing
-----------------------------------
While this should be addressed upstream, it makes no sense for for this to be a fatal error.

Related log message:
E: [0000.996] qltk.unity.init: unity.py:50:init: gi.repository.GLib.GError: gi-invoke-error-quark: Could not locate unity_launcher_entry_get_for_desktop_id: 'unity_launcher_entry_get_for_desktop_id': python3: undefined symbol: unity_launcher_entry_get_for_desktop_id (1)

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2482367