### PR TITLE
Support inhibit plugin on KDE Plasma

### DIFF
--- a/quodlibet/ext/events/inhibit.py
+++ b/quodlibet/ext/events/inhibit.py
@@ -1,5 +1,6 @@
 # Copyright 2011 Christoph Reiter <reiter.christoph@gmail.com>
 # Copyright 2020 Antigone <mail@antigone.xyz>
+# Copyright 2026 Am-curious
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -50,32 +51,48 @@ class SessionInhibit(EventPlugin):
     PLUGIN_ID = "screensaver_inhibit"
     PLUGIN_NAME = _("Inhibit Screensaver/Suspend")
     PLUGIN_DESC = _(
-        "On a GNOME desktop, when a song is playing, prevents"
-        " either the screensaver from activating, or prevents the"
-        " computer from suspending."
+        "When a song is playing, prevents either the screensaver from"
+        " activating, or prevents the computer from suspending."
     )
     PLUGIN_ICON = Icons.PREFERENCES_DESKTOP_SCREENSAVER
 
     CONFIG_MODE = PLUGIN_ID + "_mode"
 
-    DBUS_NAME = "org.gnome.SessionManager"
-    DBUS_INTERFACE = "org.gnome.SessionManager"
-    DBUS_PATH = "/org/gnome/SessionManager"
+    GNOME_DBUS = (
+        "org.gnome.SessionManager",
+        "/org/gnome/SessionManager",
+        "org.gnome.SessionManager",
+    )
+    FREEDESKTOP_DBUS = {
+        InhibitStrings.IDLE: (
+            "org.freedesktop.ScreenSaver",
+            "/org/freedesktop/ScreenSaver",
+            "org.freedesktop.ScreenSaver",
+        ),
+        InhibitStrings.SUSPEND: (
+            "org.freedesktop.PowerManagement",
+            "/org/freedesktop/PowerManagement/Inhibit",
+            "org.freedesktop.PowerManagement.Inhibit",
+        ),
+    }
 
     APPLICATION_ID = "quodlibet"
     INHIBIT_REASON = _("Music is playing")
 
     __cookie = None
+    __dbus_proxy = None
+    __uninhibit_method = None
 
-    def __get_dbus_proxy(self):
+    def __get_dbus_proxy(self, dbus):
+        name, path, interface = dbus
         bus = Gio.bus_get_sync(Gio.BusType.SESSION, None)
         return Gio.DBusProxy.new_sync(
             bus,
             Gio.DBusProxyFlags.NONE,
             None,
-            self.DBUS_NAME,
-            self.DBUS_PATH,
-            self.DBUS_INTERFACE,
+            name,
+            path,
+            interface,
             None,
         )
 
@@ -84,10 +101,12 @@ class SessionInhibit(EventPlugin):
             self.plugin_on_unpaused()
 
     def disabled(self):
-        if not app.player.paused:
-            self.plugin_on_paused()
+        self.plugin_on_paused()
 
     def plugin_on_unpaused(self):
+        if self.__cookie is not None:
+            return
+
         xid = get_toplevel_xid()
         mode = config.get("plugins", self.CONFIG_MODE, InhibitStrings.IDLE)
         flags = (
@@ -95,23 +114,39 @@ class SessionInhibit(EventPlugin):
             if mode == InhibitStrings.SUSPEND
             else InhibitFlags.IDLE
         )
-
         try:
-            dbus_proxy = self.__get_dbus_proxy()
-            self.__cookie = dbus_proxy.Inhibit(
+            dbus_proxy = self.__get_dbus_proxy(self.GNOME_DBUS)
+            cookie = dbus_proxy.Inhibit(
                 "(susu)", self.APPLICATION_ID, xid, self.INHIBIT_REASON, flags
             )
+            uninhibit_method = "Uninhibit"
         except GLib.Error:
-            pass
+            try:
+                dbus_proxy = self.__get_dbus_proxy(self.FREEDESKTOP_DBUS[mode])
+                cookie = dbus_proxy.Inhibit(
+                    "(ss)", self.APPLICATION_ID, self.INHIBIT_REASON
+                )
+                uninhibit_method = "UnInhibit"
+            except GLib.Error:
+                return
+
+        self.__dbus_proxy = dbus_proxy
+        self.__cookie = cookie
+        self.__uninhibit_method = uninhibit_method
 
     def plugin_on_paused(self):
         if self.__cookie is None:
             return
 
+        dbus_proxy = self.__dbus_proxy
+        cookie = self.__cookie
+        uninhibit_method = self.__uninhibit_method
+        self.__dbus_proxy = None
+        self.__cookie = None
+        self.__uninhibit_method = None
+
         try:
-            dbus_proxy = self.__get_dbus_proxy()
-            dbus_proxy.Uninhibit("(u)", self.__cookie)
-            self.__cookie = None
+            getattr(dbus_proxy, uninhibit_method)("(u)", cookie)
         except GLib.Error:
             pass
 
@@ -125,7 +160,6 @@ class SessionInhibit(EventPlugin):
                 self.plugin_on_unpaused()
 
         mode = config.get("plugins", self.CONFIG_MODE, InhibitStrings.IDLE)
-
         hb = Gtk.HBox(spacing=6)
         hb.set_border_width(6)
         # Translators: Inhibiting Mode

--- a/tests/plugin/test_inhibit.py
+++ b/tests/plugin/test_inhibit.py
@@ -5,6 +5,17 @@
 # the Free Software Foundation; either version 2 of the License, or
 # (at your option) any later version.
 
+import os
+import sys
+
+import pytest
+
+if os.name == "nt" or sys.platform == "darwin":
+    pytest.skip(
+        "inhibit plugin is not supported on this platform",
+        allow_module_level=True,
+    )
+
 from gi.repository import GLib
 
 from quodlibet import config

--- a/tests/plugin/test_inhibit.py
+++ b/tests/plugin/test_inhibit.py
@@ -1,0 +1,96 @@
+# Copyright 2026 Am-curious
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+
+from gi.repository import GLib
+
+from quodlibet import config
+from quodlibet.ext.events import inhibit
+from tests import TestCase, destroy_fake_app, init_fake_app
+
+
+class FakeProxy:
+    def __init__(self, cookie=42):
+        self.cookie = cookie
+        self.inhibit_call = None
+        self.uninhibit_call = None
+
+    def Inhibit(self, signature, *args):
+        self.inhibit_call = (signature, args)
+        return self.cookie
+
+    def Uninhibit(self, signature, cookie):
+        self.uninhibit_call = ("Uninhibit", signature, cookie)
+
+    def UnInhibit(self, signature, cookie):
+        self.uninhibit_call = ("UnInhibit", signature, cookie)
+
+
+class TSessionInhibit(TestCase):
+    def setUp(self):
+        config.init()
+        init_fake_app()
+        self.plugin = inhibit.SessionInhibit()
+
+    def tearDown(self):
+        self.plugin.plugin_on_paused()
+        destroy_fake_app()
+        config.quit()
+
+    def test_gnome_backend_is_preserved(self):
+        proxy = FakeProxy()
+        calls = []
+
+        def get_proxy(dbus):
+            calls.append(dbus)
+            return proxy
+
+        self.plugin._SessionInhibit__get_dbus_proxy = get_proxy
+        config.set(
+            "plugins",
+            self.plugin.CONFIG_MODE,
+            inhibit.InhibitStrings.SUSPEND,
+        )
+
+        self.plugin.plugin_on_unpaused()
+
+        self.assertEqual(calls, [self.plugin.GNOME_DBUS])
+        self.assertEqual(proxy.inhibit_call[0], "(susu)")
+        self.assertEqual(proxy.inhibit_call[1][-1], inhibit.InhibitFlags.SUSPEND)
+
+        self.plugin.plugin_on_paused()
+        self.assertEqual(proxy.uninhibit_call, ("Uninhibit", "(u)", 42))
+
+    def test_freedesktop_fallback_for_both_modes(self):
+        for mode in (inhibit.InhibitStrings.IDLE, inhibit.InhibitStrings.SUSPEND):
+            proxy = FakeProxy()
+            calls = []
+
+            def get_proxy(dbus, calls=calls, proxy=proxy):
+                calls.append(dbus)
+                if dbus == self.plugin.GNOME_DBUS:
+                    raise GLib.Error("GNOME session manager unavailable")
+                return proxy
+
+            self.plugin._SessionInhibit__get_dbus_proxy = get_proxy
+            config.set("plugins", self.plugin.CONFIG_MODE, mode)
+
+            self.plugin.plugin_on_unpaused()
+
+            self.assertEqual(
+                calls,
+                [self.plugin.GNOME_DBUS, self.plugin.FREEDESKTOP_DBUS[mode]],
+            )
+            self.assertEqual(
+                proxy.inhibit_call,
+                (
+                    "(ss)",
+                    (self.plugin.APPLICATION_ID, self.plugin.INHIBIT_REASON),
+                ),
+            )
+
+            self.plugin.plugin_on_paused()
+            self.assertEqual(proxy.uninhibit_call, ("UnInhibit", "(u)", 42))


### PR DESCRIPTION
## Check-list

- [x] There is a linked issue discussing the motivations for this feature or bugfix
- [x] Unit tests have been added where possible
- [x] I've added / updated documentation for any user-facing features.
- [x] Performance seems to be comparable or better than current `main`

## What this change is adding / fixing

Fixes #4758.

The existing Inhibit Screensaver/Suspend plugin uses
`org.gnome.SessionManager`, so inhibition does not work on KDE Plasma.

This change preserves the existing GNOME/Cinnamon behavior and adds
Freedesktop D-Bus fallbacks when the GNOME session manager is unavailable:

- `org.freedesktop.ScreenSaver` for "Inhibit Screensaver"
- `org.freedesktop.PowerManagement.Inhibit` for "Inhibit Suspend"

The plugin keeps the existing UI and uses the same Gio-based D-Bus approach,
without adding an additional dependency.

Tested manually on Fedora KDE Plasma:

- suspend inhibition while playing
- release on pause
- screensaver inhibition while playing
- switching between both modes during playback
- disabling/re-enabling the plugin during playback

Automated checks run:

- `python -m pytest tests/plugin/test_inhibit.py -q`
  - 2 passed
- `ruff check quodlibet/ext/events/inhibit.py tests/plugin/test_inhibit.py`
  - passed
- `python -m pytest tests/quality -q`
  - 1236 passed, 1 skipped
