### PR TITLE
Fix double-escaping in file renaming error messages

### DIFF
--- a/quodlibet/qltk/renamefiles.py
+++ b/quodlibet/qltk/renamefiles.py
@@ -1,5 +1,6 @@
 # Copyright 2004-2005 Joe Wreschnig, Michael Urman, Iñigo Serna
 #             2020-23 Nick Boultbee
+#                2026 Gwyneth Morgan
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -367,6 +368,7 @@ class RenameFiles(Gtk.VBox):
                         "new-name": util.bold(new_name),
                     },
                     buttons=Gtk.ButtonsType.NONE,
+                    escape_desc=False,
                 )
                 msg.add_button(_("Ignore _All Errors"), RESPONSE_SKIP_ALL)
                 msg.add_icon_button(
@@ -490,6 +492,7 @@ class RenameFiles(Gtk.VBox):
                     "root your pattern by starting it with / or ~/."
                 )
                 % (util.bold(pattern_text)),
+                escape_desc=False,
             ).run()
             return
         else:


### PR DESCRIPTION
Check-list
----------

 * [ ] There is a linked issue discussing the motivations for this feature or bugfix
 * [ ] Unit tests have been added where possible
 * [ ] I've added / updated documentation for any user-facing features.
 * [x] Performance seems to be comparable or better than current `main`


What this change is adding / fixing
-----------------------------------
<!-- A high-level description of the changes.
Hopefully the commits are atomic and well described, but this is the overall
summary of the change, to other developers / maintainers, plus any TODOs. -->

The user-controlled text is already escaped by util.bold, so it ended up being escaped twice.